### PR TITLE
feat(skills): wire mold→cook→press→age→cure pipeline handoffs

### DIFF
--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: age
-description: This skill should be used when the user wants a code review on a diff, PR, branch, or path — phrases like "review this", "/age", "is this safe to merge", "find bugs", "spot security issues", "check for slop", "review my PR", "look for problems", "what's wrong with this code". Runs eight orthogonal review dimensions (correctness, security, encapsulation, spec, complexity, deslop, assertions, NIH) over the scoped diff and emits a stake-grouped findings report. Use even when the user only asks for one dimension — the report scopes itself. Findings only — no fixes; route the user to `/cure` when they are ready to select findings.
+description: This skill should be used when the user wants a code review on a diff, PR, branch, or path — phrases like "review this", "/age", "is this safe to merge", "find bugs", "spot security issues", "check for slop", "review my PR", "look for problems", "what's wrong with this code". Runs eight orthogonal review dimensions (correctness, security, encapsulation, spec, complexity, deslop, assertions, NIH) over the scoped diff and emits a stake-grouped findings report at `.cheese/age/<slug>.md`. Use even when the user only asks for one dimension — the report scopes itself. Findings only — no fixes; route the user to `/cure` when they are ready to select findings. After `/press` (optional); before `/cure`.
 license: MIT
 ---
 
@@ -38,11 +38,11 @@ Per-dimension rubrics and recommendation shapes in `references/dimensions.md`. T
 ## Flow
 
 1. Identify the diff, scope, and relevant spec or issue.
-2. Gather evidence: diff, touched files, tests, callers/imports.
+2. Gather evidence: diff, touched files, tests, callers/imports. If `.cheese/press/<slug>.md` exists, read it for press-side findings and coverage notes — do not duplicate them.
 3. Review every dimension; dimensions with no findings simply omit themselves.
 4. Group findings by stake (high → medium) and by file.
 5. Write the report to `.cheese/age/<slug>.md` and print the path.
-6. Print `/cure <slug>` as the next step; `/cure` owns the finding-selection gate. Never auto-invoke `/cure`.
+6. Hand off via `AskUserQuestion` (see `## Handoff` below). `/cure` owns the finding-selection gate; age never auto-applies fixes.
 
 ## Preferred tools and fallbacks
 
@@ -85,13 +85,22 @@ Then print:
 
 ```
 Age report: .cheese/age/<slug>.md
-Next step:  /cure <slug>
 ```
+
+## Handoff
+
+After the report is on disk, ask via `AskUserQuestion` which downstream to run. Default options:
+
+- **Run /cure `<slug>`** *(recommended when there are high-stake findings)* — pick findings to fix.
+- **Stop** — leave the report for later.
+
+Pre-select `Run /cure` when at least one high-stake finding exists. `/cure` still owns its selection gate; the user picks individual findings there. Never auto-apply.
 
 ## Rules
 
 - Review is not a verdict; explain where to look and why.
 - Do not edit production files.
+- Do not auto-apply fixes. Prompting `/cure` via `AskUserQuestion` is fine; bypassing `/cure`'s selection gate is not.
 - Do not invent evidence. Cite files, diffs, commands, or unavailable-source notes.
 - Keep confidence qualitative (`low | medium | high`); never emit a numeric score.
 - Findings carry location + recommendation. Do not write JSON sidecars or hash-anchored fix payloads — `/cure` reads the markdown directly.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -16,9 +16,10 @@ Accept:
 
 ```text
 /age [<ref-or-range>] [--scope <path>] [--comprehensive]
+/age <slug>
 ```
 
-Default to the current working diff when no ref is supplied. If the base branch is unclear, ask or use the repository's documented default.
+When called with a `<slug>`, resolve `.cheese/press/<slug>.md` (if present) for press context and review the current working diff. When called with a `<ref-or-range>`, review that range. Default to the current working diff when neither is supplied. If the base branch is unclear, ask or use the repository's documented default.
 
 ## Review dimensions
 
@@ -38,7 +39,7 @@ Per-dimension rubrics and recommendation shapes in `references/dimensions.md`. T
 ## Flow
 
 1. Identify the diff, scope, and relevant spec or issue.
