### PR TITLE
docs(cheez-skills): audit and enhance skill documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,40 @@ The workflow skills can delegate code search, reading, and editing to these MCP-
 
 The cheez-* skills require tilth MCP and hard-fail when it is unavailable rather than fall back to host tools. Workflow skills remain portable by falling back directly to host-native tools when they are not using cheez-*.
 
+#### cheez-* router protocol
+
+The three cheez-* skills are designed to chain. The standard sequence:
+
+1. **`/cheez-search`** — locate the symbol, caller, content match, or file. AST-aware; replaces grep/rg/find.
+2. **`/cheez-read`** — read the target file or section to capture hash anchors. Smart-outlines large files; replaces cat/head/tail/ls.
+3. **`/cheez-write`** — apply hash-anchored edits with the anchors from step 2. Surgical; rejects on hash mismatch.
+
+Workflow skills (`/cook`, `/age`, `/cure`) call into this chain when they need code intelligence. A skill should never search-then-edit without reading in between — the read is what produces the anchors that make the edit safe.
+
+#### Installing tilth MCP
+
+The cheez-* skills require [tilth](https://github.com/paulnsorensen/tilth) installed as an MCP server in your harness. tilth ships a one-shot installer:
+
+```sh
+# Install tilth CLI (one-time)
+cargo install tilth        # or: brew install paulnsorensen/tap/tilth
+
+# Register tilth as an MCP server in Claude Code (with edit mode for cheez-write)
+tilth install claude-code --edit
+```
+
+Drop the `--edit` flag if you only want read/search — `cheez-write` needs edit mode to expose the `tilth_edit` MCP tool. Other supported hosts (cursor, vscode, claude-desktop, opencode, gemini, codex, zed, …) follow the same pattern: `tilth install <host> --edit`.
+
+After install, restart your harness and confirm the tools appear:
+
+- `mcp__tilth__tilth_search`
+- `mcp__tilth__tilth_read`
+- `mcp__tilth__tilth_files`
+- `mcp__tilth__tilth_deps`
+- `mcp__tilth__tilth_edit` (only with `--edit`)
+
+If those don't show up, the cheez-* skills will hard-fail with "tilth MCP server is not loaded" instead of silently falling back to host tools.
+
 ### Suggested flow
 
 ```text

--- a/README.md
+++ b/README.md
@@ -53,6 +53,27 @@ The three cheez-* skills are designed to chain. The standard sequence:
 
 Workflow skills (`/cook`, `/age`, `/cure`) call into this chain when they need code intelligence. A skill should never search-then-edit without reading in between — the read is what produces the anchors that make the edit safe.
 
+##### Tool redirection map
+
+If you'd reach for one of these on a code task, route through cheez-* instead:
+
+| If you'd run... | Use this skill | Why |
+| --- | --- | --- |
+| `grep`, `rg`, `ripgrep`, `ag`, `ack` | `/cheez-search` | AST-aware; ranks definitions over usages, filters comments/strings. |
+| `find`, `fd` (by name pattern, code work) | `/cheez-read` (`tilth_files`) | Token estimates and `.gitignore` filtering for free. |
+| `ast-grep` / `sg` (for name-shaped queries) | `/cheez-search` | `sg` is reserved for structural metavariable patterns tilth can't express. |
+| LSP "find references" / "find definition" (manual) | `/cheez-search` | Same answer, no IDE round-trip; falls through to LSP under the hood when needed. |
+| `cat`, `head`, `tail`, `less`, `more`, `bat` | `/cheez-read` | Hash anchors + outline-vs-full token budgeting. |
+| `ls`, `tree`, `eza` (code dirs) | `/cheez-read` (`tilth_files`) | Token estimates; respects `.gitignore`. |
+| `Read`, `Glob` (host tools, code paths) | `/cheez-read` | Bypasses session deduplication and emits no anchors. |
+| `sed`, `awk`, `perl -i` | `/cheez-write` | No hash-mismatch safety; silent races on concurrent writes. |
+| `patch` (apply diff to code) | `/cheez-write` | Anchored range edits are the safe equivalent. |
+| `tee`, `>`, `>>` (overwrite/append code files) | `/cheez-write` | Same — no anchors, no mismatch detection. |
+| `Edit`, `Write` (host tools, code) | `/cheez-write` | `tilth_edit` is the only edit path with hash-anchor safety. |
+| `sg --rewrite` (codemod across N files) | `/cheez-write` | Sanctioned escape from cheez-write for structural codemods; `tilth_edit` stays the default for single-block edits. |
+
+Outside code work (e.g. `find -mtime`, `ls /tmp`, log inspection with `tail -f`, JSON munging with `jq`) the host tools are still the right call. The redirection rule is: **anything that touches source code goes through cheez-***.
+
 #### Installing tilth MCP
 
 The cheez-* skills require [tilth](https://github.com/paulnsorensen/tilth) installed as an MCP server in your harness. tilth ships a one-shot installer:
@@ -104,7 +125,7 @@ Workflow skills name preferred tools when they help, with fallbacks for portabil
 | Tool | Helps with | Fallback |
 | --- | --- | --- |
 | tilth (MCP) | AST-aware read/search/edit and dependency context | Required for cheez-*; workflow skills can bypass cheez-* and use host read/edit, `ripgrep`, patches |
-| `sg` (ast-grep) | Structural pattern matching with metavariables | `ripgrep`, `find`, targeted reads |
+| `sg` (ast-grep) | Structural pattern matching and codemods (`sg --rewrite`) with metavariables | `ripgrep`, `find`, targeted reads; `tilth_edit` for non-structural edits |
 | Context7 (MCP) | Library and API documentation | repo docs, package docs, vendor pages, web search |
 | Tavily (MCP) | Current web/vendor research | host web search or user-supplied sources |
 | code-review-graph (MCP) | Review impact radius and caller/dep context | import searches, caller searches, tests |

--- a/skills/cheez-read/SKILL.md
+++ b/skills/cheez-read/SKILL.md
@@ -1,19 +1,72 @@
 ---
 name: cheez-read
-description: This skill should be used when the user asks to read, view, show, open, or display the contents of a file or directory — phrases like "read src/auth.ts", "show me this file", "what's in this directory", "view lines 44-89", "look at the imports". Replaces cat / head / tail / ls / find / Read / Glob with AST-aware tilth MCP reading. Use even when the user says "cat" or "open the file" — never call host Read or Glob directly. If tilth MCP is unavailable, stop and report rather than fall back.
+description: This skill should be used when the user asks to read, view, show, open, or display the contents of a file or directory — phrases like "read src/auth.ts", "show me this file", "what's in this directory", "view lines 44-89", "look at the imports". Replaces cat / head / tail / ls / find / Read / Glob with AST-aware tilth MCP reading. Use even when the user says "cat" or "open the file" — never call host Read or Glob directly. If tilth MCP is unavailable, stop and report rather than fall back. Do NOT use for searching symbols or text (use cheez-search), editing code (use cheez-write), or git/gh operations.
 license: MIT
 compatibility: Requires tilth MCP server.
-allowed-tools: mcp__tilth__tilth_read mcp__tilth__tilth_files mcp__tilth__tilth_deps
+allowed-tools: mcp__tilth__tilth_read, mcp__tilth__tilth_files, mcp__tilth__tilth_deps
 ---
 
 # cheez-read
 
 > **Hard dependency**: If `mcp__tilth__tilth_read` is unavailable, stop immediately and report
 > "tilth MCP server is not loaded — cannot proceed." Do NOT fall back to `cat`, `Read`, `Glob`,
-> or any host tool.
+> or any host tool. Install via `tilth install <host>` (see README "Installing tilth MCP").
+
+## Capability detection
+
+Before the first call, verify tilth is reachable:
+
+1. Check that `mcp__tilth__tilth_read` is in your tool list. If absent, stop and report `"tilth MCP server is not loaded — cannot proceed."`
+2. Make a minimal probe call: `tilth_read(path: "README.md", section: "1-1")`. If the response is a JSON-RPC error or transport failure, stop and report `"tilth MCP server present but unhealthy: <error>"`.
+3. Any other failure (file not found, bad section range, etc.) is a **content** issue — proceed normally and report the result.
 
 Smart code reading via **tilth MCP** (`tilth_read`, `tilth_files`, `tilth_deps`).
 tilth replaces cat/head/tail with AST-aware file reading that understands code structure.
+
+---
+
+## Examples
+
+### "Show me `src/auth.ts`"
+
+```
+tilth_read(path: "src/auth.ts")
+```
+
+Small files come back with full content and a header (`# src/auth.ts (258
+lines, ~3.4k tokens) [full]`); large files get the structural outline
+automatically.
+
+### "Read the `handleAuth` function in edit mode so I can change it"
+
+```
+tilth_read(path: "src/auth.ts", section: "44-89", edit: true)
+```
+
+```text
+44:b2c|export function handleAuth(req, res, next) {
+45:c3d|  const token = req.headers.authorization?.split(' ')[1];
+...
+89:e1d|}
+```
+
+The `edit: true` flag (or `--edit` in CLI mode) emits hash anchors. Capture
+`44:b2c` and `89:e1d` and pass them to cheez-write.
+
+### "List every TypeScript file under `src/handlers/`"
+
+```
+tilth_files(glob: "*.ts", scope: "src/handlers/")
+```
+
+```text
+src/handlers/auth.ts      (~1.8k tokens)
+src/handlers/orders.ts    (~3.1k tokens)
+src/handlers/webhooks.ts  (~620 tokens)
+```
+
+Token estimates let you decide what to read in full vs outline before you
+spend any context on it.
 
 ---
 
@@ -79,11 +132,15 @@ tilth_read(paths: ["src/auth.ts", "src/routes.ts", "src/middleware.ts"])
 When reading files, tilth outputs **hash-anchored lines**:
 
 ```
