### PR TITLE
ci: publish releases on git tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify tag is on main
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points at ${GITHUB_SHA}, which is not an ancestor of origin/main. Refusing to publish a release from an unreviewed branch."
+            exit 1
+          fi
+
       - name: Resolve version
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 
 on:
   push:
-    tags: ["v*"]
+    tags: ["v[0-9]*"]
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: publish github release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Package skills
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          tar --owner=0 --group=0 --sort=name \
+            -czf "dist/easy-cheese-${VERSION}.tar.gz" \
+            skills README.md LICENSE
+          zip -rq "dist/easy-cheese-${VERSION}.zip" \
+            skills README.md LICENSE
+          (cd dist && sha256sum ./*.tar.gz ./*.zip > SHA256SUMS)
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          notes_flag="--generate-notes"
+          if [[ "$TAG" == *-* ]]; then
+            prerelease_flag="--prerelease"
+          else
+            prerelease_flag=""
+          fi
+          gh release create "$TAG" \
+            --title "$TAG" \
+            $notes_flag \
+            $prerelease_flag \
+            dist/*.tar.gz \
+            dist/*.zip \
+            dist/SHA256SUMS


### PR DESCRIPTION
## Summary

Adds a GitHub Actions release workflow that publishes GitHub releases when `v*` tags are pushed. Packages all skills into tar.gz and zip artifacts with SHA256 checksums for distribution.

## Release behavior

- Triggers on `git push` of tags like `v0.1.0`, `v1.2.3`, `v1.0.0-rc1`
- Auto-marks tags with `-` (rc, alpha, beta, etc.) as pre-releases
- Uses `gh release create --generate-notes` for auto-generated release notes from PRs/commits
- Includes `skills/`, `README.md`, and `LICENSE` in both archive formats
- Attaches SHA256SUMS for verification

## To publish a release

```sh
git tag v0.1.0
git push origin v0.1.0
```