-2. Gather evidence: diff, touched files, tests, callers/imports. If `.cheese/press/<slug>.md` exists, read it for press-side findings and coverage notes — do not duplicate them.
+2. Gather evidence: diff, touched files, tests, callers/imports. If `.cheese/press/<slug>.md` exists, read it and include a `## Press findings` sub-section in the age report summarising unresolved items — `/cure` reads only `.cheese/age/<slug>.md` and cannot access the press report directly.
 3. Review every dimension; dimensions with no findings simply omit themselves.
 4. Group findings by stake (high → medium) and by file.
 5. Write the report to `.cheese/age/<slug>.md` and print the path.

--- a/skills/cook/SKILL.md
+++ b/skills/cook/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: cook
-description: This skill should be used when the user has an approved spec, pasted requirements, or a focused implementation request and wants the code written — phrases like "implement this", "build this feature", "write the code", "cook this spec", "make it work", "/cook .cheese/specs/<slug>.md", "fix this bug" (when the bug has a clear fix). Runs a TDD-disciplined cut → cook → taste-test → press handoff loop with scoped edits via cheez-write. Use even when the user just says "go" or "ship it" if a spec or clear acceptance criteria is in scope. If the request is fuzzy, route to `/mold` first; if it needs no writes, route to `/culture`.
+description: This skill should be used when the user has an approved spec, pasted requirements, or a focused unambiguous implementation request and wants the code written — phrases like "implement this", "build this feature", "write the code", "cook this spec", "make it work", "/cook .cheese/specs/<slug>.md", "fix this bug" (when the bug has a clear fix). Runs a TDD-disciplined contract → cut → implement → taste-test → handoff loop with scoped edits via cheez-write. Use even when the user just says "go" or "ship it" if a spec or clear acceptance criteria is in scope. `/cook` runs standalone when the task is unambiguous (clear inputs, expected outputs, verifiable result) — a spec is helpful but not required. If the request is genuinely fuzzy, route to `/mold` first; if it needs no writes, route to `/culture`. After `/mold` (optional); before `/press` → `/age` → `/cure`.
 license: MIT
 ---
 
 # /cook
 
-Use this skill when the user has an approved spec, pasted requirements, or a precise implementation request with acceptance criteria.
+Use this skill when the user has an approved spec, pasted requirements, a precise implementation request with acceptance criteria, or any unambiguous task that meets the standalone fast-path checks below.
 
 Do not use it for fuzzy planning (`/mold`), no-write discussion (`/culture`), or review-only work (`/age`).
 
@@ -17,16 +17,25 @@ Accept one of:
 - A spec path, usually `.cheese/specs/<slug>.md`.
 - A pasted spec or issue.
 - A focused implementation request with acceptance criteria.
+- A clear, unambiguous task — single-file fix, named bug, well-scoped tweak — even without a spec.
 
-If the request is ambiguous, ask for the missing acceptance criteria or route to `/mold`.
+### Standalone fast-path
+
+`/cook` runs without `/mold` when the task is unambiguous. Treat a request as unambiguous when **all three** are present or trivially derivable:
+
+1. **Inputs/outputs are clear.** "Tail returns wrong byte count when file ends without newline" ✓; "make tail better" ✗.
+2. **Scope is bounded.** A named function, a single failing test, a specific call site, or a small region of one or two files.
+3. **Verification is obvious.** A failing test that can be made to pass, or a runnable command whose output should change in a stated way.
+
+When the fast-path applies, derive a slug from the task (e.g. `tail-trailing-newline`), proceed straight to **Cut**, and skip the spec round-trip. Route to `/mold` only when one of the three checks fails — silent ambiguity is the cardinal sin.
 
 ## Flow
 
-1. **Contract** — confirm behaviour, non-goals, likely scope, quality gates.
+1. **Contract** — confirm behaviour, non-goals, likely scope, quality gates. For standalone fast-path tasks, the contract is the user's request restated in one sentence.
 2. **Cut** — write failing tests for the changed behaviour. See `references/tdd-loop.md`.
-3. **Cook** — make the cut tests pass with the smallest production change.
+3. **Implement** — make the cut tests pass with the smallest production change.
 4. **Taste-test** — check spec drift, readability, and scope creep. Two-round cap; details in `references/tdd-loop.md`.
-5. **Hand off** — produce the package-ready report (`references/package-report.md`) and recommend `/press` then `/age`.
+5. **Hand off** — produce the package-ready report (`references/package-report.md`) and prompt the next step via `AskUserQuestion` (see `## Handoff` below). The default chain is `/press` → `/age` → `/cure`.
 
 Use `cheez-search` to find existing patterns and `cheez-read` / `cheez-write` for precise edits.
 