-42:a3f│  let x = compute();
-43:f1b│  return x;
+42:a3f|  let x = compute();
+43:f1b|  return x;
 ```
 
-The format is `<line>:<hash>│ <content>`.
+The format is `<line>:<hash>|<content>`.
+
+> Plain reads use a `│` (U+2502) column separator. **Edit-mode reads** (the
+> ones you need for cheez-write) use `:<hash>|` — note the ASCII pipe and
+> the colon. Anchors are only emitted when tilth is run in `--edit` mode.
 
 **Why this matters:**
 - These hashes uniquely identify the line content
@@ -126,40 +183,22 @@ tilth_files(glob: "**/*.test.ts")
 # Specific directory
 tilth_files(glob: "*", scope: "src/handlers/")
 
-# Exclude patterns
-tilth_files(glob: "**/*.go", scope: ".", exclude: "*_test.go")
+# Exclude patterns (negation in the same glob)
+tilth_files(glob: "!*_test.go", scope: ".")
 ```
 
 ---
 
 ## tilth_deps — Blast Radius Check
 
-Shows what imports this file and what it imports.
-
 ```
 tilth_deps(path: "src/auth.ts")
 ```
 
-**Output:**
-```
-# Dependencies for src/auth.ts
-
-── imports ──
-  express        external
-  jsonwebtoken   external
-  @/config       src/config/index.ts
-
-── imported by ──
-  src/routes/api.ts:5
-  src/routes/admin.ts:8
-  src/middleware/auth.ts:3
-```
-
-**Use ONLY before:**
-- Renaming a file or module
-- Removing exports
-- Changing a function's signature
-- Understanding refactoring impact
+Use **only** before refactoring (rename, signature change, removal). For
+output format and the file-vs-symbol distinction, see the shared reference
+in cheez-search:
+[`../cheez-search/references/tilth-deps.md`](../cheez-search/references/tilth-deps.md).
 
 ---
 

--- a/skills/cheez-read/SKILL.md
+++ b/skills/cheez-read/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cheez-read
-description: This skill should be used when the user asks to read, view, show, open, or display the contents of a file or directory — phrases like "read src/auth.ts", "show me this file", "what's in this directory", "view lines 44-89", "look at the imports". Replaces cat / head / tail / ls / find / Read / Glob with AST-aware tilth MCP reading. Use even when the user says "cat" or "open the file" — never call host Read or Glob directly. If tilth MCP is unavailable, stop and report rather than fall back. Do NOT use for searching symbols or text (use cheez-search), editing code (use cheez-write), or git/gh operations.
+description: This skill should be used when the user asks to read, view, show, open, or display the contents of a file or directory — phrases like "read src/auth.ts", "show me this file", "what's in this directory", "view lines 44-89", "look at the imports". Replaces cat / head / tail / less / more / bat / ls / tree / eza / find / fd / Read / Glob with AST-aware tilth MCP reading and file listing. Use even when the user says "cat", "less", "bat", "tree", "ls", "find", "fd", or "open the file" — never call host Read, Glob, or any shell file viewer / lister directly. If tilth MCP is unavailable, stop and report rather than fall back. Do NOT use for searching symbols or text (use cheez-search), editing code (use cheez-write), or git/gh operations.
 license: MIT
 compatibility: Requires tilth MCP server.
 allowed-tools: mcp__tilth__tilth_read, mcp__tilth__tilth_files, mcp__tilth__tilth_deps
@@ -129,7 +129,7 @@ tilth_read(paths: ["src/auth.ts", "src/routes.ts", "src/middleware.ts"])
 
 ## Hash Anchors — The Edit Bridge
 
