### PR TITLE
docs(readme): reframe with standalone description and philosophy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A portable, skills-only toolkit of Agent Skills for shaping ideas, implementing them, and reviewing the result. No agents, no compiled harness bundles, no repo-wide MCP requirement — just self-contained `SKILL.md` files that any [Agent Skills](https://agentskills.io/specification)-compatible harness can load. The vocabulary (mold, culture, cook, press, age, cure) reads as a workflow you can dip into anywhere.
 
-## Why cheese? Two reasons:
+## Why cheese? Two reasons
 
 1. **Modeled after the gaming slang term "cheese."** The term traces back to early fighting-game culture in the late 1980s and early 1990s — Street Fighter II players coined "cheesy" wins to describe victories pulled off with cheap, repeatable, low-skill tactics (corner-trap fireball spam, throw loops, AI-pattern exploits). It spread from fighting games to RTS rush builds (StarCraft "cheese rushes"), to speedrun glitch routes, to MOBA cheese picks — anywhere a player gets a disproportionately good result for very little effort. That is exactly the design center of easy-cheese: the primary tenets are **correctness, token efficiency, and quality** — _cheap and easy_ in the best sense. Maximum result, minimum spend.
 2. **What's life without whimsy?** 🧀
@@ -129,7 +129,7 @@ Workflow skills name preferred tools when they help, with fallbacks for portabil
 
 | Tool | Helps with | Fallback |
 | --- | --- | --- |
-| tilth (MCP) | AST-aware read/search/edit and dependency context | Required for cheez-*; workflow skills can bypass cheez-* and use host read/edit, `ripgrep`, patches |
+| tilth (MCP) | AST-aware read/search/edit and dependency context | Required for cheez-\*; workflow skills can bypass cheez-\* and use host read/edit, `ripgrep`, patches |
 | `sg` (ast-grep) | Structural pattern matching and codemods (`sg --rewrite`) with metavariables | `ripgrep`, `find`, targeted reads; `tilth_edit` for non-structural edits |
 | Context7 (MCP) | Library and API documentation | repo docs, package docs, vendor pages, web search |
 | Tavily (MCP) | Current web/vendor research | host web search or user-supplied sources |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-# easy-cheese
+# 🧀 easy-cheese 🧀
 
-A lightweight, skills-only adaptation of [`paulnsorensen/cheese-flow`](https://github.com/paulnsorensen/cheese-flow) that ships only Agent Skills — no agents, no compiled harness bundles, and no repo-wide MCP requirement for the workflow skills. The vocabulary stays the same (mold, culture, cook, press, age, cure) so muscle memory carries over.
+> _"The cheese must flow."_
+
+A portable, skills-only toolkit of Agent Skills for shaping ideas, implementing them, and reviewing the result. No agents, no compiled harness bundles, no repo-wide MCP requirement — just self-contained `SKILL.md` files that any [Agent Skills](https://agentskills.io/specification)-compatible harness can load. The vocabulary (mold, culture, cook, press, age, cure) reads as a workflow you can dip into anywhere.
+
+## Why cheese? Two reasons:
+
+1. **Modeled after the gaming slang term "cheese."** The term traces back to early fighting-game culture in the late 1980s and early 1990s — Street Fighter II players coined "cheesy" wins to describe victories pulled off with cheap, repeatable, low-skill tactics (corner-trap fireball spam, throw loops, AI-pattern exploits). It spread from fighting games to RTS rush builds (StarCraft "cheese rushes"), to speedrun glitch routes, to MOBA cheese picks — anywhere a player gets a disproportionately good result for very little effort. That is exactly the design center of easy-cheese: the primary tenets are **correctness, token efficiency, and quality** — _cheap and easy_ in the best sense. Maximum result, minimum spend.
+2. **What's life without whimsy?** 🧀
 
 ## Skill layout
 
@@ -106,17 +113,15 @@ If those don't show up, the cheez-* skills will hard-fail with "tilth MCP server
 
 Use only the skills you need. A clear bug can go straight to `/cook`; a no-write design discussion should stay in `/culture`.
 
-## Differences from cheese-flow
+## Scope
 
-Easy Cheese is intentionally a smaller surface. Compared to upstream:
+Easy-cheese is intentionally a small surface. What that means in practice:
 
 - **Skills only.** No agents, commands, eta templates, or compiled harness bundles. Each capability is a single `SKILL.md`.
 - **No repo-wide MCP requirement.** Workflow skills suggest tools (tilth, Context7, Tavily, code-review-graph) but have host-native fallbacks. The cheez-* tool skills are the exception: they require tilth MCP by design.
-- **`/age` drops the `precedent` dimension.** Without git history analysis as a built-in agent, that dim is unreliable in a portable skill.
-- **No `/fromage`, `/fromagerie`, `/cleanup`, `/nih-audit`.** Those orchestrators live in cheese-flow proper.
+- **`/age` runs eight dimensions, not nine.** Without git history analysis as a built-in agent, the `precedent` dimension is unreliable in a portable skill, so it's omitted.
+- **No orchestrator skills** (no large-feature decomposition, no PR-rescue convoy, no whole-repo NIH audit). Each skill is a single, scoped step a human can drive.
 - **No automatic re-age loop in `/cure`.** The skill describes the protocol; the human runs the next `/age` when ready.
-
-If you need the full pipeline, install cheese-flow itself.
 
 ## Optional tools
 


### PR DESCRIPTION
## Summary
- Reframe the README opener so easy-cheese stands on its own (portable, skills-only Agent Skills toolkit) instead of being introduced as a derivative.
- Add a "Why cheese?" section explaining the gaming-slang origin and the **correctness, token efficiency, quality** tenets.
- Rename the "Differences" section to "Scope" so the bullets read as scope intent (skills-only, no MCP requirement, 8-dim `/age`, no orchestrators, no auto re-age) rather than a comparison.

## Test plan
- [ ] Render README on GitHub and confirm headings, table layout, and the new "Why cheese?" list display correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)