@@ -55,7 +64,17 @@ Summarize:
 - Files changed and why.
 - Tests or checks run.
 - Remaining risks or skipped checks.
-- Suggested next skill: usually `/press`, then `/age`.
+- Suggested next skill: usually `/press` → `/age` → `/cure`.
+
+## Handoff
+
+After the package-ready report is printed, ask via `AskUserQuestion` which downstream to run. Default options:
+
+- **Run /press `<slug>`** *(recommended)* — harden tests before review.
+- **Run /age `<slug>`** — review the diff now and skip the press pass.
+- **Stop** — leave further hardening for later.
+
+Pre-select `Run /press` when the cooked diff added new behaviour or touched untested seams. The user may also chain: pressing then age then cure happens via each step's own `AskUserQuestion`. Never auto-invoke; the user must select.
 
 ## Rules
 

--- a/skills/cook/SKILL.md
+++ b/skills/cook/SKILL.md
@@ -27,7 +27,7 @@ Accept one of:
 2. **Scope is bounded.** A named function, a single failing test, a specific call site, or a small region of one or two files.
 3. **Verification is obvious.** A failing test that can be made to pass, or a runnable command whose output should change in a stated way.
 
-When the fast-path applies, derive a slug from the task (e.g. `tail-trailing-newline`), proceed straight to **Cut**, and skip the spec round-trip. Route to `/mold` only when one of the three checks fails — silent ambiguity is the cardinal sin.
+When the fast-path applies, derive a slug from the task (e.g. `tail-trailing-newline`), treat **Contract** as a one-sentence restatement of the request, and proceed directly to **Cut** without a spec round-trip. Route to `/mold` only when one of the three checks fails — silent ambiguity is the cardinal sin.
 
 ## Flow
 

--- a/skills/cook/references/package-report.md
+++ b/skills/cook/references/package-report.md
@@ -29,8 +29,9 @@ Before opening a PR or handing off to `/age`, cook produces a package-ready repo
 - [x] All changed files are intentional.
 
 ### Next step
-- /press   — harden tests and check coverage
-- /age     — review the diff
+- /press <slug>   — harden tests and check coverage
+- /age <slug>     — review the diff
+- /cure <slug>    — apply selected age findings (after /age)
 ```
 
 ## Honesty rules

--- a/skills/culture/SKILL.md
+++ b/skills/culture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: culture
-description: This skill should be used when the user wants to think out loud, rubber-duck a design, walk through trade-offs, or explore an ambiguous problem WITHOUT producing files, code, or specs — phrases like "let's talk through X", "rubber duck this with me", "I'm trying to decide between A and B", "help me think about Y", "what would happen if we…", "/culture". Hard invariant — culture never writes to production files, never commits, never opens PRs. Output is conversation, not artifacts. Use when the user wants shared mental model first; if the dialogue reveals real work to do, recommend `/mold`, `/cook`, `/age`, or `/briesearch` and stop.
+description: This skill should be used when the user wants to think out loud, rubber-duck a design, walk through trade-offs, or explore an ambiguous problem WITHOUT producing files, code, or specs — phrases like "let's talk through X", "rubber duck this with me", "I'm trying to decide between A and B", "help me think about Y", "what would happen if we…", "/culture". Hard invariant — culture never writes to production files, never commits, never opens PRs. Output is conversation, not artifacts. Use when the user wants shared mental model first; if the dialogue reveals real work to do, recommend `/mold` (fuzzy → spec) or `/cook` (clear ask → code) and stop. Before `/mold` or `/cook`.
 license: MIT
 ---
 
@@ -20,7 +20,7 @@ Do not use it when the user wants a written spec (`/mold`), implementation (`/co
 2. Identify assumptions, constraints, and decision criteria.
 3. Explore trade-offs and likely blast radius.
 4. Use evidence only when it helps the conversation; avoid deep research unless the user asks.
-5. End with a compact summary, open questions, and suggested next skill.
+5. End with a compact summary, open questions, and a `## Handoff` prompt (see below).
 
 ## Preferred tools and fallbacks
 
@@ -39,7 +39,16 @@ Return a short conversational summary:
 - Current understanding
 - Trade-offs or options
 - Open questions