-When reading files, tilth outputs **hash-anchored lines**:
+When reading files in **edit mode**, tilth outputs **hash-anchored lines**:
 
 ```
 42:a3f|  let x = compute();
@@ -261,8 +261,9 @@ tilth tracks what you've read in the current session:
 
 ## DO NOT
 
-- **DO NOT use cat/head/tail** — use tilth_read.
-- **DO NOT use ls/find** — use tilth_files.
+- **DO NOT use cat / head / tail / less / more / bat** to view code — use `tilth_read`. Hash anchors and outline-vs-full token budgeting only work through tilth.
+- **DO NOT use ls / tree / eza / find / fd to enumerate code files** — use `tilth_files`. Token estimates and `.gitignore` filtering only work through tilth.
+- **DO NOT use the host Read or Glob tools** on code paths — they bypass tilth's session deduplication and emit no anchors.
 - **DO NOT re-read files** shown earlier — reference your notes.
 - **DO NOT use for searching** — use cheez-search.
 - **DO NOT use for editing** — use cheez-write.

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cheez-search
-description: This skill should be used when the user asks to find a symbol, definition, caller, import, or text pattern in the codebase — phrases like "where is X defined", "what calls Y", "find all usages of Z", "trace this function", "find the TODO comments", "search for this error string". Replaces grep / rg / find with AST-aware tilth MCP search for name-shaped and text-shaped queries; use sg only for AST-shape patterns tilth cannot express. Use even when the user says "grep" — never call host Grep, Glob, or rg directly. If tilth MCP is unavailable, stop and report rather than fall back. Do NOT use for reading whole files (use cheez-read), editing code (use cheez-write), or running tests/builds.
+description: This skill should be used when the user asks to find a symbol, definition, caller, import, or text pattern in the codebase — phrases like "where is X defined", "what calls Y", "find all usages of Z", "trace this function", "find the TODO comments", "search for this error string". Replaces grep / rg / ripgrep / ag / ack / find / fd with AST-aware tilth MCP search for name-shaped and text-shaped queries; use ast-grep (`sg`) only for AST-shape patterns with metavariables tilth cannot express. Use even when the user says "grep", "rg", "ripgrep", "ag", "ack", "fd", or "find" — never call host Grep, Glob, ripgrep, ast-grep, or any shell search directly. If tilth MCP is unavailable, stop and report rather than fall back. Do NOT use for reading whole files (use cheez-read), editing code (use cheez-write), or running tests/builds.
 license: MIT
 compatibility: Requires tilth MCP server. Optional ast-grep (`sg`) for structural metavariable patterns tilth cannot express.
 allowed-tools: mcp__tilth__tilth_search, mcp__tilth__tilth_deps, Bash
@@ -209,10 +209,14 @@ tilth_search(query: "FIXME\\(.*?\\):", kind: "regex", scope: "src/")
 
 tilth covers names and text. For *shapes* with metavariables (`$X`, `$$$BODY`)
 that tilth cannot express, drop to `sg` (ast-grep) via Bash. This is the
-**only** sanctioned shell escape from cheez-search.
+**only** sanctioned shell escape from cheez-search. The same escape covers
+structural codemods via `sg --rewrite` (dry-run first; `tilth_edit` remains
+the default for one-off block edits).
 
-For metavar pattern syntax, the language matrix, and the hard rules for safe
-`sg` invocations (path validation, `--json` parsing, scope filters), see
+For metavar pattern syntax, the language matrix, hard rules for safe `sg`
+invocations (`--lang`, `--json`, no `--interactive`, path validation, scope
+filters), pitfalls (CST-not-AST, metavar binding, strict vs lenient), and the
+codemod dry-run protocol, see
 [`references/sg-patterns.md`](references/sg-patterns.md).
 
 ---
@@ -321,7 +325,9 @@ tilth_deps(path: "src/auth/index.ts")
 
 ## DO NOT
 
-- **DO NOT use Grep/rg** — use `tilth_search`. `sg` is the *only* sanctioned shell escape, and only for AST-shape patterns tilth can't express.
+- **DO NOT use grep / rg / ripgrep / ag / ack** — use `tilth_search`. `sg` (ast-grep) is the *only* sanctioned shell escape, and only for AST-shape patterns with metavariables tilth can't express.
+- **DO NOT use find / fd to locate files by name pattern** — use `tilth_files` (cheez-read). `find` for non-name predicates (size, mtime, perms) is fine outside code work, but redirect anything code-related back through cheez-*.
+- **DO NOT use ast-grep (`sg`) for name-shaped or text queries** — that's `tilth_search` territory. `sg` is for structural patterns with metavars (`$X`, `$$$BODY`) only.
 - **DO NOT blind text search** — use a semantic `kind` (`symbol`, `callers`, `content`, `regex`) before reaching for `sg`.
 - **DO NOT re-read expanded results** — they're already shown.
 - **DO NOT use for file reading** — use cheez-read.

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -1,20 +1,76 @@
 ---
 name: cheez-search
-description: This skill should be used when the user asks to find a symbol, definition, caller, import, or text pattern in the codebase — phrases like "where is X defined", "what calls Y", "find all usages of Z", "trace this function", "find the TODO comments", "search for this error string". Replaces grep / rg / find with AST-aware tilth MCP search for name-shaped and text-shaped queries; use sg only for AST-shape patterns tilth cannot express. Use even when the user says "grep" — never call host Grep, Glob, or rg directly. If tilth MCP is unavailable, stop and report rather than fall back.
+description: This skill should be used when the user asks to find a symbol, definition, caller, import, or text pattern in the codebase — phrases like "where is X defined", "what calls Y", "find all usages of Z", "trace this function", "find the TODO comments", "search for this error string". Replaces grep / rg / find with AST-aware tilth MCP search for name-shaped and text-shaped queries; use sg only for AST-shape patterns tilth cannot express. Use even when the user says "grep" — never call host Grep, Glob, or rg directly. If tilth MCP is unavailable, stop and report rather than fall back. Do NOT use for reading whole files (use cheez-read), editing code (use cheez-write), or running tests/builds.
 license: MIT
 compatibility: Requires tilth MCP server. Optional ast-grep (`sg`) for structural metavariable patterns tilth cannot express.
-allowed-tools: mcp__tilth__tilth_search mcp__tilth__tilth_deps Bash
+allowed-tools: mcp__tilth__tilth_search, mcp__tilth__tilth_deps, Bash
 ---
 
 # cheez-search
 
 > **Hard dependency**: If `mcp__tilth__tilth_search` is unavailable, stop immediately and report
 > "tilth MCP server is not loaded — cannot proceed." Do NOT fall back to `Grep`, `Glob`, `rg`,
-> or any host tool.
+> or any host tool. Install via `tilth install <host>` (see README "Installing tilth MCP").
+
+## Capability detection
+
+Before the first call, verify tilth is reachable:
+
+1. Check that `mcp__tilth__tilth_search` is in your tool list. If absent, stop and report `"tilth MCP server is not loaded — cannot proceed."`
+2. Make a minimal probe call: `tilth_search(query: "tilth", scope: ".")`. If the response is a JSON-RPC error or transport failure, stop and report `"tilth MCP server present but unhealthy: <error>"`.
+3. Any other failure (zero matches, malformed regex, etc.) is a **content** issue — proceed normally and report the result.
 
 AST-aware code search via **tilth MCP** (`tilth_search`, `tilth_deps`).
 Tree-sitter finds where symbols are **defined** — not just where strings appear.
 Understand dependencies instead of blindly grepping.
+
+---
+
+## Examples
+
+### "Where is `handleAuth` defined?"
+
+```
+tilth_search(query: "handleAuth", scope: "src/")
+```
+
+```text
+# Search: "handleAuth" in src/ — 6 matches (2 definitions, 4 usages)
+
+## src/auth.ts:44-89 [definition]
+→ [44-89]  export fn handleAuth(req, res, next)
+## src/routes/api.ts:34 [usage]
+→ [34]   router.use('/api/protected/*', handleAuth);
+```
+
+The `[definition]` tag answers the question; usages come along for free.
+
+### "What calls `validateToken`?"
+
+```
+tilth_search(query: "validateToken", kind: "callers", scope: ".")
+```
+
+```text
+# Callers: "validateToken" — 3 call sites
+
+## src/auth.ts:62 [usage] in handleAuth
+→ [62]   const claims = validateToken(token);
+
+## src/middleware/admin.ts:18 [usage] in requireAdmin
+→ [18]   if (!validateToken(req.headers.authorization)) return next(403);
+```
+
+`kind: "callers"` filters out comments and strings — only real call sites.
+
+### "Find any TODO that mentions retries"
+
+```
+tilth_search(query: "TODO.*retry", kind: "regex", scope: "src/")
+```
+
+Use `kind: "regex"` for pattern matches across content; bound the scope to
+keep the cost down.
 
 ---
 
@@ -151,33 +207,13 @@ tilth_search(query: "FIXME\\(.*?\\):", kind: "regex", scope: "src/")
 
 ## AST-shape Patterns — ast-grep fallback
 
-tilth covers names and text. For *shapes* with metavariables — "any call to
-`JSON.parse(JSON.stringify(…))`", "any `for` loop with `time.Sleep` in its
-body" — use `sg` (ast-grep) via Bash.
+tilth covers names and text. For *shapes* with metavariables (`$X`, `$$$BODY`)
+that tilth cannot express, drop to `sg` (ast-grep) via Bash. This is the
+**only** sanctioned shell escape from cheez-search.
 
-```bash
-# AST template: $X is a metavar that matches any single node.
-sg --lang typescript -p 'JSON.parse(JSON.stringify($X))' --json src/
-
-# $$$BODY matches a sequence of statements.
-sg --lang rust -p 'impl std::fmt::Display for $TYPE { $$$BODY }' --json src/
-
-# Bound the scan; never splice unvalidated user input as the path.
-SCOPE=$(realpath "$SCOPE_INPUT")
-sg --lang python -p 're.match($PATTERN, $INPUT)' --json "$SCOPE"
-```
-
-**When `sg` is the right pick:**
-- The pattern needs metavars (`$X`, `$$$BODY`) or specific node kinds.
-- You're surveying a structural shape across a directory (anti-pattern sweeps, refactor previews).
-- Tree-sitter symbol search would over-match because the *name* isn't fixed.
-
-**Hard rules for sg invocations:**
-- Validate any path that flows from user input before splicing it into the command line.
-  Reject `;`, `&`, `|`, backtick, `$(`, `>`, `<`, newline. Resolve to an absolute path with
-  `realpath` and confirm it sits under the repo root.
-- Always pass `--json` and parse defensively — the JSON shape varies between ast-grep versions.
-- Filter test/build/vendor directories with `--globs` or by post-filtering JSON.
+For metavar pattern syntax, the language matrix, and the hard rules for safe
+`sg` invocations (path validation, `--json` parsing, scope filters), see
+[`references/sg-patterns.md`](references/sg-patterns.md).
 
 ---
 
@@ -223,28 +259,13 @@ tilth_search(query: "handleAuth", scope: ".", expand: 0)
 
 ## tilth_deps — Dependency Graph
 
-For understanding module relationships (not searching):
-
 ```
 tilth_deps(path: "src/auth.ts")
 ```
 
-**Output:**
-```
-# Dependencies for src/auth.ts
-
-── imports ──
-  express        external
-  jsonwebtoken   external
-  @/config       src/config/index.ts
-
-── imported by ──
-  src/routes/api.ts:5
-  src/routes/admin.ts:8
-  src/middleware/auth.ts:3
-```
-
-Use for: understanding blast radius before refactoring, finding consumers of a module, tracing import chains.
+Use **only** before refactoring (rename, signature change, removal). For
+output format, scope rules, and the symbol-vs-file distinction, see
+[`references/tilth-deps.md`](references/tilth-deps.md).
 
 ---
 

--- a/skills/cheez-search/references/sg-patterns.md
+++ b/skills/cheez-search/references/sg-patterns.md
@@ -1,0 +1,58 @@
+# ast-grep (`sg`) patterns
+
+`tilth_search` covers names and text. For *shapes* with metavariables — "any
+call to `JSON.parse(JSON.stringify(…))`", "any `for` loop with `time.Sleep` in
+its body" — drop to `sg` (ast-grep) via Bash. This is the **only** sanctioned
+shell escape from cheez-search.
+
+## When `sg` is the right pick
+
+- The pattern needs metavars (`$X`, `$$$BODY`) or specific node kinds.
+- You're surveying a structural shape across a directory (anti-pattern sweeps,
+  refactor previews, lint-style scans).
+- Tree-sitter symbol search would over-match because the *name* isn't fixed.
+
+If the question is "where is `handleAuth` defined" or "what calls
+`validateToken`", stay in `tilth_search`. `sg` is for shape, not name.
+
+## Pattern syntax
+
+```bash
+# AST template: $X is a metavar that matches any single node.
+sg --lang typescript -p 'JSON.parse(JSON.stringify($X))' --json src/
+
+# $$$BODY matches a sequence of statements.
+sg --lang rust -p 'impl std::fmt::Display for $TYPE { $$$BODY }' --json src/
+
+# Bound the scan; never splice unvalidated user input as the path.
+SCOPE=$(realpath "$SCOPE_INPUT")
+sg --lang python -p 're.match($PATTERN, $INPUT)' --json "$SCOPE"
+```
+
+## Hard rules for `sg` invocations
+
+- Validate any path that flows from user input before splicing it into the
+  command line. Reject `;`, `&`, `|`, backtick, `$(`, `>`, `<`, newline.
+  Resolve to an absolute path with `realpath` and confirm it sits under the
+  repo root.
+- Always pass `--json` and parse defensively — the JSON shape varies between
+  ast-grep versions.
+- Filter test/build/vendor directories with `--globs` or by post-filtering
+  JSON.
+
+## Common pattern shapes
+
+| Goal | Pattern |
+|------|---------|
+| Calls to a method on any receiver | `$RECV.someMethod($$$ARGS)` |
+| Anti-pattern: deep clone via JSON | `JSON.parse(JSON.stringify($X))` |
+| Empty catch blocks | `try { $$$BODY } catch ($E) { }` |
+| Sleep inside a loop | `for ($$$INIT) { $$$BEFORE time.Sleep($D) $$$AFTER }` |
+| Trait impls for a specific trait | `impl Display for $TYPE { $$$BODY }` |
+
+## When to escalate further
+
+If `sg` patterns get hairy (chained metavars, nested negations) and you're
+hand-rolling logic that overlaps a real linter — clippy, eslint, ruff, gosec
+— stop and use the linter. `sg` is for one-off structural sweeps, not for
+maintained rule sets.

--- a/skills/cheez-search/references/sg-patterns.md
+++ b/skills/cheez-search/references/sg-patterns.md
@@ -3,7 +3,9 @@
 `tilth_search` covers names and text. For *shapes* with metavariables — "any
 call to `JSON.parse(JSON.stringify(…))`", "any `for` loop with `time.Sleep` in
 its body" — drop to `sg` (ast-grep) via Bash. This is the **only** sanctioned
-shell escape from cheez-search.
+shell escape from cheez-search. The same escape covers structural codemods
+via `sg --rewrite` (see "Structural codemods" below); `tilth_edit` remains
+the default for one-off block edits.
 
 ## When `sg` is the right pick
 
@@ -11,6 +13,8 @@ shell escape from cheez-search.
 - You're surveying a structural shape across a directory (anti-pattern sweeps,
   refactor previews, lint-style scans).
 - Tree-sitter symbol search would over-match because the *name* isn't fixed.
+- You want to apply the same structural change across many files in one pass
+  (codemod) — see the dedicated section below.
 
 If the question is "where is `handleAuth` defined" or "what calls
 `validateToken`", stay in `tilth_search`. `sg` is for shape, not name.
@@ -31,14 +35,55 @@ sg --lang python -p 're.match($PATTERN, $INPUT)' --json "$SCOPE"
 
 ## Hard rules for `sg` invocations
 
-- Validate any path that flows from user input before splicing it into the
-  command line. Reject `;`, `&`, `|`, backtick, `$(`, `>`, `<`, newline.
+- **Always pass `--lang`/`-l`.** Pattern parsing is language-specific; the
+  same pattern string can parse differently per language. Don't rely on
+  extension inference for anything that goes into a script.
+- **Always pass `--json`** when piping into a tool, an LLM, or a follow-up
+  shell step. Never parse the pretty TTY output.
+- **Never pass `--interactive`.** It requires a TTY and human input; it will
+  hang or fail in agent contexts.
+- **Never pass `-U` (rewrite-update) without a dry run first.** See
+  "Structural codemods" — search-only invocation, then re-run with `-U`
+  after the diff is staged or confirmed.
+- **Validate any path** that flows from user input before splicing it into
+  the command line. Reject `;`, `&`, `|`, backtick, `$(`, `>`, `<`, newline.
   Resolve to an absolute path with `realpath` and confirm it sits under the
   repo root.
-- Always pass `--json` and parse defensively — the JSON shape varies between
-  ast-grep versions.
-- Filter test/build/vendor directories with `--globs` or by post-filtering
-  JSON.
+- **Parse `--json` defensively.** Key by field name (`text`, `file`,
+  `range`, `metaVariables`); tolerate missing keys; do not hard-code
+  positional `jq` paths. The shape has shifted between minor releases.
+- **Filter test/build/vendor directories** with `--globs` or by
+  post-filtering JSON.
+
+## Pitfalls
+
+- **CST, not AST.** ast-grep matches the Concrete Syntax Tree, so trivia
+  and punctuation can affect what nodes exist. The pattern itself must be
+  valid syntax in the target language — "didn't match" is often "didn't
+  parse on the pattern side".
+- **Metavar binding.** Repeating the same metavar name within a single
+  pattern (`$VAR ... $VAR`) requires both occurrences to match the **same**
+  node text. Use distinct names (`$A`, `$B`) when you want independent
+  matches; reuse the name only when you want the binding.
+- **Lenient by default.** ast-grep matches loosely on CST nodes. Pass
+  `--strict` (or `strictness:` in YAML rules) when you need exact node-kind
+  equality and the loose match is producing surprises.
+- **No semantics.** `$X.unwrap()` is text-shape only — the receiver's type
+  is unknown to ast-grep. Anything that needs type info, control flow, or
+  data flow has to escalate (see "When to escalate further").
+
+## Performance: narrow first, parse second
+
+ast-grep parses every file in scope, so cost scales with **file count**, not
+match count. A wide `**/*` over a monorepo can be ~10× slower than a
+constrained scope. Two-stage workflow:
+
+1. **List candidates** with `tilth_search` (definitions, imports, content
+   hits) or `tilth_files` (glob/path predicates) to get the file set.
+2. **Run `sg`** with `--globs` or explicit paths bounded to that set.
+
+This pattern beats one giant wildcard scan and keeps the JSON output small
+enough to inspect.
 
 ## Common pattern shapes
 
@@ -49,10 +94,74 @@ sg --lang python -p 're.match($PATTERN, $INPUT)' --json "$SCOPE"
 | Empty catch blocks | `try { $$$BODY } catch ($E) { }` |
 | Sleep inside a loop | `for ($$$INIT) { $$$BEFORE time.Sleep($D) $$$AFTER }` |
 | Trait impls for a specific trait | `impl Display for $TYPE { $$$BODY }` |
+| React hook destructure | `const [$STATE, $SETTER] = useState($$$INIT)` |
+| Async function declaration | `async function $NAME($$$PARAMS) { $$$BODY }` |
+| Class with any body | `class $NAME { $$$BODY }` |
+
+## Structural codemods (`sg --rewrite`)
+
+`sg --rewrite '<template>'` plus `-U` (update files in place) is the
+sanctioned codemod path. It complements `tilth_edit` rather than replacing
+it: tilth_edit excels at "replace this specific block in this specific file"
+with hash-anchor concurrency safety; `sg --rewrite` excels at "rewrite every
+instance of this shape across the repo" with structural-match safety.
+
+Use it when:
+
+- The change repeats across N locations and the surrounding text varies.
+- The pattern can be expressed structurally (metavars carry the variable
+  parts; the rewrite template fills them back in).
+- You don't know all the locations a priori and want discovery + change in
+  one pass.
+
+**Dry-run-first protocol** (non-negotiable):
+
+1. Run the pattern **without** `-U`. Inspect `--json` matches; count them.
+   ```bash
+   sg --lang typescript \
+      -p 'JSON.parse(JSON.stringify($X))' \
+      -r 'structuredClone($X)' \
+      --json src/
+   ```
+2. Confirm the working tree is clean or stashed. Mass rewrites that bury
+   uncommitted work are unrecoverable without a stash.
+3. Re-run with `-U` to apply.
+   ```bash
+   sg --lang typescript \
+      -p 'JSON.parse(JSON.stringify($X))' \
+      -r 'structuredClone($X)' \
+      -U src/
+   ```
+4. **Diff the result** (`git diff`). Commit or revert as a unit; do not
+   layer additional changes on top until the codemod is reviewed.
+5. If matches > expected, **bail and revert** — your pattern was too loose.
+   Tighten with `--strict`, `--globs`, or distinct metavar names, then
+   repeat from step 1.
+
+`sg --rewrite` does not have hash-anchor safety. Structural matching catches
+"didn't accidentally rewrite a string literal that looks like code"; it does
+not catch "file changed under me mid-run". Treat it as a single transactional
+change between two clean git states.
 
 ## When to escalate further
 
-If `sg` patterns get hairy (chained metavars, nested negations) and you're
-hand-rolling logic that overlaps a real linter — clippy, eslint, ruff, gosec
-— stop and use the linter. `sg` is for one-off structural sweeps, not for
-maintained rule sets.
+`sg` does not implement type information, control-flow analysis, data-flow
+analysis, taint analysis, or constant propagation. If the rule needs any of
+those, escalate to a real linter or a security tool:
+
+- **ESLint** (`@typescript-eslint`) — type-aware JS/TS rules, plugin
+  ecosystem, editor integration.
+- **Clippy** — Rust lints with full type inference and borrow-checker
+  awareness. `sg` can do shape-level Rust patterns but not lifetime
+  semantics.
+- **Ruff** — Python lint/format with thousands of vetted rules covering
+  what isort/flake8/pyupgrade/black do.
+- **gosec** — Go security rule pack.
+- **Semgrep** — when you need taint analysis, security rule packs, or
+  composition primitives like `pattern-not-inside` and `pattern-either`
+  that ast-grep does not provide.
+
+If your `sg` patterns are growing chained metavars and nested negations,
+or you're hand-rolling logic that overlaps a maintained rule set, stop and
+adopt the linter. `sg` is for one-off structural sweeps and
+repo-specific codemods, not for maintained rule infrastructure.

--- a/skills/cheez-search/references/tilth-deps.md
+++ b/skills/cheez-search/references/tilth-deps.md
@@ -1,0 +1,58 @@
+# `tilth_deps` — Blast-Radius Check
+
+Shows what imports a file and what that file imports. Use to understand the
+fallout of a rename, signature change, or removal **before** you make it.
+
+## Call shape
+
+```
+tilth_deps(path: "src/auth.ts")
+```
+
+## Output
+
+```text
+# Dependencies for src/auth.ts
+
+── imports ──
+  express        external
+  jsonwebtoken   external
+  @/config       src/config/index.ts
+
+── imported by ──
+  src/routes/api.ts:5
+  src/routes/admin.ts:8
+  src/middleware/auth.ts:3
+```
+
+The `── imports ──` block is what `src/auth.ts` pulls in. The `── imported
+by ──` block is the blast radius — every file that will care if you change
+this one.
+
+## When to use
+
+- **Before renaming a file or module** — you'll need to update every
+  importer in the bottom block.
+- **Before removing or renaming an export** — same.
+- **Before changing a function or class signature** — visit each importer to
+  decide whether the new shape is compatible.
+- **When estimating refactor scope** — count the importers and weigh whether
+  the change is local or cross-cutting.
+
+## When NOT to use
+
+- For "where is X defined" — that's `tilth_search`, not `tilth_deps`.
+- For "what does this function do" — that's `tilth_read`.
+- For unrelated curiosity — every call costs tokens; only run when you're
+  about to make a structural change.
+
+## Limits
+
+- `tilth_deps` is path-scoped, not symbol-scoped. It tells you which files
+  import the target file, not which functions inside those files use a
+  specific export. For that, follow up with
+  `tilth_search(query: "<symbol>", kind: "callers")`.
+- External dependencies are listed without versions. If you need version
+  context, check the lockfile or `package.json` / `Cargo.toml` separately.
+- Generated, vendored, or `.gitignore`d files may not appear — tilth indexes
+  what tree-sitter can parse and what's in the repo.

--- a/skills/cheez-write/SKILL.md
+++ b/skills/cheez-write/SKILL.md
@@ -1,19 +1,87 @@
 ---
 name: cheez-write
-description: This skill should be used when the user asks to edit, replace, modify, update, change, delete, or insert code in a file — phrases like "replace this function", "delete lines 44-89", "update validateToken", "change the implementation", "add this import", "fix this bug" (when fixing requires editing). Replaces sed / awk / Edit / Write with hash-anchored tilth MCP edits. Always read first via cheez-read to get hash anchors. Never rewrite whole files. If tilth MCP is unavailable, stop and report rather than fall back.
+description: This skill should be used when the user asks to edit, replace, modify, update, change, delete, or insert code in a file — phrases like "replace this function", "delete lines 44-89", "update validateToken", "change the implementation", "add this import", "fix this bug" (when fixing requires editing). Replaces sed / awk / Edit / Write with hash-anchored tilth MCP edits. Always read first via cheez-read to get hash anchors. Prefer surgical anchored edits over whole-file rewrites. If tilth MCP is unavailable, stop and report rather than fall back. Do NOT use for reading files (cheez-read first to get anchors), searching code (use cheez-search), or running tests/builds.
 license: MIT
 compatibility: Requires tilth MCP server.
-allowed-tools: mcp__tilth__tilth_edit mcp__tilth__tilth_read
+allowed-tools: mcp__tilth__tilth_edit, mcp__tilth__tilth_read
 ---
 
 # cheez-write
 
 > **Hard dependency**: If `mcp__tilth__tilth_edit` is unavailable, stop immediately and report
 > "tilth MCP server is not loaded — cannot proceed." Do NOT fall back to `Edit`, `Write`,
-> or any host tool.
+> or any host tool. Install via `tilth install <host> --edit` — the `--edit` flag is required
+> to expose `tilth_edit` (see README "Installing tilth MCP").
+
+## Capability detection
+
+Before the first call, verify tilth's edit tool is reachable:
+
+1. Check that `mcp__tilth__tilth_edit` is in your tool list. If only `tilth_read` and `tilth_search` are present, tilth was installed without `--edit`. Stop and report `"tilth MCP server is loaded but edit mode is disabled — re-install with 'tilth install <host> --edit'."`
+2. The first edit call is a probe by definition — if it returns a JSON-RPC transport error (not a hash mismatch), stop and report `"tilth MCP server present but unhealthy: <error>"`.
+3. Hash mismatches, syntax errors in the new content, or anchor-not-found are **content** issues — recover via the protocol below, do not bail.
 
 Hash-anchored file editing via **tilth MCP** (`tilth_edit`).
-Never rewrite whole files. Use hash anchors from tilth_read to make precise, surgical edits.
+Use hash anchors from tilth_read to make precise, surgical edits. Avoid
+rewriting whole files unless the size and change ratio justify it (see
+"When full-file rewrite is acceptable" below).
+
+---
+
+## Examples
+
+### "Replace the body of `handleAuth` in `src/auth.ts`"
+
+Step 1 — read with edit mode to get anchors:
+
+```
+tilth_read(path: "src/auth.ts", section: "44-89", edit: true)
+# returns 44:b2c|... and 89:e1d|...
+```
+
+Step 2 — apply with the captured anchors:
+
+```json
+tilth_edit({
+  "path": "src/auth.ts",
+  "edits": [{
+    "start": "44:b2c",
+    "end":   "89:e1d",
+    "content": "export function handleAuth(req, res, next) {\n  const token = extractToken(req);\n  if (!validateToken(token)) return res.status(401).end();\n  next();\n}"
+  }]
+})
+```
+
+Response confirms `Edit applied to src/auth.ts` and may list callers to
+review.
+
+### "Add an import without nuking the existing one on line 13"
+
+`tilth_edit` replaces — there is no native insert. Anchor on line 13 and put
+the original line back at the top of `content`:
+
+```json
+tilth_edit({
+  "path": "src/auth.ts",
+  "edits": [{
+    "start": "13:abc",
+    "content": "import { existingThing } from './existing';\nimport { newHelper } from './helpers';"
+  }]
+})
+```
+
+### "Hash mismatch — file changed under me"
+
+```
+Error: Hash mismatch at line 44
+Expected: b2c
+Found: f9a
+```
+
+Re-read the section, capture the new anchors, retry once. If it mismatches
+again, **stop** — see "Hash Mismatch Handling → Repeated mismatches" below
+(`tilth_edit` has no fuzzy / search-replace mode, so blind retries lose
+races, not win them).
 
 ---
 
@@ -34,14 +102,14 @@ tilth_edit uses **hash anchors** — unique identifiers for each line — to:
 
 ## Hash Anchor Format
 
-When you read a file with tilth_read, lines have anchors:
+When you read a file with tilth_read in edit mode, lines have anchors:
 
 ```
-42:a3f│  let x = compute();
-43:f1b│  return x;
+42:a3f|  let x = compute();
+43:f1b|  return x;
 ```
 
-Format: `<line>:<hash>│ <content>`
+Format: `<line>:<hash>|<content>` (ASCII pipe, no space).
 
 The hash is a short content fingerprint. If someone else edits the file,
 hashes change, and your edit is safely rejected.
@@ -52,7 +120,8 @@ hashes change, and your edit is safely rejected.
 
 ### tilth_edit — Precise File Editing
 
-**Single line edit:**
+The minimal shape — single anchor, replacement content:
+
 ```json
 tilth_edit({
   "path": "src/auth.ts",
@@ -62,49 +131,10 @@ tilth_edit({
 })
 ```
 
-**Multi-line range replacement:**
-```json
-tilth_edit({
-  "path": "src/auth.ts",
-  "edits": [
-    {
-      "start": "44:b2c",
-      "end": "89:e1d",
-      "content": "export function handleAuth(req, res, next) {\n  // new implementation\n  const token = extractToken(req);\n  if (!token) return res.status(401).end();\n  next();\n}"
-    }
-  ]
-})
-```
-
-**Delete a block:**
-```json
-tilth_edit({
-  "path": "src/auth.ts",
-  "edits": [
-    { "start": "44:b2c", "end": "89:e1d", "content": "" }
-  ]
-})
-```
-
-**Multiple edits in one call:**
-```json
-tilth_edit({
-  "path": "src/auth.ts",
-  "edits": [
-    { "start": "12:a1b", "content": "import { newHelper } from './helpers';" },
-    { "start": "44:b2c", "end": "89:e1d", "content": "// replaced function\n..." }
-  ]
-})
-```
-
-**Show diff in response:**
-```json
-tilth_edit({
-  "path": "src/auth.ts",
-  "diff": true,
-  "edits": [...]
-})
-```
+For range replacement, deletion, multi-edit, insert-after, cross-file
+batches, and the `diff: true` response option, see
+[`references/edit-patterns.md`](references/edit-patterns.md). That file is the
+JSON cookbook; this body sticks to the protocol.
 
 ---
 
@@ -118,11 +148,11 @@ tilth_read(path: "src/auth.ts", section: "44-89")
 
 Output:
 ```
-44:b2c│ export function handleAuth(req, res, next) {
-45:c3d│   const token = req.headers.authorization?.split(' ')[1];
+44:b2c|export function handleAuth(req, res, next) {
+45:c3d|  const token = req.headers.authorization?.split(' ')[1];
 ...
-88:d4e│   next();
-89:e1d│ }
+88:d4e|  next();
+89:e1d|}
 ```
 
 ### Step 2: Note Your Anchors
@@ -184,7 +214,7 @@ Expected: b2c
 Found: f9a
 
 Current content:
-44:f9a│ export async function handleAuth(req, res, next) {
+44:f9a|export async function handleAuth(req, res, next) {
 ...
 ```
 
@@ -194,6 +224,28 @@ Current content:
 3. Edit with new anchors.
 
 This is a **safety feature**, not a bug.
+
+### Repeated mismatches → bail out, don't loop
+
+If you hit **two consecutive mismatches** on the same anchor, you're racing a
+concurrent writer. `tilth_edit` has no fuzzy / search-replace mode — there
+is no "ignore the hash, just match this string" option. A third retry will
+likely lose the same race.
+
+The correct move is to bail and report:
+
+1. Read the latest section one final time and capture the current content.
+2. Prepare the new content as a unified diff or full block, but **do not
+   apply** it.
+3. Report `"hash-anchor race on <path>:<line>; current content and proposed
+   replacement attached. Retry once the file is quiescent or apply manually."`
+   along with the captured anchors and proposed content.
+4. Stop. Let the orchestrator (or a human) decide whether to apply the change
+   or escalate.
+
+This trades automation for safety — losing a race twice means whatever's
+writing the file is faster than your read-edit cycle, and a third blind
+retry could overwrite real work.
 
 ---
 
@@ -216,43 +268,14 @@ Check these locations and update if needed.
 
 ## Common Patterns
 
-### Insert After a Line
-
-Use the start anchor of the line AFTER where you want to insert:
-
-```json
-tilth_edit({
-  "path": "src/auth.ts",
-  "edits": [{
-    "start": "13:abc",
-    "content": "import { newHelper } from './helpers';\nimport { oldImport } from './old';"
-  }]
-})
-```
-
-This replaces line 13. To truly "insert", include the original line 13 content
-in your new content.
-
-### Delete Multiple Functions
-
-```json
-tilth_edit({
-  "path": "src/auth.ts",
-  "edits": [
-    { "start": "44:b2c", "end": "89:e1d", "content": "" },
-    { "start": "120:f4g", "end": "180:h5i", "content": "" }
-  ]
-})
-```
-
-### Batch Edits Across Files
-
-Make separate tilth_edit calls per file (cannot batch across files):
-
-```
-tilth_edit({ path: "src/auth.ts", edits: [...] })
-tilth_edit({ path: "src/routes.ts", edits: [...] })
-```
+| Goal | Pattern | Reference |
+|------|---------|-----------|
+| Replace one line | single anchor, new `content` | [edit-patterns.md#single-line-replacement](references/edit-patterns.md#single-line-replacement) |
+| Replace a range | `start` + `end` anchors | [edit-patterns.md#multi-line-range-replacement](references/edit-patterns.md#multi-line-range-replacement) |
+| Delete a block | range with `content: ""` | [edit-patterns.md#delete-a-block](references/edit-patterns.md#delete-a-block) |
+| Insert after a line | anchor on that line, prepend its content | [edit-patterns.md#insert-after-a-line](references/edit-patterns.md#insert-after-a-line) |
+| Multi-edit in one file | `edits: [...]` ordered bottom-up | [edit-patterns.md#multiple-edits-in-one-call](references/edit-patterns.md#multiple-edits-in-one-call) |
+| Cross-file change | one `tilth_edit` call per file | [edit-patterns.md#edits-across-multiple-files](references/edit-patterns.md#edits-across-multiple-files) |
 
 ---
 
@@ -281,12 +304,33 @@ Then edit with those anchors.
 
 ---
 
+## When full-file rewrite is acceptable
+
+Hash-anchored, surgical edits are the default. There is one exception:
+
+| File size | Policy |
+|-----------|--------|
+| **> 150 lines** | Never rewrite the whole file. Always hash-anchored. |
+| **≤ 150 lines** | Anchored single-edit preferred, but a full rewrite (delete-everything + insert) is acceptable when **≥ 80%** of the file is changing. Below that threshold, do the surgical edit. |
+
+The 150-line / 80% threshold is informed by 2026 industry data (Cursor's
+published numbers, can.ac analysis, the Morph benchmark) showing full-file
+rewrites tie or beat diff-style on small files. The threshold keeps the
+spirit conservative — large files always stay anchored.
+
+When you do rewrite a small file in full, still use `tilth_edit` (anchor on
+line 1, end-anchor on the last line). Do **not** drop to host `Write` —
+that bypasses tilth's hash-mismatch safety.
+
+---
+
 ## DO NOT
 
-- **DO NOT rewrite entire files** — use hash anchors for surgical edits.
+- **DO NOT rewrite files > 150 lines** — use hash anchors for surgical edits.
+- **DO NOT rewrite small files when the change is < 80%** — anchor the changed range only.
 - **DO NOT guess hash values** — always read first to get current anchors.
-- **DO NOT ignore hash mismatches** — re-read and retry.
-- **DO NOT use host Edit/Write tool** — use tilth_edit exclusively.
+- **DO NOT ignore hash mismatches** — re-read and retry (see Hash Mismatch Handling).
+- **DO NOT use host Edit/Write tool** — use `tilth_edit` exclusively.
 - **DO NOT edit without reading** — you need the anchors.
 - **DO NOT use for reading** — use cheez-read.
 - **DO NOT use for searching** — use cheez-search.

--- a/skills/cheez-write/SKILL.md
+++ b/skills/cheez-write/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: cheez-write
-description: This skill should be used when the user asks to edit, replace, modify, update, change, delete, or insert code in a file — phrases like "replace this function", "delete lines 44-89", "update validateToken", "change the implementation", "add this import", "fix this bug" (when fixing requires editing). Replaces sed / awk / Edit / Write with hash-anchored tilth MCP edits. Always read first via cheez-read to get hash anchors. Prefer surgical anchored edits over whole-file rewrites. If tilth MCP is unavailable, stop and report rather than fall back. Do NOT use for reading files (cheez-read first to get anchors), searching code (use cheez-search), or running tests/builds.
+description: This skill should be used when the user asks to edit, replace, modify, update, change, delete, or insert code in a file — phrases like "replace this function", "delete lines 44-89", "update validateToken", "change the implementation", "add this import", "fix this bug" (when fixing requires editing), or apply a cross-cutting structural change (codemod) like "rewrite every X to Y". Replaces sed / awk / perl -i / patch / tee / Edit / Write / shell redirects (`>`, `>>`) with hash-anchored tilth MCP edits for one-off block changes; sanctions `sg --rewrite` (ast-grep) for structural codemods that span many files. Always read first via cheez-read to get hash anchors for anchored edits. Prefer surgical anchored edits over whole-file rewrites. If tilth MCP is unavailable, stop and report rather than fall back. Do NOT use for reading files (cheez-read first to get anchors), searching code (use cheez-search), or running tests/builds.
 license: MIT
-compatibility: Requires tilth MCP server.
-allowed-tools: mcp__tilth__tilth_edit, mcp__tilth__tilth_read
+compatibility: Requires tilth MCP server. Optional ast-grep (`sg`) for structural codemods (`sg --rewrite`) that span many files.
+allowed-tools: mcp__tilth__tilth_edit, mcp__tilth__tilth_read, Bash
 ---
 
 # cheez-write
@@ -324,13 +324,54 @@ that bypasses tilth's hash-mismatch safety.
 
 ---
 
+## Structural codemods — `sg --rewrite` escape
+
+`tilth_edit` excels at "replace this specific block in this specific file"
+with hash-anchor concurrency safety. It handles cross-cutting structural
+changes awkwardly: one file at a time, one read-for-anchors per location.
+For codemods — "rewrite every `JSON.parse(JSON.stringify($X))` to
+`structuredClone($X)`", "convert every `var $X = $Y` to `let $X = $Y`" —
+drop to `sg --rewrite` (ast-grep) via Bash. This is the **only** sanctioned
+shell escape from cheez-write.
+
+The two tools are **complementary, not redundant**:
+
+| Tool | Safety property | Best for |
+|------|------------------|----------|
+| `tilth_edit` | Hash-anchor (concurrency) | Specific-block edits, signature changes |
+| `sg --rewrite` | Structural match (CST) | Cross-cutting codemods over N files |
+
+When the change repeats across many locations and the surrounding text
+varies, `sg --rewrite` captures the variable parts via metavars and templates
+them back into the rewrite — `tilth_edit` cannot express that without N
+reads.
+
+For invocation rules (`--lang`, `--json`, no `--interactive`), pitfalls
+(CST-not-AST, metavar binding, lenient-by-default), and the **non-negotiable
+dry-run-first protocol** (search → clean tree → `-U` → diff → revert if too
+loose), see
+[`../cheez-search/references/sg-patterns.md`](../cheez-search/references/sg-patterns.md)
+— the "Structural codemods (`sg --rewrite`)" and "Pitfalls" sections in
+particular.
+
+`sg --rewrite` does not have hash-anchor safety. Treat each codemod as a
+single transactional change between two clean git states; never layer
+additional edits on top until the codemod is committed or reverted.
+
+---
+
 ## DO NOT
 
 - **DO NOT rewrite files > 150 lines** — use hash anchors for surgical edits.
 - **DO NOT rewrite small files when the change is < 80%** — anchor the changed range only.
 - **DO NOT guess hash values** — always read first to get current anchors.
 - **DO NOT ignore hash mismatches** — re-read and retry (see Hash Mismatch Handling).
-- **DO NOT use host Edit/Write tool** — use `tilth_edit` exclusively.
+- **DO NOT use sed / awk / perl -i** to edit code — they bypass hash anchors and structural safety, and have no mismatch detection. `sg --rewrite` is the *only* sanctioned shell escape, and only for structural codemods that follow the dry-run-first protocol.
+- **DO NOT use `patch`** to apply diffs to code — `tilth_edit`'s anchored ranges are the safe equivalent.
+- **DO NOT use `tee` or shell redirects (`>`, `>>`)** to overwrite/append code files — both bypass anchors. Use `tilth_edit`.
+- **DO NOT use the host Edit/Write tool** — use `tilth_edit` (or `sg --rewrite` for structural codemods) exclusively for code.
+- **DO NOT use `sg --rewrite` for one-off block edits** — that's `tilth_edit` territory. The codemod escape is only for cross-cutting structural changes; using it on a single location wastes its strength and skips hash-anchor safety.
+- **DO NOT skip the dry-run-first protocol for `sg --rewrite`** — search-only first, clean working tree, then `-U`. Never combine search+rewrite blindly.
 - **DO NOT edit without reading** — you need the anchors.
 - **DO NOT use for reading** — use cheez-read.
 - **DO NOT use for searching** — use cheez-search.

--- a/skills/cheez-write/references/edit-patterns.md
+++ b/skills/cheez-write/references/edit-patterns.md
@@ -1,0 +1,132 @@
+# `tilth_edit` JSON cookbook
+
+Every edit follows the same shape: `{ path, edits: [...] }`. Each edit needs
+a `start` anchor; `end` is required only for range replacements. `content` is
+the new text (use `""` to delete).
+
+## Single-line replacement
+
+```json
+{
+  "path": "src/auth.ts",
+  "edits": [
+    { "start": "42:a3f", "content": "  let x = recompute();" }
+  ]
+}
+```
+
+Replaces line 42 only. The hash `a3f` must match what `tilth_read` returned
+in edit mode.
+
+## Multi-line range replacement
+
+```json
+{
+  "path": "src/auth.ts",
+  "edits": [
+    {
+      "start": "44:b2c",
+      "end": "89:e1d",
+      "content": "export function handleAuth(req, res, next) {\n  const token = extractToken(req);\n  if (!token) return res.status(401).end();\n  next();\n}"
+    }
+  ]
+}
+```
+
+Replaces lines 44–89 inclusive. Both anchors must match.
+
+## Delete a block
+
+```json
+{
+  "path": "src/auth.ts",
+  "edits": [
+    { "start": "44:b2c", "end": "89:e1d", "content": "" }
+  ]
+}
+```
+
+Empty `content` deletes the range.
+
+## Multiple edits in one call
+
+```json
+{
+  "path": "src/auth.ts",
+  "edits": [
+    { "start": "12:a1b", "content": "import { newHelper } from './helpers';" },
+    { "start": "44:b2c", "end": "89:e1d", "content": "// replaced function\n..." }
+  ]
+}
+```
+
+All edits in a single call apply atomically — either every anchor matches and
+all edits land, or none do. Order edits **bottom-up by line number** so that
+earlier edits don't invalidate later anchors.
+
+## Show diff in response
+
+```json
+{
+  "path": "src/auth.ts",
+  "diff": true,
+  "edits": [
+    { "start": "44:b2c", "end": "89:e1d", "content": "..." }
+  ]
+}
+```
+
+Useful when the change is non-trivial and you want to verify the diff before
+moving on.
+
+## Insert "after" a line
+
+`tilth_edit` replaces the anchored line(s); there is no native insert. To
+insert after line 13, anchor on line 13 and prepend the original line content
+to your new content:
+
+```json
+{
+  "path": "src/auth.ts",
+  "edits": [
+    {
+      "start": "13:abc",
+      "content": "import { existingThing } from './existing';\nimport { newHelper } from './helpers';"
+    }
+  ]
+}
+```
+
+The first line of `content` reproduces line 13 (`import { existingThing }
+…`); the second is the actual insertion. Read line 13 carefully before doing
+this — the original content goes back verbatim.
+
+## Edits across multiple files
+
+`tilth_edit` is single-file. For multi-file changes, make one call per file:
+
+```text
+tilth_edit({ path: "src/auth.ts",   edits: [...] })
+tilth_edit({ path: "src/routes.ts", edits: [...] })
+```
+
+There is no atomic cross-file edit. If the second call fails after the first
+succeeded, you have a partially applied change — read the second file and
+recover before moving on.
+
+## Caller-update notices
+
+When you change a function signature, `tilth_edit` may surface callers in
+its response:
+
+```text
+Edit applied to src/auth.ts
+
+── callers that may need updates ──
+  src/routes/api.ts:34   router.use('/api/*', handleAuth)
+  src/routes/admin.ts:12 app.use(handleAuth)
+  src/middleware.ts:8    const wrapped = handleAuth(...)
+```
+
+Visit each location, decide whether the new signature is compatible, and
+edit if needed. The notice is informational — it does not block the edit.


### PR DESCRIPTION
## Summary

Refactored cheez-read, cheez-search, and cheez-write skill documentation with clearer descriptions, capability detection protocols, and comprehensive examples. Added shared reference files for tilth-deps, sg-patterns, and edit-patterns patterns. Updated README with the cheez-* router protocol sequence and tilth MCP installation guide.

## Changes

- **README.md**: New section on cheez-* router protocol and tilth MCP setup instructions
- **cheez-read/SKILL.md**: Enhanced with capability detection, examples, and anti-pattern documentation
- **cheez-search/SKILL.md**: Restructured with examples and references to external pattern docs
- **cheez-write/SKILL.md**: Expanded with capability detection, examples, and hash-anchor patterns
- **New references/**: Shared documentation for tilth-deps, sg-patterns, and edit-patterns