-- Suggested next step (`/mold`, `/cook`, `/briesearch`, `/age`, or pause)
+
+## Handoff
+
+When the conversation reveals real work, ask via `AskUserQuestion` which downstream to run. Default options (pick at most two of these plus a stop):
+
+- **Run /mold** *(recommended when the idea is still fuzzy)* — converge on a spec.
+- **Run /cook** *(recommended when the ask is clear and unambiguous)* — implement directly.
+- **Pause** — keep the dialogue in head; no further action.
+
+`/briesearch` is offered only when the conversation hit a factual gap that external docs could close. `/age` is never the next step from culture — review needs a diff to look at.
 
 ## Rules
 

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cure
-description: This skill should be used when the user has an `/age` report (or any list of review findings, CI failures, or a "fix these" instruction) and wants the selected items resolved — phrases like "fix these findings", "/cure <slug>", "address the high-stake items", "act on the age report", "fix the failing CI", "apply the cleanup". Loads the report, gates on explicit user selection, applies focused fixes via cheez-write, runs the project's existing test/lint/build gates, and produces a shipping-ready summary. Use even when the user just says "fix it" if a review report or finding list is in scope. Default selection is empty — never apply everything implicitly. After `/age`; loops back to `/age <touched-paths>` for re-review or hands off to `/gh` to ship.
+description: This skill should be used when the user has an `/age` report (or any list of review findings, CI failures, or a "fix these" instruction) and wants the selected items resolved — phrases like "fix these findings", "/cure <slug>", "address the high-stake items", "act on the age report", "fix the failing CI", "apply the cleanup". Loads the report, gates on explicit user selection, applies focused fixes via cheez-write, runs the project's existing test/lint/build gates, and produces a shipping-ready summary. Use even when the user just says "fix it" if a review report or finding list is in scope. Default selection is empty — never apply everything implicitly. After `/age`; loops back to `/age --scope <touched-path>` for re-review or hands off to `/gh` to ship.
 license: MIT
 ---
 
@@ -22,7 +22,7 @@ If selection is ambiguous, render a numbered selection list per `references/sele
 2. **Select** — gate on explicit user selection. See `references/selection.md` for the recognized verbs.
 3. **Apply** — fix one logical group at a time via `cheez-read` (re-confirm anchor location) and `cheez-write` (apply).
 4. **Validate** — run the narrowest tests that prove each fix, then any relevant project-wide gates (lint, typecheck, build).
-5. **Re-review hand-off** — recommend `/age <touched-paths>` so review runs through the proper skill rather than reimplementing it inline. `/cure` does not re-grade its own work. If the user picks re-age, the resulting report can feed a fresh `/cure` invocation.
+5. **Re-review hand-off** — recommend `/age --scope <touched-path>` so review runs through the proper skill rather than reimplementing it inline. `/cure` does not re-grade its own work. If the user picks re-age, the resulting report can feed a fresh `/cure` invocation.
 6. **Ship report** — what changed, checks run, deferred items, residual risks.
 7. **Hand off** — prompt the next step via `AskUserQuestion` (see `## Handoff` below). Never auto-invoke.
 
@@ -59,14 +59,14 @@ Run the narrowest tests that prove the fix, then any relevant existing wider gat
 
 ### Re-review
 - Remaining risk:
-- Suggested next step: `/age <touched-paths>` to verify the fixes, or `/gh` to ship.
+- Suggested next step: `/age --scope <touched-path>` to verify the fixes, or `/gh` to ship.
 ```
 
 ## Handoff
 
 After the cure report is rendered, ask via `AskUserQuestion` which downstream to run. Default options:
 
-- **Run /age `<touched-paths>`** *(recommended when fixes were non-trivial)* — re-review the touched code through the proper skill.
+- **Run /age `--scope <touched-path>`** *(recommended when fixes were non-trivial)* — re-review the touched code through the proper skill.
 - **Run /gh** — open or update the PR.
 - **Stop** — sit on the changes for now.
 

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cure
-description: This skill should be used when the user has an `/age` report (or any list of review findings, CI failures, or a "fix these" instruction) and wants the selected items resolved — phrases like "fix these findings", "/cure <slug>", "address the high-stake items", "act on the age report", "fix the failing CI", "apply the cleanup". Loads the report, gates on explicit user selection, applies focused fixes via cheez-write, runs the project's existing test/lint/build gates, and produces a shipping-ready summary. Use even when the user just says "fix it" if a review report or finding list is in scope. Default selection is empty — never apply everything implicitly.
+description: This skill should be used when the user has an `/age` report (or any list of review findings, CI failures, or a "fix these" instruction) and wants the selected items resolved — phrases like "fix these findings", "/cure <slug>", "address the high-stake items", "act on the age report", "fix the failing CI", "apply the cleanup". Loads the report, gates on explicit user selection, applies focused fixes via cheez-write, runs the project's existing test/lint/build gates, and produces a shipping-ready summary. Use even when the user just says "fix it" if a review report or finding list is in scope. Default selection is empty — never apply everything implicitly. After `/age`; loops back to `/age <touched-paths>` for re-review or hands off to `/gh` to ship.
 license: MIT
 ---
 
@@ -22,8 +22,9 @@ If selection is ambiguous, render a numbered selection list per `references/sele
 2. **Select** — gate on explicit user selection. See `references/selection.md` for the recognized verbs.
 3. **Apply** — fix one logical group at a time via `cheez-read` (re-confirm anchor location) and `cheez-write` (apply).
 4. **Validate** — run the narrowest tests that prove each fix, then any relevant project-wide gates (lint, typecheck, build).
-5. **Re-review** — apply `/age` principles to the touched paths. If new findings appear, surface them in the report; the user re-invokes `/cure` to act on them.
+5. **Re-review hand-off** — recommend `/age <touched-paths>` so review runs through the proper skill rather than reimplementing it inline. `/cure` does not re-grade its own work. If the user picks re-age, the resulting report can feed a fresh `/cure` invocation.
 6. **Ship report** — what changed, checks run, deferred items, residual risks.
+7. **Hand off** — prompt the next step via `AskUserQuestion` (see `## Handoff` below). Never auto-invoke.
 
 ## Preferred tools and fallbacks
 
@@ -58,8 +59,18 @@ Run the narrowest tests that prove the fix, then any relevant existing wider gat
 
 ### Re-review
 - Remaining risk:
-- Suggested next step:
+- Suggested next step: `/age <touched-paths>` to verify the fixes, or `/gh` to ship.
 ```
+
+## Handoff
+
+After the cure report is rendered, ask via `AskUserQuestion` which downstream to run. Default options:
+
+- **Run /age `<touched-paths>`** *(recommended when fixes were non-trivial)* — re-review the touched code through the proper skill.
+- **Run /gh** — open or update the PR.
+- **Stop** — sit on the changes for now.
+
+Pre-select `Run /age` when any applied fix touched logic outside the original finding's hunk, when a corrective fix exposed adjacent risk, or when checks were skipped. Pre-select `Run /gh` when all selected findings applied cleanly and gates passed. Never auto-invoke.
 
 ## Rules
 

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -60,7 +60,7 @@ Default to project-local cheese artifacts when the user wants files:
 
 After the spec is written, ask the user via `AskUserQuestion` which downstream to run. Default options:
 
-- **Run /cook `<slug>`** *(recommended)* — implement the spec.
+- **Run /cook `.cheese/specs/<slug>.md`** *(recommended)* — implement the spec.
 - **Run /briesearch** — gather more external evidence first.
 - **Stop** — leave the spec for later.
 

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mold
-description: This skill should be used when the user has a fuzzy idea, half-formed feature, or design direction and wants to converge on a spec — phrases like "let's design X", "I'm thinking about Y", "what should the API for Z look like", "shape this into a spec", "I want to add a feature that…", "/mold". Runs an iterative dialogue (Explore / Ground / Shape / Sketch / Grill / Diagnose), grounds every load-bearing claim with cheez-search or briesearch, locks public seams in pseudocode, and only writes a spec to `.cheese/specs/<slug>.md` after an explicit approval gate. Use even when the user is "just thinking out loud" if they want the dialogue to leave behind a written artifact — for pure no-write thinking, route to `/culture` instead.
+description: This skill should be used when the user has a fuzzy idea, half-formed feature, or design direction and wants to converge on a spec — phrases like "let's design X", "I'm thinking about Y", "what should the API for Z look like", "shape this into a spec", "I want to add a feature that…", "/mold". Runs an iterative dialogue (Explore / Ground / Shape / Sketch / Grill / Diagnose), grounds every load-bearing claim with cheez-search or briesearch, locks public seams in pseudocode, and only writes a spec to `.cheese/specs/<slug>.md` after an explicit approval gate. Use even when the user is "just thinking out loud" if they want the dialogue to leave behind a written artifact — for pure no-write thinking, route to `/culture` instead. After `/culture` (optional); before `/cook`.
 license: MIT
 ---
 
@@ -17,7 +17,7 @@ Do not use it for free-form discussion with no artifact intent (`/culture`), dir
 3. **Sketch** — for any feature touching >1 module or a new public interface, lock seams in pseudocode signatures before talking spec content.
 4. **Two-key handshake** — both the user (explicit verb) and the agent (coherence self-check) must agree before extraction. See `references/handshake.md`.
 5. **Curdle** — write the approved spec to `.cheese/specs/<slug>.md` (and optional `.cheese/issues/<slug>-NNN.md`). Format and slug rules in `references/curdle.md`.
-6. **Hand off** — suggest the next skill inline. Never auto-invoke.
+6. **Hand off** — once the spec is on disk, prompt the next step via `AskUserQuestion` (see `## Handoff` below). Never auto-invoke.
 
 ## Modes
 
@@ -45,16 +45,9 @@ Optional tools accelerate the work; missing tools do not block the dialogue. Whe
 
 ## Approval gate
 
-Before writing, present this check:
+Curdle requires the **two-key handshake**: an explicit user verb (e.g. `curdle`, `ship it`) and the agent's coherence self-check. The full checklist, mandatory gates, and override semantics live in `references/handshake.md` — do not duplicate them here.
 
-- [ ] Problem statement is clear and grounded.
-- [ ] Chosen option and non-goals are explicit.
-- [ ] Public seams or affected modules are sketched when relevant.
-- [ ] Open questions are marked `[TBD]`, `[BLOCKED]`, or `[?]`.
-- [ ] Quality gates or reproduction steps are named.
-- [ ] User approved artifact type, slug, and target path.
-
-If any item is unchecked, propose the smallest next question or evidence check. Write artifacts only after approval.
+If any gate is unmet, propose the smallest next question or evidence check. Write artifacts only after both keys pass.
 
 ## Output paths
 
@@ -62,6 +55,16 @@ Default to project-local cheese artifacts when the user wants files:
 
 - Spec: `.cheese/specs/<slug>.md`
 - Issues: `.cheese/issues/<slug>-001.md`, `.cheese/issues/<slug>-002.md`, ...
+
+## Handoff
+
+After the spec is written, ask the user via `AskUserQuestion` which downstream to run. Default options:
+
+- **Run /cook `<slug>`** *(recommended)* — implement the spec.
+- **Run /briesearch** — gather more external evidence first.
+- **Stop** — leave the spec for later.
+
+Pre-select `Run /cook` only when acceptance criteria are explicit and quality gates are runnable. Never auto-invoke; the user must select.
 
 ## Rules
 

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -66,14 +66,18 @@ Write to `.cheese/press/<slug>.md` and print the path. The report shape:
 <ready for /age | follow-up recommended | blocked>
 
 ## Next step
-/age <slug>   — review the cooked + pressed diff
+<ready for /age>:           /age <slug>           — review the cooked + pressed diff
+<follow-up recommended>:    address open findings, then /age <slug>
+<blocked>:                  resolve blocking issues before proceeding
 ```
 
 Then print:
 
 ```
 Press report: .cheese/press/<slug>.md
-Next step:    /age <slug>
+Next step:    /age <slug>                       (when ready for /age)
+              address open findings, then /age  (when follow-up recommended)
+              blocked — resolve before continuing (when blocked)
 ```
 
 ## Handoff

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: press
-description: This skill should be used right after `/cook` produces green changes, when the user wants the test surface hardened before review or shipping — phrases like "press the changes", "harden this", "check coverage", "strengthen the tests", "are the tests good enough", "press before /age", "/press". Reads the spec + cooked diff, maps changed behavior to tests, finds weak assertions and missing boundaries, adds focused hardening tests, and produces a readiness report. Use even when the user wants to "tighten things up" before review. Do NOT use to add broad new behavior — only corrective fixes that hardening tests force.
+description: This skill should be used right after `/cook` produces green changes, when the user wants the test surface hardened before review or shipping — phrases like "press the changes", "harden this", "check coverage", "strengthen the tests", "are the tests good enough", "press before /age", "/press". Reads the spec + cooked diff, maps changed behavior to tests, finds weak assertions and missing boundaries, adds focused hardening tests, writes a press report to `.cheese/press/<slug>.md`, and prompts `/age` next. Use even when the user wants to "tighten things up" before review. Do NOT use to add broad new behavior — only corrective fixes that hardening tests force. After `/cook`; before `/age` → `/cure`.
 license: MIT
 ---
 
@@ -18,7 +18,8 @@ Do not use it to implement broad new behavior. Press may add or strengthen tests
 4. **Add focused tests** — observe red first when behaviour changes. Use `cheez-write` for precise edits.
 5. **Corrective fixes** — only for defects the hardening tests expose. No new behaviour.
 6. **Run checks** — narrowest useful tests, then relevant wider gates already in the project.
-7. **Report** — ready, follow-up, or blocked.
+7. **Report** — write `.cheese/press/<slug>.md` (slug carried from `/cook`, or derived from branch/task) and print the path. Mark readiness: `ready for /age`, `follow-up recommended`, or `blocked`.
+8. **Hand off** — prompt the next step via `AskUserQuestion` (see `## Handoff` below). Never auto-invoke.
 
 ## Preferred tools and fallbacks
 
@@ -41,24 +42,48 @@ If optional tools are missing, press a narrower surface and state the residual r
 
 ## Output
 
-```markdown
-## Press Report
+Write to `.cheese/press/<slug>.md` and print the path. The report shape:
 
-### Checks run
+```markdown
+# Press Report — <slug>
+
+## Orientation
+<one or two factual sentences about what /cook changed>
+
+## Checks run
 - <command>: <pass|fail|skipped with reason>
 
-### Findings
+## Findings
 | Severity | Category | Evidence | Recommendation |
 | --- | --- | --- | --- |
 
-### Coverage
+## Coverage
 - Spec coverage:
 - Boundary coverage:
 - Assertion strength:
 
-### Handoff
+## Readiness
 <ready for /age | follow-up recommended | blocked>
+
+## Next step
+/age <slug>   — review the cooked + pressed diff
 ```
+
+Then print:
+
+```
+Press report: .cheese/press/<slug>.md
+Next step:    /age <slug>
+```
+
+## Handoff
+
+After the press report is on disk, ask via `AskUserQuestion` which downstream to run. Default options:
+
+- **Run /age `<slug>`** *(recommended when readiness is `ready for /age`)* — review the diff.
+- **Stop** — address `follow-up recommended` items before review.
+
+Pre-select `Run /age` only when readiness is `ready for /age`. If the report is `blocked`, do not pre-select anything; the user decides whether to fix or escalate.
 
 ## Rules
 


### PR DESCRIPTION
## Summary

Implements Layers 1–3 of the skill-flow audit (`paulnsorensen/skill-flow-audit`):

- **L1 — descriptions** now name pipeline neighbours (`After /<upstream>; before /<downstream>.`) across all six skills, fixing the handoff trigger-rate weakness.
- **L2 — handoffs** use `AskUserQuestion` with Recommended pre-selection at every non-mutating step. The two artifact-mutating gates (mold's two-key handshake, cure's selection list) stay as hard gates.
- **L3 — per-skill structural fixes**: mold collapses its duplicated approval checklist into a pointer at `references/handshake.md`; culture narrows its 4-way fan-out to `/mold` or `/cook`; cook gains a 3-check standalone fast-path so unambiguous tasks bypass `/mold`, and step 3 is renamed `Implement` to drop the overloaded `Cook`; press now writes a `.cheese/press/<slug>.md` artifact for `/age` to consume; age relaxes its rule to `never auto-apply`; cure fills the unfilled terminal handoff and replaces the inline-review layering violation with a `/age <touched-paths>` recommendation.

## Test plan

- [ ] Smoke-run each skill end-to-end and confirm the new `## Handoff` `AskUserQuestion` prompt appears.
- [ ] Confirm `/cook` accepts an unambiguous task (e.g. a single named bug) without routing through `/mold`.
- [ ] Confirm `/press` writes `.cheese/press/<slug>.md` and that `/age` reads it as evidence.
- [ ] Confirm `/cure` recommends `/age <touched-paths>` rather than re-grading inline.

Layer 4 (orchestrator skill) is intentionally deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)