### PR TITLE
docs(refs): add Sliced Bread architecture references and wire skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > _"The cheese must flow."_
 
-A portable, skills-only toolkit of Agent Skills for shaping ideas, implementing them, and reviewing the result. No agents, no compiled harness bundles, no repo-wide MCP requirement — just self-contained `SKILL.md` files that any [Agent Skills](https://agentskills.io/specification)-compatible harness can load. The vocabulary (mold, culture, cook, press, age, cure) reads as a workflow you can dip into anywhere.
+A portable toolkit of Agent Skills for shaping ideas, implementing them, and reviewing the result, paired with a small set of architectural references the skills cite. No agents, no compiled harness bundles, no repo-wide MCP requirement — just self-contained `SKILL.md` files that any [Agent Skills](https://agentskills.io/specification)-compatible harness can load, plus optional `references/` markdown the skills point at on demand. The vocabulary (mold, culture, cook, press, age, cure) reads as a workflow you can dip into anywhere.
 
 ## Why cheese? Two reasons
 
@@ -113,11 +113,26 @@ If those don't show up, the cheez-* skills will hard-fail with "tilth MCP server
 
 Use only the skills you need. A clear bug can go straight to `/cook`; a no-write design discussion should stay in `/culture`.
 
+## References
+
+Long-form architectural docs that workflow skills cite when slice boundaries, dependency direction, or growth decisions come up.
+
+| Path | What it covers |
+| --- | --- |
+| `references/sliced-bread.md` | Sliced Bread architecture: organic vertical slices, the crust rule, growth pattern, dependency direction quick-check, review checklist. Always start here. |
+| `references/sb/practice.md` | Judgement calls: slice-local duplication, CQRS within a slice, anti-corruption layers, testing strategy, slice graduation (folder → workspace package → library → service). |
+| `references/sb/attribution.md` | Predecessor lineage (VSA, Hexagonal, Screaming, Clean / Onion, DDD) and where Sliced Bread inherits, differs, or drops. |
+| `references/sb/rust.md` | Rust mechanics: `foo.rs` + `foo/` facade, `pub use`, `pub(super)`, Cargo workspaces. |
+| `references/sb/go.md` | Go mechanics: `internal/` as compile-time enforcement, package = directory, `go.work`. |
+| `references/sb/ts.md` | TypeScript mechanics: `package.json` `"exports"` map as the modern facade, why barrel files are now an anti-pattern, project references. |
+
+`/mold` (Sketch), `/cook`, `/age` (encapsulation), and `/culture` cite these by relative path. Add new references here when the workflow skills need shared vocabulary they can both load on demand.
+
 ## Scope
 
 Easy-cheese is intentionally a small surface. What that means in practice:
 
-- **Skills only.** No agents, commands, eta templates, or compiled harness bundles. Each capability is a single `SKILL.md`.
+- **Skills plus references.** No agents, commands, eta templates, or compiled harness bundles. Each capability is a single `SKILL.md`; long-form architectural prose the skills point at lives under `references/`.
 - **No repo-wide MCP requirement.** Workflow skills suggest tools (tilth, Context7, Tavily, code-review-graph) but have host-native fallbacks. The cheez-* tool skills are the exception: they require tilth MCP by design.
 - **`/age` runs eight dimensions, not nine.** Without git history analysis as a built-in agent, the `precedent` dimension is unreliable in a portable skill, so it's omitted.
 - **No orchestrator skills** (no large-feature decomposition, no PR-rescue convoy, no whole-repo NIH audit). Each skill is a single, scoped step a human can drive.

--- a/references/README.md
+++ b/references/README.md
@@ -1,0 +1,14 @@
+# References
+
+Long-form architectural and engineering references that ship alongside easy-cheese. Source-of-truth documents that the workflow skills can cite or load on demand. Workflow skills (`/mold`, `/cook`, `/age`, `/cure`, `/culture`) reference these directly when slice boundaries, dependency direction, or growth decisions come up.
+
+## Sliced Bread Architecture
+
+| Document | When to load |
+|---|---|
+| [sliced-bread.md](./sliced-bread.md) | **Always.** Language-agnostic rationale, growth pattern, anti-patterns, boundary decisions, dependency-direction quick-check, review checklist. Start here. |
+| [sb/practice.md](./sb/practice.md) | When the task is a *judgement call*, not a build. Load if the prompt involves: extracting or keeping near-duplicate models across slices, deciding on read/write asymmetry (CQRS), integrating with an external API or legacy system (anti-corruption layer), choosing a per-slice testing approach, or graduating a slice to a workspace package, library, or service. Skip for routine feature work inside an existing slice — `sliced-bread.md` is enough. |
+| [sb/attribution.md](./sb/attribution.md) | When reviewers question the architectural choices. Predecessor lineage (VSA, Hexagonal, Screaming, Clean, Onion, DDD), what's inherited, what's deliberately dropped, terminology distinctions (especially "shared kernel" vs "common leaf"). |
+| [sb/rust.md](./sb/rust.md) | When the codebase is Rust. Module privacy, the `foo.rs` + `foo/` facade convention, `pub use` re-exports, workspaces. |
+| [sb/go.md](./sb/go.md) | When the codebase is Go. The `internal/` directory as compile-time enforcement, package = directory, `go.work` workspaces. |
+| [sb/ts.md](./sb/ts.md) | When the codebase is TypeScript. `package.json` `"exports"` maps as the modern facade, why barrel files are now anti-pattern, project references, monorepo workspaces. |

--- a/references/sb/attribution.md
+++ b/references/sb/attribution.md
@@ -1,0 +1,79 @@
+# Sliced Bread — Lineage and Attribution
+
+Sliced Bread doesn't invent much. It synthesizes five well-known architectural ideas into one organic growth pattern, then files off the ceremony each predecessor accumulated. This doc credits the predecessors and pins down where Sliced Bread inherits, where it differs, and where its terminology overlaps but means something different.
+
+> Companion to [Sliced Bread](../sliced-bread.md).
+
+---
+
+## Predecessors
+
+### Vertical Slice Architecture — Jimmy Bogard, 2018
+
+**Inherits:** organize-by-feature; "minimize coupling between slices, maximize within"; rejection of mandated layered abstractions; tolerance for slice-local duplication.
+
+**Differs:** Sliced Bread adds the explicit organic growth pattern (file → extract sibling → facade + folder) and the `common/` leaf rule. VSA leaves both unspecified.
+
+**Read:** Bogard, "Vertical Slice Architecture," April 2018.
+
+### Hexagonal Architecture / Ports & Adapters — Alistair Cockburn, 2005
+
+**Inherits:** the entire `adapters/` ↔ `domains/` boundary. The rule "domain defines a protocol (port), adapter implements it" is verbatim Cockburn.
+
+**Differs:** Sliced Bread doesn't distinguish primary (driving) from secondary (driven) ports as a top-level concern — it splits the same role across `entrypoints/` (driving) and `adapters/` (driven) when needed. The two layers together cover what Cockburn calls "ports and adapters."
+
+**Read:** Cockburn, "Hexagonal Architecture," HaT 2005.02.
+
+### Screaming Architecture — Robert C. Martin, 2012
+
+**Inherits:** the principle that the top-level folder layout should "scream" what the system does. `orders/`, `pricing/`, `fulfillment/` are the scream. Not `controllers/`, `services/`, `repositories/`.
+
+**Differs:** nothing meaningful.
+
+**Read:** Martin, "Screaming Architecture," 2012.
+
+### Clean Architecture / Onion — Robert C. Martin, 2012; Jeffrey Palermo, 2008
+
+**Inherits:** the dependency-inversion direction (outer layers depend on inner; inner never depends on outer); domain model purity.
+
+**Differs:** Sliced Bread deliberately drops the concentric ring structure. There are no use-case, interactor, or controller rings — just slices. Layers within a slice are emergent, not prescribed.
+
+**Read:** Martin, "Clean Architecture," 2012; Palermo, "Onion Architecture," 2008.
+
+### Domain-Driven Design — Eric Evans, 2003
+
+**Inherits:** domain events as a first-class concept; ubiquitous-language naming (slice names match business concepts).
+
+**Differs significantly on terminology:**
+
+> **DDD's "shared kernel" is not Sliced Bread's `common/` leaf.**
+> Evans' shared kernel is a *bidirectional governance artifact* shared between two bounded contexts that requires team coordination to evolve. Sliced Bread's `common/` is a *unidirectional utility leaf* — it imports nothing from siblings, siblings import freely from it, no governance involved. Use the term "common leaf" to avoid the collision.
+
+Sliced Bread also drops most of DDD's tactical patterns (aggregates, repositories as a separate noun, factories): a slice owns its own model and chooses its own internal structure.
+
+**Read:** Evans, *Domain-Driven Design*, 2003 (Ch. 14: "Maintaining Model Integrity").
+
+---
+
+## What Sliced Bread adds
+
+Ideas not in any single predecessor:
+
+1. **Organic growth pattern.** File → extract sibling → file becomes facade + folder. No predecessor specifies the growth path; most default to pre-built layered structures.
+2. **The crust = the index/facade file.** Every slice has a single public API surface. External code only imports from the crust.
+3. **Common leaf rule.** `common/` imports nothing from siblings. Strictly unidirectional — distinct from DDD's bidirectional shared kernel.
+4. **Event-direction discipline.** Events are for *reverse* dependencies only, not general-purpose messaging.
+5. **Concrete growth thresholds.** Numeric triggers (extract ~150–200 lines, hard ceiling 300) instead of "split when it feels right."
+
+---
+
+## What Sliced Bread deliberately drops
+
+| Drop | Why |
+|---|---|
+| Clean's concentric rings | Adds ceremony for no enforcement gain |
+| Hexagonal's primary/secondary distinction as a top-level split | Already handled by the `entrypoints/` vs `adapters/` split |
+| DDD's tactical patterns (aggregates, repositories as nouns, factories) | Slice owns its own model; no aggregate-root prescription |
+| MediatR / explicit dispatcher | Direct function calls until events are needed |
+| Use-case classes per operation | A function in the slice is enough |
+| "Application Services" as a separate ring | The slice's public API *is* the application service |

--- a/references/sb/go.md
+++ b/references/sb/go.md
@@ -1,0 +1,428 @@
+# Sliced Bread Architecture for Go
+
+Organic vertical slices using Go's package model and the `internal/` directory as the enforcement mechanism. No ceremony upfront — structure emerges as complexity demands it.
+
+> Companion to [Sliced Bread](../sliced-bread.md). Read that first for the language-agnostic rationale and anti-patterns. See also [attribution](./attribution.md) for predecessor lineage (VSA, Hexagonal, Screaming, Clean, DDD).
+
+---
+
+## Why Go is a natural fit
+
+Go's package system gives you two compile-time enforcement primitives out of the box:
+
+- **Capitalization controls export.** Lowercase identifiers are package-private. There is no `pub` or `private` keyword — just naming.
+- **`internal/` is compile-enforced.** Code under `path/internal/foo` can only be imported by code rooted at `path/`. The Go compiler rejects external imports outright. This is unique among mainstream languages — it gives you slice boundaries that even a determined developer cannot bypass without restructuring.
+
+These two mechanics map cleanly onto Sliced Bread's "crust" concept. The crust is the package directory itself; everything below an `internal/` is hidden from siblings.
+
+**Key insight:** Go's package = directory. There's no facade-file vs internals split like Rust's `foo.rs` + `foo/` convention. The package's exported identifiers *are* the crust. `internal/` lets you have multiple files (or sub-packages) without exposing them.
+
+---
+
+## Core structure
+
+```
+my-app/
+├── go.mod                            # Module root
+├── cmd/
+│   └── server/
+│       └── main.go                   # Ignition key — calls app.Run()
+├── internal/                         # Module-private — invisible to other modules
+│   ├── domain/                       # The loaf — all business logic
+│   │   ├── common/                   # Common leaf
+│   │   │   └── money.go
+│   │   ├── orders/                   # A slice
+│   │   │   ├── orders.go             # Public API (the crust)
+│   │   │   ├── fulfillment.go        # Sibling, same package
+│   │   │   └── internal/             # Hidden even from sibling slices
+│   │   │       └── validation.go
+│   │   └── pricing/                  # Thin slice — one file is fine
+│   │       └── pricing.go
+│   ├── entrypoints/                  # Inbound — HTTP handlers, gRPC, CLI cmds
+│   │   ├── http/
+│   │   └── cli/
+│   ├── adapters/                     # Outbound — implements domain interfaces
+│   │   ├── postgres/
+│   │   └── stripe/
+│   └── app/                          # Composition root
+│       └── app.go
+└── pkg/                              # Optional: code intended for external import
+```
+
+### The critical mapping
+
+| Sliced Bread concept | Go mechanism |
+|---|---|
+| The crust (public API) | Exported identifiers (capitalized) in the package's top-level files |
+| Slice internals | Lowercase identifiers + `internal/` subdirectories |
+| Index/barrel file | The package itself — Go has no separate "index" file |
+| "No cross-slice reaching" | Place internals under `internal/`; the compiler rejects sibling imports |
+| Pure domain models | No `database/sql`, `net/http`, or third-party SDK imports under `internal/domain/` |
+| Entrypoints | `internal/entrypoints/<protocol>/` |
+| Adapters | `internal/adapters/<technology>/` |
+
+---
+
+## The package is the crust
+
+In Go, a package's exported (capitalized) names form its public API. There is no separate facade file. To split a slice across multiple files without exposing internals, use *unexported names* + `internal/` subdirectories.
+
+```go
+// internal/domain/orders/orders.go — the crust
+//
+// External callers do:
+//   import "my-app/internal/domain/orders"
+//   orders.Place(items)
+//   var o orders.Order
+
+package orders
+
+type Order struct {
+    ID     OrderID
+    Status Status
+    Items  []LineItem
+}
+
+type Status int
+
+const (
+    Pending Status = iota
+    Fulfilled
+    Cancelled
+)
+
+// Place is the slice's public entry point.
+func Place(items []LineItem) (*Order, error) {
+    if err := validateItems(items); err != nil {  // unexported helper, same package
+        return nil, err
+    }
+    return &Order{Items: items, Status: Pending}, nil
+}
+
+// validateItems lives in this same file (or any sibling .go file in
+// package orders). Lowercase = invisible to sibling slices like pricing/.
+func validateItems(items []LineItem) error { /* ... */ }
+```
+
+For helpers that want their own package namespace while staying invisible to
+sibling slices, drop them under `internal/`. Anything under `orders/internal/`
+is importable only by code rooted at `orders/` — the compiler rejects any
+other consumer. Helpers there operate on primitives or types they own;
+importing the parent `orders` package would form a cycle
+(orders → internal → orders).
+
+```go
+// internal/domain/orders/internal/limits.go
+//
+// Anything under orders/internal/ is importable only by files rooted at
+// orders/. The compiler rejects any other consumer.
+
+package internal
+
+const MaxLineItems = 100
+
+func CheckCount(n int) error { /* takes a primitive — no cycle with orders */ }
+```
+
+### Visibility cheat sheet
+
+| Mechanism | Meaning in Sliced Bread |
+|---|---|
+| Capitalized name | Exported — part of the package's public API |
+| Lowercase name | Package-private — invisible outside this package |
+| `internal/` directory | Subtree-private — only importable from within the parent path |
+| `pkg/` directory | Convention for code intentionally meant for external consumers |
+
+**Default to lowercase** for everything inside a slice. Promote to exported only by deliberate decision. Every capital letter is a contract.
+
+---
+
+## Growth pattern
+
+### Stage 1: One file per concept
+
+```
+internal/domain/
+├── common/
+│   └── money.go
+├── orders/
+│   └── orders.go          # everything in one file
+└── pricing/
+    └── pricing.go
+```
+
+### Stage 2: Multiple files, same package
+
+```
+internal/domain/orders/
+├── orders.go              # core types + public API
+├── fulfillment.go         # related logic, same package
+└── validation.go          # private helpers (lowercase exports)
+```
+
+All three files are in `package orders`. Lowercase identifiers stay hidden; capitalized ones are exposed.
+
+### Stage 3: Hide internals with `internal/`
+
+When `validation.go` grows into multiple files but you don't want them visible to sibling slices, push them down:
+
+```
+internal/domain/orders/
+├── orders.go
+├── fulfillment.go
+└── internal/
+    ├── validation.go
+    └── tax.go
+```
+
+Now `internal/domain/pricing/` cannot import `internal/domain/orders/internal/...` even if it tried — the compiler rejects it.
+
+### Stage 4: Sub-packages for genuinely independent concerns
+
+When `fulfillment.go` itself becomes a cluster of files with its own public API:
+
+```
+internal/domain/orders/
+├── orders.go
+├── fulfillment/             # sub-package with its own crust
+│   └── fulfillment.go
+└── internal/
+    └── validation.go
+```
+
+`fulfillment` is now a sub-slice. External code can do `import "my-app/internal/domain/orders/fulfillment"`.
+
+---
+
+## Cross-slice communication
+
+### Do: Import the package
+
+```go
+// internal/domain/pricing/pricing.go
+import "my-app/internal/domain/orders"
+
+func calculate(o *orders.Order) Money { /* ... */ }
+```
+
+### Don't: Import a slice's `internal/`
+
+```go
+// internal/domain/pricing/pricing.go
+import "my-app/internal/domain/orders/internal"  // ← compile error
+```
+
+The compiler enforces this. No linter needed.
+
+### Events for reverse dependencies
+
+If `orders` depends on `pricing`, then `pricing` cannot import `orders`. Define the event in `common/`:
+
+```go
+// internal/domain/common/events.go
+package common
+
+type DomainEvent interface{ event() }
+
+type OrderPlaced struct{ OrderID string }
+
+func (OrderPlaced) event() {}
+
+type EventBus interface {
+    Publish(DomainEvent)
+    Subscribe(func(DomainEvent))
+}
+```
+
+Slices emit events via the bus; `app/` wires subscriptions. Synchronous in-process dispatch is the default; an async or queued bus is an adapter implementation choice.
+
+---
+
+## Adapters and interfaces
+
+Domain slices define interfaces (Go's structural typing makes this implicit-friendly). Adapters implement them. The domain never imports adapter code.
+
+```go
+// internal/domain/orders/orders.go — defines the port
+type Repository interface {
+    Save(*Order) error
+    FindByID(OrderID) (*Order, error)
+}
+```
+
+```go
+// internal/adapters/postgres/orders.go — implements the port
+package postgres
+
+import (
+    "database/sql"
+    "my-app/internal/domain/orders"
+)
+
+type OrderRepo struct {
+    DB *sql.DB
+}
+
+func (r *OrderRepo) Save(o *orders.Order) error                          { /* ... */ }
+func (r *OrderRepo) FindByID(id orders.OrderID) (*orders.Order, error)   { /* ... */ }
+```
+
+```go
+// internal/app/app.go — wires it together
+package app
+
+import (
+    "my-app/internal/adapters/postgres"
+    "my-app/internal/domain/orders"
+    "my-app/internal/entrypoints/http"
+)
+
+func Run() error {
+    db := openDB()
+    repo := &postgres.OrderRepo{DB: db}
+
+    var _ orders.Repository = repo  // compile-time interface check
+
+    return http.Serve(repo)
+}
+```
+
+The `internal/domain/` tree has zero `database/sql`, `net/http`, or SDK imports. If you see one, that's a boundary violation.
+
+---
+
+## Entrypoints
+
+`internal/entrypoints/` is where external requests translate into domain calls. HTTP handlers, gRPC service impls, CLI subcommands, queue consumers.
+
+```go
+// internal/entrypoints/http/orders.go
+package http
+
+import (
+    "encoding/json"
+    "net/http"
+
+    "my-app/internal/domain/orders"
+)
+
+func PlaceHandler(repo orders.Repository) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        var items []orders.LineItem
+        if err := json.NewDecoder(r.Body).Decode(&items); err != nil {
+            http.Error(w, err.Error(), 400)
+            return
+        }
+
+        o, err := orders.Place(items)
+        if err != nil {
+            http.Error(w, err.Error(), 422)
+            return
+        }
+        if err := repo.Save(o); err != nil {
+            http.Error(w, err.Error(), 500)
+            return
+        }
+        json.NewEncoder(w).Encode(o)
+    }
+}
+```
+
+Entrypoints decode, call domain, encode, map errors. They receive their dependencies as parameters — they do not construct adapters themselves.
+
+---
+
+## When to use `go.work` workspaces
+
+`go.work` is the heavy artillery. Use when module privacy isn't enough:
+
+| Signal | Response |
+|---|---|
+| Want independent builds and versioning per slice | Multi-module workspace |
+| Need to publish a slice as a standalone library | Separate module |
+| Single application, <20k LOC | One module + `internal/` is fine |
+| Multiple binaries sharing domain logic | Multi-module with shared domain module |
+
+For multi-module:
+
+```
+my-app/
+├── go.work
+├── domain/                  # own module: github.com/me/my-app/domain
+│   ├── go.mod
+│   ├── orders/
+│   └── pricing/
+├── adapters/                # own module
+│   ├── go.mod
+│   └── postgres/
+└── cmd/
+    └── server/              # own module
+        ├── go.mod
+        └── main.go
+```
+
+The `go.mod` `require` graph now physically encodes the dependency direction.
+
+---
+
+## Rules (Go-specific)
+
+1. **The package is the crust.** A package's exported names are its public API. Don't add a separate "index file" — Go doesn't need it.
+2. **Default to lowercase.** Export only with intent. Every capital letter is a contract.
+3. **`internal/` is your friend.** Anything you don't want siblings to reach goes under `internal/`. The compiler enforces it for free.
+4. **No infrastructure imports in `internal/domain/`.** No `database/sql`, no `net/http`, no SDK packages. (Exception: `encoding/json` struct tags on domain types are pragmatic.)
+5. **Interfaces as ports — defined where they're consumed.** Go style: the domain declares what it needs as an interface; adapters satisfy it structurally. Don't put interfaces in adapter packages.
+6. **Entrypoints are thin.** Decode, call domain, encode. No business logic. Receive dependencies as parameters.
+7. **Common is a leaf.** `internal/domain/common/` imports nothing from sibling slices.
+8. **Grow, don't pre-build.** A new slice starts as one `.go` file. It earns more files when crowded, an `internal/` subdirectory when it needs hidden helpers, a sub-package when it has its own crust, a separate module when independent versioning matters.
+
+---
+
+## The `cmd/` and `app/` split
+
+Go convention puts binaries under `cmd/<name>/main.go`. Keep `main.go` trivial — call `app.Run()` and nothing else.
+
+```go
+// cmd/server/main.go
+package main
+
+import (
+    "log"
+
+    "my-app/internal/app"
+)
+
+func main() {
+    if err := app.Run(); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+`internal/app/` is the composition root: build adapters, inject them into entrypoints, start the server.
+
+```
+            ┌──────────────┐
+            │   main.go    │  cmd/server/main.go — calls app.Run()
+            └──────┬───────┘
+                   │
+                   ▼
+            ┌──────────────┐
+            │     app/     │  Composition root — only package that
+            │              │  sees all three layers below
+            └──┬───┬───┬───┘
+               │   │   │
+       ┌───────┘   │   └───────┐
+       ▼           ▼           ▼
+┌────────────┐ ┌────────┐ ┌──────────┐
+│entrypoints/│ │domain/ │ │adapters/ │
+└────────────┘ └────────┘ └──────────┘
+```
+
+**Who imports whom:**
+
+- **`internal/domain/`** → nothing outside itself
+- **`internal/adapters/`** → `internal/domain/` only (implements interfaces)
+- **`internal/entrypoints/`** → `internal/domain/` only (calls domain, receives adapters as parameters)
+- **`internal/app/`** → all three
+- **`cmd/*/main.go`** → `internal/app/` only

--- a/references/sb/practice.md
+++ b/references/sb/practice.md
@@ -1,0 +1,351 @@
+# Sliced Bread in Practice
+
+Applied patterns and judgement calls that don't fit cleanly in the language docs:
+how slices interact with CQRS, anti-corruption layers, testing, slice-local
+duplication, and — the section most teams need most — when a slice should
+graduate from a folder to a workspace package, library, or service.
+
+> **Load this doc when** the task is a judgement call, not a build:
+> extracting/keeping near-duplicate models, deciding on a read/write split,
+> integrating with an external system whose vocabulary clashes, choosing a
+> per-slice testing strategy, or graduating a slice. For routine feature work
+> inside an existing slice, [Sliced Bread](../sliced-bread.md) alone is enough.
+
+> Companion to [Sliced Bread](../sliced-bread.md). Read that first for the
+> language-agnostic rationale and anti-patterns. See also
+> [attribution](./attribution.md) for predecessor lineage.
+
+---
+
+## Slice-local duplication is fine
+
+The single most-resisted rule in vertical-slice architectures: **each slice owns
+its own model of a concept.** If `orders.LineItem` and `invoicing.LineItem` look
+80% alike, that is not duplication to eliminate. It is two distinct concepts
+that happen to share a current shape.
+
+Sandi Metz: *"Duplication is far cheaper than the wrong abstraction."* The cost
+ordering, in practice:
+
+| Cost | Severity |
+|---|---|
+| A wrong abstraction shared across slices | High — every change ripples and shapes both sides |
+| Two near-duplicate structures evolving independently | Low — each slice updates its own without coordination |
+| Genuine pure-data values used identically by 3+ slices, kept duplicated | Medium — extract to `common/` |
+
+### Keep the duplication when
+
+- The structures look similar but model different concepts (`Customer` in
+  `billing` is not `Customer` in `support`).
+- The slices have different lifecycle, validation, or consistency needs.
+- One representation is read-optimized, the other is write-authoritative.
+- Extraction would force every change to coordinate across slice owners.
+
+### Promote to `common/` only when a named slice is the wrong answer
+
+The first question is never "should this go in common?" — it's "is there a
+slice missing here?" Most extraction candidates turn out to be unnamed
+domains. A `notifications/` slice beats a `common/notify.*` file every time.
+
+Promote to `common/` only when *all* of these hold:
+
+- 2+ slices reference the type today, with identical semantics. (Don't
+  pre-promote on speculation.)
+- The type carries **zero behavior** — pure data, or a port/protocol whose
+  shape is the contract.
+- A named slice would be a worse fit — the type is too atomic to deserve a
+  domain (`Money`, `UserId`, `Timestamp`, `Email`), or it's an event payload
+  whose schema can't live with either producer or consumer without creating
+  a cycle.
+
+If you find yourself adding *behavior* to a `common/` type, that's the
+signal: the type wants to live in a slice. Move it.
+
+The promotion threshold is a deliberate counterweight to the DRY reflex. Two
+copies of a struct cost less than one wrong abstraction — and a named slice
+usually beats both.
+
+---
+
+## CQRS within a slice
+
+Command Query Responsibility Segregation pairs naturally with vertical slices.
+Inside a slice, commands (mutations) and queries (reads) can take separate paths
+with different models.
+
+```
+domains/orders/
+├── (slice facade)              # whatever your language calls the crust
+├── order.*                     # write model — the entity
+├── place.*                     # command
+├── update-status.*             # command
+└── queries/
+    ├── by-customer.*           # read-optimized, can join across stores
+    └── pending-summary.*       # denormalized projection
+```
+
+### When CQRS earns its keep within a slice
+
+- Read models genuinely differ in shape (denormalized for UI).
+- Reads and writes scale on different dimensions (heavy reads, infrequent
+  writes — read-side caching, replicas, or projections).
+- Different consistency contracts per side (eventual on reads, strong on writes).
+
+### When it's overkill
+
+- Reads and writes share the same shape — a query method on the entity is enough.
+- No projections, no event sourcing, no replicas.
+- The slice has five operations total and you'd be adding two folders to
+  separate `find_by_id` from `place`.
+
+CQRS is a slice-local choice, not a project-wide mandate. Some slices will use
+it, most won't. There is no global "queries/ folder must exist" rule.
+
+---
+
+## Anti-corruption layers
+
+When a slice talks to an external system whose vocabulary or model conflicts
+with yours — legacy databases, third-party APIs, partner integrations — the
+adapter doubles as an Anti-Corruption Layer (ACL). Its job is to make sure
+foreign concepts never leak past it.
+
+### The rule
+
+- **Domain code never imports vendor types.** No `StripeCharge`,
+  `LegacyAccountRow`, or `SalesforceOpportunity` inside `domains/`.
+- **Adapters speak both languages.** The domain port is in your concepts.
+  The adapter implementation knows the foreign one. Translation happens at
+  the boundary.
+
+### Example
+
+```ts
+// domains/payments/index.ts — port in your vocabulary
+export interface PaymentGateway {
+  charge(amount: Money, customer: CustomerRef): Promise<PaymentReceipt>;
+}
+```
+
+```ts
+// adapters/stripe/payment-gateway.ts — the ACL
+export class StripePaymentGateway implements PaymentGateway {
+  async charge(amount: Money, customer: CustomerRef): Promise<PaymentReceipt> {
+    const result = await this.stripe.charges.create({
+      amount: amount.cents,
+      currency: amount.currency.code,
+      customer: customer.externalId,
+    });
+    return PaymentReceipt.fromStripe(result); // translate at the seam
+  }
+}
+```
+
+### The harder case: legacy databases
+
+If you adopt a system with hundreds of badly-named columns, the ORM mapping
+inside the adapter *is* your ACL. The domain entity has well-named fields;
+the adapter does the renaming. A leaky ORM that surfaces `usr_acct_typ_cd`
+to the domain has skipped the ACL and corrupted the model.
+
+### When the foreign model is your model
+
+If you're integrating with a system whose vocabulary you've adopted as the
+authoritative one (e.g. you're a thin shell over a SaaS), the adapter is
+just an adapter — there's nothing to anti-corrupt against. The ACL pattern
+exists to protect a *distinct* domain model.
+
+---
+
+## Testing strategy per slice
+
+Vertical slicing reshapes the test pyramid. Center of gravity shifts up:
+
+| Layer | What it tests | Where it lives |
+|---|---|---|
+| **Slice integration** (most) | Slice's public API end-to-end with in-memory or testcontainer adapters | Co-located with the slice (`orders/__tests__/place.test.ts`) |
+| **Pure unit** | Calculations, parsing, validation — no IO | Co-located, often same file as the function |
+| **Cross-slice / use-case** | Orchestration across multiple slices | `app/__tests__/checkout.test.ts` |
+| **End-to-end** (few) | Through entrypoints to real adapters | Top-level `e2e/` |
+
+### What changes vs layered testing
+
+- **Repository-mock unit tests largely disappear.** Slice integration tests
+  exercise the real interface against a fake or in-memory adapter — same
+  surface as production, faster than the DB.
+- **Service-layer unit tests disappear with the service layer.** A slice's
+  public API *is* the service.
+- **Each slice's test suite is self-contained.** No shared fixtures across
+  slices. If `pricing` tests need data set up by the `orders` slice, that
+  is a coupling smell — the dependency is leaking through tests.
+
+### Heuristics
+
+- Test through the crust, not through internals. Internal refactors
+  shouldn't break tests; behavior changes should.
+- One integration test that goes through the slice's public command beats
+  five unit tests on private helpers.
+- Don't unit-test code that's already covered by an integration test for
+  the same path — you're paying maintenance for the same coverage twice.
+
+---
+
+## Slice growth and graduation
+
+A slice starts as one file. It can grow into multiple files, then a folder
+with hidden internals, then a workspace package, then a separately versioned
+library, then a separately deployed service. Each step adds friction. Never
+take a step without a concrete reason — and **don't skip steps**.
+
+### Five stages of slice maturity
+
+| Stage | Shape | Cost | Triggers to advance |
+|---|---|---|---|
+| 1. **File** | `pricing.*` | None | >150–200 lines, 3+ concepts in one file |
+| 2. **Folder** | `pricing/{index,calc,rules}.*` (+ internal) | Subdir, facade file | Hidden helpers want privacy from siblings |
+| 3. **Workspace package** | `packages/pricing/` (Cargo member / pnpm workspace / `go.mod`) | Manifest, build target, typecheck boundary | Build-time pain, ownership split, contract pressure, TS visibility enforcement |
+| 4. **Versioned library** | published to internal registry | SemVer, publish pipeline, registry coordination | A second repository imports it |
+| 5. **Service** | network boundary | Network reliability, distributed observability, schema versioning, deployment topology | Independent scale / deploy / runtime / failure isolation |
+
+You can stop at any stage. **Most slices end at stage 2 forever.** The
+literature loves stages 4–5; production codebases live at stage 2.
+
+### Stage 1 → 2: file becomes folder
+
+Mechanical. Covered in [sliced-bread.md → Growth pattern](../sliced-bread.md#growth-pattern).
+The trigger is internal pressure (file size, hidden helpers wanting
+privacy) — no external coordination, no manifest changes.
+
+### Stage 2 → 3: folder becomes workspace package
+
+A workspace package adds a manifest (`Cargo.toml`, `package.json`, `go.mod`),
+a build target, and a typecheck/test boundary. The cost is real: cross-package
+refactors need package-aware tooling, and your devloop now includes a build
+step per package.
+
+**Worth it when:**
+
+- **Build-time pain.** Typecheck or compile of one slice gates iteration on
+  another. Workspace packages give you parallel, cacheable build units.
+- **Ownership split.** A different team owns the slice's evolution and you
+  want explicit changelog and review surface for the boundary.
+- **Public-API contract pressure.** The slice has many consumers and you
+  want changes to the crust to break loudly at compile time across them.
+- **TypeScript visibility enforcement.** TS has no compile-enforced module
+  privacy at the directory level (see [`./ts.md`](./ts.md)). Once the
+  honor system on `"exports"` stops being honored, a package boundary is
+  the strongest enforcement available.
+
+**Don't graduate because:**
+
+- The directory "feels important."
+- You read a blog post about monorepo packages.
+- Reviewers say "this should be its own package" without naming a concrete pain.
+
+### Stage 3 → 4: workspace package becomes versioned library
+
+A second repository needs the slice. Now you publish.
+
+**Triggers:**
+
+- A second repo imports the package.
+- The slice's release cadence diverges from the host application's.
+- An open-source release is planned.
+
+**Costs:**
+
+- SemVer commitment — every breaking change is a major version bump.
+- Publish pipeline, registry, security scanning, sign-off.
+- Coordination overhead with downstream consumers on every change.
+
+This is the most common over-shoot in monorepos: extracting a library "to be
+reusable" *before* there is a second consumer. Resist. **Two consumers is
+the trigger; one consumer is just a directory.**
+
+### Stage 4 → 5: library becomes service
+
+The slice runs in its own process, exposed by RPC, HTTP, or message queue.
+
+**Real triggers:**
+
+- **Independent scaling.** The slice is the bottleneck or a fan-out hot spot;
+  scaling the host wastes resources.
+- **Independent deploy.** Deploying the host has unacceptable risk and the
+  slice changes on a different cadence.
+- **Runtime isolation.** Different language, memory profile, or security
+  boundary.
+- **Failure isolation.** The slice crashing shouldn't take the host with it.
+
+**Not triggers:**
+
+- "Microservices are best practice."
+- "We want to reuse this from another service" — publish a library first.
+- Resume-driven architecture.
+
+The operational tax of a service split is severe and well-documented:
+network reliability, distributed transactions, observability across
+processes, schema versioning, deployment topology. **Default to in-process.**
+The slice boundary already gives you most of what you'd want from a service
+split — without that tax. Promote only when the in-process arrangement is
+causing concrete, measurable pain.
+
+### Reverse moves
+
+Graduation is reversible:
+
+- A graduated workspace package can be inlined back to a folder if the
+  boundary turned out wrong.
+- A published library can be republished as a workspace package and the
+  external version frozen.
+- A service can be re-merged into the monolith ("strangler fig" in reverse).
+
+Reverse moves are how you correct over-shoot. They should not be rare.
+Architectures that treat graduation as a one-way ratchet calcify.
+
+### When the loaf itself gets too big
+
+A monorepo with 30+ slices and a single flat `domains/` directory eventually
+feels heavy. Three options, in order of cost:
+
+1. **Group by bounded context.** `domains/billing/{invoicing,subscriptions,payments}/`
+   when groups of slices share value objects, events, or vocabulary. Cheap,
+   reversible, no manifest changes.
+2. **Extract a sub-loaf.** `packages/billing/src/domains/{invoicing,subscriptions}/`
+   — a workspace package that is itself a Sliced Bread structure inside.
+   Medium cost, reversible, follows the stage 2→3 rule.
+3. **Split the application.** When two halves of the loaf rarely touch and
+   have separate users / deployments, the second loaf is a different
+   application. Expensive, often irreversible.
+
+Try the cheap moves first. Bounded-context grouping costs nothing and tells
+you most of what you'd learn from a hypothetical split.
+
+### The graduation review checklist
+
+Before advancing a slice, write down:
+
+1. **What concrete pain does the current shape cause?** (Build minutes,
+   blast radius incidents, ownership friction, contract drift.) If you
+   can't name it in one paragraph with a real example, don't graduate.
+2. **What does this graduation cost in tooling, process, and friction?**
+   Be specific — "extra build step in CI," "every change now needs a
+   version bump," etc.
+3. **What's the smallest graduation that resolves the pain?** Don't skip
+   stages. A folder might be enough; a workspace package might be enough;
+   you probably don't need a service.
+4. **Is graduation reversible? If not, what would you need to see to undo it?**
+
+Adjective-only justifications ("cleaner," "more scalable," "more
+modular") are an architectural smell. They mean someone is graduating to
+satisfy a feeling, not to resolve a problem.
+
+---
+
+## Reading order
+
+1. [`../sliced-bread.md`](../sliced-bread.md) — start here for the rationale.
+2. This doc — applied patterns and graduation triggers.
+3. Language-specific guide ([rust](./rust.md), [go](./go.md), [ts](./ts.md))
+   for the actual mechanics in your language. Each covers the *syntax* of
+   workspaces, packages, and module privacy; this doc covers the *when*.
+4. [`./attribution.md`](./attribution.md) — predecessors and what's distinct.

--- a/references/sb/rust.md
+++ b/references/sb/rust.md
@@ -1,0 +1,506 @@
+# Sliced Bread Architecture for Rust
+
+Organic vertical slices that grow from simple files into structured modules, using Rust's module system and privacy model as the enforcement mechanism. No ceremony upfront — structure emerges as complexity demands it.
+
+> Companion to [Sliced Bread](../sliced-bread.md). Read that first for the language-agnostic rationale and anti-patterns. See also [attribution](./attribution.md) for predecessor lineage (VSA, Hexagonal, Screaming, Clean, DDD).
+
+---
+
+## Why Rust is a natural fit
+
+Rust's module system was *designed* around the facade pattern. Aaron Turon's 2017 survey of `futures`, `regex`, `rayon`, `serde`, `std`, and other major crates found that virtually all of them used `pub use` re-exports to decouple internal file organization from the public API surface. The Rust 2018 edition formalized this by introducing the `foo.rs` + `foo/` convention — a file that acts as a facade over a directory of the same name.
+
+This is exactly the Sliced Bread growth pattern. Rust just gives it compiler-enforced privacy boundaries for free.
+
+**Key insight:** Rust's tightest privacy boundary is the module subtree. Private items are visible to child modules but invisible to siblings. This makes domain modules natural bounded contexts — a `users/` slice can enforce invariants across all its internals while hiding everything behind `pub use` re-exports. Horizontal layers (separate `models/`, `handlers/`, `services/` folders) work *against* this strength by forcing everything to be `pub(crate)`.
+
+---
+
+## Core structure
+
+```
+src/
+├── lib.rs                         # Table of contents — declares all four modules
+├── main.rs                        # Ignition key — calls app::run()
+├── domain/                        # The loaf — all business logic lives here
+│   ├── mod.rs                     # Declares child modules, re-exports public API
+│   ├── common/                    # Common leaf (no sibling deps; not DDD's shared kernel)
+│   │   └── mod.rs
+│   ├── orders.rs                  # ← A slice facade (the crust)
+│   ├── orders/                    # ← Internals behind the facade
+│   │   ├── model.rs
+│   │   ├── fulfillment.rs         # Can itself become a facade later
+│   │   └── validation.rs
+│   └── pricing.rs                 # Thin slice — single file is fine
+├── entrypoints/                   # Inbound surface — where the outside world calls in
+│   ├── mod.rs
+│   ├── commands.rs                # Tauri commands
+│   └── routes.rs                  # axum route handlers
+├── adapters/                      # Outbound — implements domain traits
+│   ├── mod.rs
+│   ├── sqlite.rs
+│   └── github.rs
+└── app/                           # Composition root — wires everything together
+    └── mod.rs
+```
+
+### The critical mapping
+
+| Sliced Bread concept | Rust mechanism |
+|---------------------|----------------|
+| The crust (public API) | `foo.rs` — the facade file |
+| Slice internals | `foo/` — the directory of private submodules |
+| Index/barrel file | `pub use` re-exports in `foo.rs` |
+| "No cross-slice reaching" | Module privacy — siblings can't see each other's internals |
+| Pure models | No `use rusqlite`, `use axum`, etc. in `domain/` |
+| Entrypoints call in | `entrypoints/` translates external requests into domain calls |
+| Adapters implement out | `adapters/` implements domain-defined traits |
+| One-way dependencies | Enforced by `use` paths; cycles won't compile cleanly |
+
+---
+
+## The facade is the file
+
+In Rust 2018+, when you have both `orders.rs` and `orders/`, the file `orders.rs` **is** the module root. Everything in `orders/` is a child module. This is the facade pattern with zero boilerplate — the language gives it to you.
+
+```rust
+// src/domain/orders.rs — THE CRUST
+//
+// This file IS the public API. External code does:
+//   use crate::domain::orders::Order;
+//   use crate::domain::orders::place_order;
+//
+// They never touch orders/model.rs or orders/fulfillment.rs directly.
+
+mod model;        // private — declares orders/model.rs
+mod fulfillment;  // private — declares orders/fulfillment.rs
+mod validation;   // private — declares orders/validation.rs
+
+// Re-export the public surface
+pub use model::Order;
+pub use model::OrderStatus;
+pub use model::LineItem;
+pub use fulfillment::FulfillmentService;
+
+// Public functions that orchestrate internals
+pub fn place_order(items: Vec<LineItem>) -> Result<Order, OrderError> {
+    validation::validate_items(&items)?;
+    let order = Order::new(items);
+    Ok(order)
+}
+
+// This stays private — internal error type
+pub(crate) struct OrderError { /* ... */ }
+```
+
+```rust
+// src/domain/orders/model.rs — INTERNAL
+//
+// This file defines the core types. It's private to the orders module.
+// Only orders.rs (the facade) decides what gets re-exported.
+
+pub struct Order {
+    pub id: OrderId,
+    pub status: OrderStatus,
+    pub items: Vec<LineItem>,
+}
+
+pub struct LineItem { /* ... */ }
+
+pub enum OrderStatus {
+    Pending,
+    Fulfilled,
+    Cancelled,
+}
+
+// Not re-exported — truly internal
+pub(super) fn recalculate_totals(order: &mut Order) { /* ... */ }
+```
+
+### Visibility cheat sheet
+
+| Visibility | Meaning in Sliced Bread |
+|-----------|------------------------|
+| `pub` | Part of the crate's public API (use sparingly) |
+| `pub(crate)` | Visible across slices within the crate — the "internal public" |
+| `pub(super)` | Visible to the facade file only — internal to the slice |
+| `pub(in crate::domain)` | Visible within the domain module tree only |
+| (no modifier) | Private to the current file |
+
+**Default to `pub(super)`** for items inside a slice's subfolder. The facade (`orders.rs`) then selectively promotes items to `pub` or `pub(crate)` via re-exports. This is the "crust is the contract" rule enforced by the compiler.
+
+---
+
+## Growth pattern
+
+### Stage 1: One file per concept
+
+```
+src/domain/
+├── mod.rs
+├── common.rs     # shared types
+├── orders.rs     # everything in one file
+└── pricing.rs    # everything in one file
+```
+
+This is fine. Don't create folders preemptively.
+
+### Stage 2: Extract sibling files
+
+When `orders.rs` gets crowded, you split — but the file *becomes the facade* automatically:
+
+```
+src/domain/
+├── mod.rs
+├── common.rs
+├── orders.rs       # ← was the whole slice, now becomes the facade
+├── orders/
+│   ├── model.rs    # ← extracted from orders.rs
+│   └── validation.rs
+└── pricing.rs
+```
+
+The `pub use` re-exports in `orders.rs` mean **no call sites change**. Anyone doing `use crate::domain::orders::Order` still works. This is the key property — the facade absorbs the refactoring.
+
+### Stage 3: Nested facades
+
+When `fulfillment.rs` itself gets complex, it becomes its own facade:
+
+```
+src/domain/
+├── mod.rs
+├── orders.rs                # facade
+├── orders/
+│   ├── model.rs
+│   ├── validation.rs
+│   ├── fulfillment.rs       # ← sub-facade
+│   └── fulfillment/
+│       ├── shipping.rs
+│       └── tracking.rs
+└── pricing.rs
+```
+
+The pattern is fractal. Every `.rs` file is potentially a facade over a same-named directory. You only add the directory when you need it.
+
+---
+
+## Cross-slice communication
+
+### Do: Import through the facade
+
+```rust
+// In src/domain/pricing.rs
+use crate::domain::orders::Order;       // ✓ goes through the crust
+use crate::domain::orders::LineItem;    // ✓ goes through the crust
+```
+
+### Don't: Reach into internals
+
+```rust
+// In src/domain/pricing.rs
+use crate::domain::orders::model::Order;           // ✗ compiler allows it if pub,
+                                                    //   but architecturally wrong
+use crate::domain::orders::fulfillment::Tracker;   // ✗ reaching into a slice
+```
+
+**Enforcement:** Keep submodules private (`mod model` not `pub mod model`). The compiler then prevents the wrong imports entirely. No linter needed.
+
+### Events for reverse dependencies
+
+If `orders` depends on `pricing`, then `pricing` must not `use` anything from `orders`. For reverse communication, define events in `common`:
+
+```rust
+// src/domain/common.rs
+pub enum DomainEvent {
+    OrderPlaced { order_id: OrderId },
+    PriceChanged { sku: Sku, new_price: Money },
+}
+
+pub trait EventBus: Send + Sync {
+    fn publish(&self, event: DomainEvent);
+    fn subscribe(&self, handler: Box<dyn Fn(&DomainEvent) + Send>);
+}
+```
+
+Slices emit events. The `app/` layer wires up the subscriptions. No slice knows who's listening.
+
+---
+
+## Adapters and traits
+
+Domain slices define traits (ports). Adapters implement them. The domain never imports adapter code.
+
+```rust
+// src/domain/orders.rs — defines the port
+pub trait OrderRepository: Send + Sync {
+    fn save(&self, order: &Order) -> Result<(), RepositoryError>;
+    fn find_by_id(&self, id: &OrderId) -> Result<Option<Order>, RepositoryError>;
+    fn find_pending(&self) -> Result<Vec<Order>, RepositoryError>;
+}
+```
+
+```rust
+// src/adapters/sqlite.rs — implements the port
+use crate::domain::orders::{Order, OrderId, OrderRepository, RepositoryError};
+
+pub struct SqliteOrderRepo {
+    conn: rusqlite::Connection,
+}
+
+impl OrderRepository for SqliteOrderRepo {
+    fn save(&self, order: &Order) -> Result<(), RepositoryError> {
+        // rusqlite calls here — this is the only place they live
+        todo!()
+    }
+    // ...
+}
+```
+
+```rust
+// src/app.rs — wires it together
+use crate::domain::orders::OrderRepository;
+use crate::adapters::sqlite::SqliteOrderRepo;
+use crate::entrypoints::routes;
+
+pub fn run() {
+    // Build adapters
+    let repo: Arc<dyn OrderRepository> = Arc::new(SqliteOrderRepo::new("app.db"));
+
+    // Mount entrypoints with injected dependencies
+    let router = axum::Router::new()
+        .route("/orders", post(routes::place_order_handler))
+        .with_state(repo);
+
+    // Start the server
+    // ...
+}
+```
+
+The `domain/` module tree has **zero** `use rusqlite`, `use axum`, `use octocrab`, etc. If you see a framework import in `domain/`, something is wrong.
+
+---
+
+## Entrypoints
+
+`entrypoints/` is what most projects call "handlers" — the code that receives an external request and translates it into a domain operation. CLI subcommands, REST route handlers, Tauri commands, gRPC service impls, webhook receivers. If you've written `handlers/` or `controllers/` before, this is the same role under a more honest name.
+
+Entrypoints are the **mirror image** of adapters. Adapters implement domain traits (the domain calls *out* through them). Entrypoints call *into* the domain. Both are framework-specific. Neither contains business logic.
+
+The important distinction: **the domain and adapters together form the core application — a library that could be used by any entrypoint.** The entrypoints are just different ways to drive that library. A REST API, a CLI tool, and a Tauri desktop app could all share the same `domain/` and `adapters/`, each providing their own `entrypoints/`.
+
+```rust
+// src/entrypoints/commands.rs — Tauri commands
+use crate::domain::orders::{self, LineItem, Order};
+use crate::domain::orders::OrderRepository;
+
+#[tauri::command]
+pub async fn place_order(
+    items: Vec<LineItem>,
+    repo: tauri::State<'_, Box<dyn OrderRepository>>,
+) -> Result<Order, String> {
+    orders::place_order(items)
+        .and_then(|order| {
+            repo.save(&order)?;
+            Ok(order)
+        })
+        .map_err(|e| e.to_string())
+}
+```
+
+```rust
+// src/entrypoints/routes.rs — axum handlers
+use axum::{Json, extract::State};
+use crate::domain::orders::{self, LineItem, Order};
+use crate::domain::orders::OrderRepository;
+
+pub async fn place_order_handler(
+    State(repo): State<Arc<dyn OrderRepository>>,
+    Json(items): Json<Vec<LineItem>>,
+) -> Result<Json<Order>, AppError> {
+    let order = orders::place_order(items)?;
+    repo.save(&order)?;
+    Ok(Json(order))
+}
+```
+
+### What entrypoints do
+
+- **Deserialize** incoming requests (JSON, CLI args, IPC messages)
+- **Call** domain functions and trait methods
+- **Serialize** domain results into responses
+- **Map** domain errors into framework-specific error responses
+
+### What entrypoints do NOT do
+
+- Business logic (that's `domain/`)
+- Database queries (that's `adapters/`)
+- Construct their own dependencies (that's `app/` — entrypoints receive injected services)
+
+### Entrypoints receive, they don't construct
+
+Entrypoints take their dependencies as parameters — injected by the `app/` layer during composition. A Tauri command receives a `State<Box<dyn OrderRepository>>`. An axum handler receives `State<Arc<dyn OrderRepository>>`. The entrypoint never knows it's talking to SQLite vs Postgres vs an in-memory mock.
+
+---
+
+## When to use workspaces
+
+Workspaces are the heavy artillery. Use them when module privacy isn't enough:
+
+| Signal | Response |
+|--------|----------|
+| Want independent compile times | Workspace with `crates/` |
+| Need to publish a slice as a standalone library | Workspace |
+| Team boundaries align with slice boundaries | Workspace |
+| Single application, <20k LOC | Single crate with `domain/` modules is fine |
+| Multiple binaries sharing domain logic | Workspace with a shared `domain` crate |
+
+For a workspace, each slice becomes its own crate:
+
+```
+Cargo.toml (workspace)
+crates/
+├── domain-common/       # common-leaf crate
+├── domain-orders/       # orders slice crate
+├── domain-pricing/      # pricing slice crate
+├── adapters-sqlite/     # adapter crate
+└── app/                 # binary crate, depends on everything
+```
+
+Dependency direction is now enforced in `Cargo.toml` — if `domain-orders` doesn't list `domain-pricing` as a dependency, the code physically cannot import from it. This is the strongest architectural guarantee Rust offers.
+
+---
+
+## Rules (Rust-specific)
+
+1. **The facade is the file** — `foo.rs` is the public API for the `foo` slice. `foo/` contains private submodules. External code only `use`s from `foo.rs`, never from `foo/*.rs`.
+
+2. **`mod` is private by default** — Declare child modules with `mod`, not `pub mod`. Selectively re-export with `pub use`. This is the crust.
+
+3. **`pub(super)` for slice internals** — Items in `orders/model.rs` should be `pub(super)`, not `pub`. The facade then decides what to promote.
+
+4. **No framework imports in `domain/`** — If you see `use rusqlite`, `use axum`, `use reqwest`, or `use serde` in a domain file, that's a boundary violation. (Exception: `serde::{Serialize, Deserialize}` on domain types is pragmatic and widely accepted.)
+
+5. **Traits as ports** — Domain slices define trait interfaces. `adapters/` implements them. `entrypoints/` calls through them. `app/` wires them.
+
+6. **Entrypoints are thin** — They deserialize, call domain, serialize. No business logic, no direct adapter access. They receive dependencies via injection.
+
+7. **Common is a leaf** — `domain/common/` imports nothing from sibling slices. It only contains types, errors, and traits that multiple slices share.
+
+8. **Grow, don't pre-build** — A new slice starts as a single `.rs` file. It earns a folder when it needs one. It earns a workspace crate when module privacy isn't enough.
+
+---
+
+## The app layer
+
+`app/` is the one horizontal layer in the architecture. It sits on top of the vertical slices and is the only place where domain traits meet concrete adapters. It's the composition root, the entry point orchestrator, and the home for anything framework-specific that doesn't belong in `domain/` or `adapters/`.
+
+### What lives in `app/`
+
+| Concern | Example |
+|---------|---------|
+| Composition / DI wiring | Building concrete types, injecting adapters into entrypoints |
+| Startup / shutdown | Initializing the database, spawning background tasks, graceful shutdown |
+| Configuration | Loading config files, environment variables, choosing which adapters to wire |
+| Router / command registration | Mounting entrypoint handlers onto the framework (axum Router, Tauri builder) |
+
+### What does NOT live in `app/`
+
+| Concern | Where it belongs |
+|---------|-----------------|
+| Business rules | `domain/` slices |
+| Request handling logic | `entrypoints/` |
+| Database queries, API clients | `adapters/` |
+| Domain types and traits | `domain/` slices |
+
+### `app/` as a facade too
+
+`app/` follows the same growth pattern as domain slices. It starts as a single file, earns a folder when it needs one:
+
+```
+# Stage 1: Simple
+src/app.rs                    # everything in one file
+
+# Stage 2: Growing
+src/app.rs                    # facade — re-exports, run()
+src/app/
+├── config.rs                 # configuration loading
+├── startup.rs                # wiring adapters to entrypoints
+└── router.rs                 # mounting routes / registering commands
+```
+
+---
+
+## The crate root: `lib.rs` and `main.rs`
+
+`lib.rs` is the crate's table of contents. It declares the three top-level modules and nothing else. All the interesting work happens inside them.
+
+```rust
+// src/lib.rs — the table of contents
+//
+// Declares the architecture's four layers.
+// Does not contain logic, types, or wiring.
+
+pub mod domain;
+pub mod entrypoints;
+pub mod adapters;
+pub mod app;
+```
+
+`main.rs` is a thin shim that calls into the `app` layer to bootstrap:
+
+```rust
+// src/main.rs — the ignition key
+//
+// This file should be trivially small. It calls app::run()
+// and that's it. All composition logic lives in app/.
+
+fn main() {
+    my_crate::app::run();
+}
+```
+
+Or for async applications:
+
+```rust
+#[tokio::main]
+async fn main() {
+    my_crate::app::run().await;
+}
+```
+
+### Why this split matters
+
+- **`lib.rs` makes the crate testable** — integration tests in `tests/` can `use my_crate::domain::orders::Order` without going through `main`.
+- **`main.rs` stays trivial** — it's just the entry point. No logic, no wiring, no imports beyond `app::run()`.
+- **`app/` owns the composition** — it's the only module that imports from both `domain/` and `adapters/`. Domain slices never see adapters directly. Adapters only see the domain traits they implement.
+
+### Dependency flow
+
+```
+            ┌──────────────┐
+            │   main.rs    │  Calls app::run(). Nothing else.
+            └──────┬───────┘
+                   │
+                   ▼
+            ┌──────────────┐
+            │    app/      │  Composition root. The only module that
+            │              │  sees all three layers below.
+            └──┬───┬───┬───┘
+               │   │   │
+       ┌───────┘   │   └───────┐
+       ▼           ▼           ▼
+┌────────────┐ ┌────────┐ ┌──────────┐
+│entrypoints/│ │domain/ │ │adapters/ │
+│            │ │        │ │          │
+│ calls ─────┼─▶        │◀─ impls ── │
+│ into       │ │        │ │ traits   │
+└────────────┘ └────────┘ └──────────┘
+```
+
+**Who can import from whom:**
+
+- **`domain/`** → nothing outside itself (pure, no framework deps)
+- **`adapters/`** → `domain/` only (implements domain traits)
+- **`entrypoints/`** → `domain/` only (calls domain functions, receives adapters via DI)
+- **`app/`** → all three (wires adapters into entrypoints, owns startup)
+- **`main.rs`** → `app/` only

--- a/references/sb/ts.md
+++ b/references/sb/ts.md
@@ -1,0 +1,417 @@
+# Sliced Bread Architecture for TypeScript
+
+Organic vertical slices using `package.json` `"exports"` maps and TypeScript project references as the enforcement mechanisms. No ceremony upfront — structure emerges as complexity demands it.
+
+> Companion to [Sliced Bread](../sliced-bread.md). Read that first for the language-agnostic rationale and anti-patterns. See also [attribution](./attribution.md) for predecessor lineage (VSA, Hexagonal, Screaming, Clean, DDD).
+
+---
+
+## Why TypeScript is the trickiest fit
+
+TypeScript has *no built-in compiler-enforced privacy at module boundaries*. The `private` modifier only hides class members. A file's exports are visible to anyone who can resolve the file path — the compiler will not stop `import { internalThing } from "../slices/orders/_secret"`.
+
+Privacy in TypeScript comes from **packaging**, not from language keywords:
+
+| Mechanism | Enforces |
+|---|---|
+| `package.json` `"exports"` map | What can be imported from a package — Node.js refuses other paths |
+| `tsconfig.json` project references | Build graph — TS errors on out-of-graph imports |
+| ESLint rules (e.g. `no-restricted-imports`) | Linter-enforced facade |
+| Monorepo workspace boundaries (npm/pnpm/yarn workspaces) | Hard separation per package |
+
+**Key insight:** the modern TypeScript facade is the `"exports"` map, not the barrel `index.ts`. Barrel files used to be the recommended pattern; since 2024 they are widely considered an anti-pattern (see "Barrel files considered harmful," below).
+
+---
+
+## Why barrel files are now an anti-pattern
+
+A barrel file (`index.ts` that re-exports from siblings) was the classic facade pattern in TypeScript. It is now considered harmful:
+
+- **Tree-shaking breaks.** Bundlers must follow every re-export to determine if anything in the barrel is used. Even with ESM, complex barrels defeat dead-code elimination — practitioners have measured 60–70% bundle bloat in real projects.
+- **Cold-start cost.** Importing one symbol via a barrel forces the module loader to evaluate every re-exported file. For `vitest`, `tsx`, and other dev-time loaders this becomes a multi-second startup penalty.
+- **Circular import landmines.** Barrels make cycles silent. `a → index → b → index → a` is invisible until runtime.
+- **IDE rename slowdowns.** Every rename has to walk the barrel graph.
+
+The replacement: **`package.json` `"exports"` maps** define the facade declaratively, the bundler reads them directly, and Node.js enforces them at import time.
+
+---
+
+## Core structure
+
+Single-package layout:
+
+```
+my-app/
+├── package.json                      # "exports" map = the facade
+├── tsconfig.json
+├── src/
+│   ├── domains/                      # The loaf
+│   │   ├── common/                   # Common leaf
+│   │   │   └── money.ts
+│   │   ├── orders/                   # A slice
+│   │   │   ├── orders.ts             # Public API (the crust)
+│   │   │   ├── fulfillment.ts        # Sibling
+│   │   │   └── _validation.ts        # Underscore = "do not import"
+│   │   └── pricing/                  # Thin slice — one file is fine
+│   │       └── pricing.ts
+│   ├── entrypoints/                  # Inbound — HTTP handlers, CLI, etc.
+│   │   ├── http/
+│   │   └── cli/
+│   ├── adapters/                     # Outbound — implements domain protocols
+│   │   ├── postgres/
+│   │   └── stripe/
+│   └── app/                          # Composition root
+│       └── app.ts
+└── tests/
+```
+
+Monorepo layout (workspaces):
+
+```
+my-app/
+├── package.json                      # workspaces: ["packages/*"]
+├── tsconfig.json                     # references each package
+└── packages/
+    ├── domain-orders/                # own package — own "exports"
+    │   ├── package.json
+    │   ├── src/
+    │   │   ├── orders.ts             # exposed via package.json "exports"
+    │   │   └── internal/
+    │   │       └── validation.ts     # not exposed, sibling-private
+    │   └── tsconfig.json
+    ├── domain-pricing/
+    ├── adapters-postgres/
+    └── app-server/
+```
+
+### The critical mapping
+
+| Sliced Bread concept | TypeScript mechanism |
+|---|---|
+| The crust (public API) | `package.json` `"exports"` map (or, in single-package, the slice's named entry file) |
+| Slice internals | Files not listed in `"exports"`; underscore-prefixed names by convention |
+| Index/barrel file | **Not used.** `"exports"` map replaces it. |
+| "No cross-slice reaching" | `"exports"` map (Node enforces) + `no-restricted-imports` (lint) |
+| Pure domain models | No `pg`, `stripe`, `express` imports under `domains/` |
+| Entrypoints | `entrypoints/http`, `entrypoints/cli`, etc. |
+| Adapters | `adapters/<technology>/` |
+
+---
+
+## The `"exports"` map is the crust
+
+In a monorepo workspace package:
+
+```json
+// packages/domain-orders/package.json
+{
+  "name": "@my-app/domain-orders",
+  "type": "module",
+  "exports": {
+    ".": "./dist/orders.js",
+    "./events": "./dist/events.js"
+  }
+}
+```
+
+External code can do:
+
+```ts
+import { Order, place } from "@my-app/domain-orders";
+import { OrderPlaced } from "@my-app/domain-orders/events";
+```
+
+But cannot do:
+
+```ts
+import { validate } from "@my-app/domain-orders/internal/validation";
+//                       ^ Node.js refuses; tsserver flags it
+```
+
+Single-package equivalent (no workspace): use `tsconfig.json` `paths` to alias the slice root, plus a lint rule (`no-restricted-imports`) to forbid deeper paths.
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "paths": {
+      "@/orders": ["src/domains/orders/orders.ts"],
+      "@/orders/events": ["src/domains/orders/events.ts"]
+    }
+  }
+}
+```
+
+```js
+// .eslintrc.js
+{
+  rules: {
+    "no-restricted-imports": ["error", {
+      patterns: ["@/orders/internal/*", "**/domains/orders/_*"]
+    }]
+  }
+}
+```
+
+### Visibility cheat sheet
+
+| Mechanism | Meaning in Sliced Bread |
+|---|---|
+| Listed in `"exports"` | Public — part of the package's API |
+| Not listed in `"exports"` | Package-private — Node refuses; TS errors with `"moduleResolution": "node16"+` |
+| `_underscore-prefix` filename | Convention: "do not import from outside this slice" — relies on lint, not compiler |
+| `private` class member | Object-level only — does not affect module imports |
+
+**Default to "not exported."** Add to `"exports"` only by deliberate decision. The exports map *is* the contract.
+
+---
+
+## Growth pattern
+
+### Stage 1: One file per concept
+
+```
+src/domains/
+├── common/
+│   └── money.ts
+├── orders/
+│   └── orders.ts            # everything in one file
+└── pricing/
+    └── pricing.ts
+```
+
+### Stage 2: Extract siblings
+
+```
+src/domains/orders/
+├── orders.ts                # the crust — what tsconfig paths point at
+├── fulfillment.ts
+└── _validation.ts
+```
+
+Update `tsconfig.json` `paths` and the lint rule if needed; the slice's public surface (`orders.ts`) stays the import target.
+
+### Stage 3: Promote to a workspace package
+
+When the slice has stable boundaries and benefits from independent build/test, lift it into a workspace package:
+
+```
+packages/domain-orders/
+├── package.json             # "exports" replaces the tsconfig paths trick
+├── src/
+│   ├── orders.ts
+│   ├── fulfillment.ts
+│   └── internal/
+│       └── validation.ts
+└── tsconfig.json
+```
+
+Now Node.js enforces the boundary. No lint rules needed.
+
+---
+
+## Cross-slice communication
+
+### Do: Import via the package name (or path alias)
+
+```ts
+// src/domains/pricing/pricing.ts
+import { Order, type LineItem } from "@my-app/domain-orders";
+```
+
+### Don't: Reach into internals
+
+```ts
+import { validate } from "@my-app/domain-orders/internal/validation";  // ← refused
+import type { OrderInternal } from "../orders/_validation";            // ← lint error
+```
+
+### Events for reverse dependencies
+
+If `orders` depends on `pricing`, then `pricing` cannot import `orders`. Define the event in `common/`:
+
+```ts
+// src/domains/common/events.ts
+export type DomainEvent =
+  | { type: "OrderPlaced"; orderId: string }
+  | { type: "PriceChanged"; sku: string; newPrice: number };
+
+export interface EventBus {
+  publish(event: DomainEvent): void;
+  subscribe(handler: (event: DomainEvent) => void): void;
+}
+```
+
+Slices emit; `app/` wires subscriptions. Synchronous in-process dispatch is the default; an async or queued bus is an adapter implementation choice.
+
+---
+
+## Adapters and protocols
+
+Domain slices define interfaces. Adapters implement them.
+
+```ts
+// src/domains/orders/orders.ts — defines the port
+export interface OrderRepository {
+  save(order: Order): Promise<void>;
+  findById(id: OrderId): Promise<Order | null>;
+}
+```
+
+```ts
+// src/adapters/postgres/orders.ts — implements the port
+import type { Order, OrderId, OrderRepository } from "@/orders";
+import { Pool } from "pg";
+
+export class PostgresOrderRepo implements OrderRepository {
+  constructor(private pool: Pool) {}
+
+  async save(order: Order): Promise<void> { /* ... */ }
+  async findById(id: OrderId): Promise<Order | null> { /* ... */ }
+}
+```
+
+```ts
+// src/app/app.ts — wires it together
+import { Pool } from "pg";
+import express from "express";
+import { PostgresOrderRepo } from "@/adapters/postgres/orders";
+import { placeOrderHandler } from "@/entrypoints/http/orders";
+
+export async function run() {
+  const pool = new Pool({ /* config */ });
+  const repo = new PostgresOrderRepo(pool);
+
+  const app = express();
+  app.post("/orders", placeOrderHandler(repo));
+  app.listen(3000);
+}
+```
+
+The `domains/` tree has zero `pg`, `express`, `stripe`, or HTTP-client imports. If you see one, that's a boundary violation. (Exception: `zod` schemas on domain types are pragmatic and acceptable.)
+
+---
+
+## Entrypoints
+
+`entrypoints/` translates external requests into domain calls. Express handlers, Next.js route handlers, tRPC procedures, CLI commands.
+
+```ts
+// src/entrypoints/http/orders.ts
+import type { Request, Response } from "express";
+import { type OrderRepository, place, type LineItem } from "@/orders";
+
+export function placeOrderHandler(repo: OrderRepository) {
+  return async (req: Request, res: Response) => {
+    const items = req.body as LineItem[];
+    try {
+      const order = await place(items);
+      await repo.save(order);
+      res.json(order);
+    } catch (err) {
+      res.status(422).json({ error: (err as Error).message });
+    }
+  };
+}
+```
+
+Entrypoints decode, call domain, encode, map errors. They receive dependencies as parameters.
+
+---
+
+## When to use TypeScript project references
+
+`tsconfig.json` `references` give you incremental build graphs and out-of-graph import errors. Use when:
+
+| Signal | Response |
+|---|---|
+| Slow `tsc` rebuilds across slices | Add references — only changed slices recompile |
+| Want explicit "this slice depends on that one" declared in config | References declare it |
+| Need stricter compile-time isolation than lint provides | References are TS-enforced |
+| Already in a workspace monorepo | Pair references with workspaces — they layer cleanly |
+
+```json
+// tsconfig.json (root)
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/domain-common" },
+    { "path": "./packages/domain-orders" },
+    { "path": "./packages/domain-pricing" },
+    { "path": "./packages/adapters-postgres" },
+    { "path": "./packages/app-server" }
+  ]
+}
+```
+
+```json
+// packages/domain-orders/tsconfig.json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "composite": true
+  },
+  "references": [
+    { "path": "../domain-common" }
+  ]
+}
+```
+
+If `domain-orders` doesn't reference `adapters-postgres`, importing from it now causes a TS build error — not just a lint warning.
+
+---
+
+## Rules (TypeScript-specific)
+
+1. **The `"exports"` map is the crust.** Use it in workspace packages. In single-package projects, use `tsconfig.json` `paths` + a lint rule that forbids deep imports.
+2. **Avoid barrel files.** No `src/domains/orders/index.ts` that re-exports from siblings. Either use `"exports"` or alias the slice's root file directly.
+3. **Default to "not exported."** Add to `"exports"` only by deliberate decision. Underscore-prefix files inside a slice when they are internal helpers.
+4. **No infrastructure imports in `domains/`.** No `pg`, `mysql2`, `express`, `axios`, `stripe`, `aws-sdk`. `zod` schemas on domain types are pragmatic.
+5. **Interfaces as ports.** Domain slices declare interfaces that adapters implement. Don't put interfaces in adapter packages.
+6. **Entrypoints are thin.** Parse, call, serialize. No business logic. Receive adapters as constructor arguments or function parameters.
+7. **Common is a leaf.** `domains/common/` imports nothing from sibling slices.
+8. **Grow, don't pre-build.** A new slice starts as one `.ts` file. Extract siblings when crowded. Promote to a workspace package when the slice's boundary is stable enough to benefit from compile-time enforcement.
+
+---
+
+## The `app/` and entry point split
+
+Top-level entry (`bin/server.ts` or `src/index.ts`) should be trivial — it calls `app.run()` and nothing else.
+
+```ts
+// src/index.ts
+import { run } from "@/app";
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+`app/` is the composition root: instantiate adapters, inject them into entrypoints, mount routes, start the server.
+
+```
+            ┌──────────────┐
+            │  index.ts    │  Trivial — calls app.run()
+            └──────┬───────┘
+                   │
+                   ▼
+            ┌──────────────┐
+            │     app/     │  Composition root — sees all three layers
+            └──┬───┬───┬───┘
+               │   │   │
+       ┌───────┘   │   └───────┐
+       ▼           ▼           ▼
+┌────────────┐ ┌────────┐ ┌──────────┐
+│entrypoints/│ │domains/│ │adapters/ │
+└────────────┘ └────────┘ └──────────┘
+```
+
+**Who imports whom:**
+
+- **`domains/`** → only `domains/common/` and stdlib types
+- **`adapters/`** → `domains/` (implements interfaces)
+- **`entrypoints/`** → `domains/` (calls domain functions, receives adapters as params)
+- **`app/`** → all three
+- **`index.ts`** → `app/` only

--- a/references/sliced-bread.md
+++ b/references/sliced-bread.md
@@ -1,0 +1,275 @@
+# Sliced Bread Architecture
+
+Organic vertical slices. Files grow into facades. No ceremony.
+
+```
+src/
+├── domains/                     # The loaf
+│   ├── common/                  # Common leaf (no sibling deps — see attribution.md re: DDD)
+│   ├── orders/                  # A slice
+│   │   ├── index.*              # Public API (the crust)
+│   │   ├── order.*              # Core concept
+│   │   ├── fulfillment.*        # Facade → delegates to fulfillment/
+│   │   └── fulfillment/
+│   └── pricing/                 # Thin slice (one file is fine)
+├── adapters/                    # Implements domain protocols
+│   ├── postgres/                # Outbound — DB driver
+│   ├── stripe/                  # Outbound — third-party SDK
+│   ├── auth/                    # Cross-cutting — JWT, session
+│   ├── logging/                 # Cross-cutting — structured logger
+│   └── cache/                   # Cross-cutting — Redis, in-memory
+└── app/                         # Presentation + orchestration (DI)
+```
+
+Cross-cutting concerns (auth, logging, cache, metrics) are a *category of adapter*,
+not a separate "infrastructure" or "middleware" layer. They implement domain-defined
+ports (e.g. `domains.common.AuthContext`) the same way storage adapters do.
+
+## Growth pattern
+
+1. Start with one file per concept.
+2. Extract sibling when crowded.
+3. File becomes facade + folder when it wants friends.
+
+## Rules
+
+- Index/barrel file is the crust — external code imports from here only.
+- Don't reach into another slice (import from index, not internals).
+- Models stay pure (no ORM, framework, or adapter imports).
+- One direction only (use events for reverse deps).
+- `common/` is a leaf (imports nothing from siblings).
+
+## Lineage
+
+Sliced Bread synthesizes Vertical Slice Architecture (Bogard, 2018), Hexagonal /
+Ports & Adapters (Cockburn, 2005), Screaming Architecture (Martin, 2012),
+Clean / Onion (Martin 2012, Palermo 2008), and Domain-Driven Design (Evans, 2003).
+For what it inherits, what it differs on, and why "common leaf" is *not* DDD's
+"shared kernel," see [`sb/attribution.md`](./sb/attribution.md).
+
+---
+
+## Why vertical slices?
+
+Layered architecture (controllers → services → repositories) groups by technical role.
+This means a single feature change touches every layer. Vertical slices group by
+business concept — an `orders` change stays in `orders/`.
+
+Cross-cutting concerns (auth, logging, caching) live in `adapters/` behind
+domain-defined ports — not sprinkled across slices, and not pushed into a
+separate middleware layer. If you're tempted to add auth logic inside a domain
+slice, push it down to `adapters/`.
+
+## Why organic growth?
+
+Pre-creating folders, abstract base classes, and registries for a single implementation
+is speculative architecture. It costs complexity now for flexibility that may never
+be needed. The growth pattern (one file → extract sibling → facade + folder) means
+structure emerges from actual pressure, not imagination.
+
+**Growth triggers:**
+
+- A file passes ~150–200 lines or holds 3+ distinct concepts → extract siblings.
+  (300 lines is the hard ceiling in this guide — by then you are well past
+  the trigger.)
+- 3+ related files cluster around a sub-concept → create subdirectory
+- A file becomes an import hub for its children → it's now a facade
+
+**Not growth triggers:**
+
+- "We might need this later"
+- "This looks like it could be its own module"
+- A single implementation of a pattern (one adapter, one strategy, one handler)
+
+## Anti-patterns
+
+### Cross-slice internal imports
+
+```
+# BAD — reaching past the crust
+from domains.pricing.discount_calculator import DiscountCalculator
+
+# GOOD — import from the public API
+from domains.pricing import calculate_discount
+```
+
+Why it matters: internal files can be renamed, split, or reorganized freely.
+The index/barrel file is a contract; internals are implementation details.
+
+### Domain importing infrastructure
+
+```
+# BAD — order.py imports an HTTP client
+from adapters.stripe import StripeClient
+
+# GOOD — order.py defines a protocol, adapter implements it
+class PaymentGateway(Protocol):
+    async def charge(self, amount: Money) -> PaymentResult: ...
+```
+
+Why it matters: domain models are the most stable code. Coupling them to
+infrastructure means infrastructure changes ripple into business logic.
+
+### Circular dependencies between slices
+
+```
+# orders imports pricing, pricing imports orders — cycle
+```
+
+Resolution: use domain events. `orders` emits `OrderPlaced`, `pricing` subscribes.
+
+Where does the event type live? Default rule:
+
+- **Single-producer event** → in the producer slice's public API
+  (`orders.OrderPlaced`), *when the consumer can import from the producer
+  without forming a cycle*.
+- **Promoted to `common/events/`** → when (a) 2+ slices need to *produce* the
+  same event type, (b) the consumer can't import from the producer without
+  forming a cycle (e.g. `orders` already imports `pricing`, so `pricing`
+  consuming `OrderPlaced` would cycle), or (c) it's referenced by a contract
+  outside the loaf (entrypoints, persisted log).
+
+Default to keeping events in the producer. Promote on second producer or to
+break a cycle, not in anticipation.
+
+**Dispatch is synchronous in-process by default.** Subscribers run on the producer's
+call stack within the same transaction unless an adapter (queue, outbox, broker)
+explicitly says otherwise. Async dispatch is an *implementation choice of the bus
+adapter*, not a property of the event itself — domain code shouldn't care.
+
+### Adapters importing app layer
+
+```
+# BAD — adapter depends on a use case or handler
+from app.use_cases.checkout import Checkout
+
+# GOOD — adapters only know about domain ports
+from domains.orders import OrderRepository
+```
+
+Why it matters: adapters implement domain contracts. They shouldn't know how the
+application orchestrates those contracts.
+
+### Premature abstraction
+
+```
+# BAD — AbstractRepositoryFactory with one concrete implementation
+# BAD — EventBus interface when only one event exists
+# BAD — PluginRegistry with a single plugin
+
+# GOOD — just use the concrete thing until you need the abstraction
+```
+
+## Boundary decisions
+
+### When does something belong in `common/`?
+
+**Default: prefer a named slice.** Most "shared" code is a missing domain in
+disguise. If two slices both send notifications, the right answer is usually a
+`notifications/` slice with its own crust — not `common/notifications.*`.
+Naming the slice forces you to articulate what it *is*, rather than where it
+*goes*. A soft `common/` is worse than no `common/`; it becomes a junk drawer
+that quietly couples everything to everything.
+
+`common/` is a quarantine for **shapes, not behavior**. Use it only when *all*
+of these hold:
+
+- The type has **zero behavior** — pure data, no methods that encode
+  slice-specific rules.
+- It is **referenced by 2+ slices today** (don't pre-promote on speculation).
+- A named slice is genuinely a worse fit — the type is too atomic to deserve
+  a domain of its own, or extraction would force a cycle.
+
+**Valid cases:**
+
+- Pure value types with universal semantics — `Money`, `UserId`, `Timestamp`,
+  `Email`.
+- Cross-slice event payloads, where producer and consumer can't both own the
+  schema without creating a cycle.
+- Infrastructural taxonomy with no domain — error enums, result wrappers,
+  opaque ID newtypes, trace/correlation context.
+- Ports (protocols/traits) defined for adapters to implement — these are
+  shape, not behavior.
+
+**Not common:**
+
+- Anything with logic ("validation helpers," "format utilities") — that logic
+  belongs to *some* slice. Find it, name it, and put it there.
+- Anything used by only one slice — keep it inside the slice.
+- Anything extracted "to be reusable later" — wait until a second caller
+  actually exists.
+- Cross-slice request/response models — prefer events; the producer owns the
+  schema and consumers adapt.
+
+If `common/` ever needs to import from a sibling slice, it has stopped being
+common. The fix is to move the offending type into a slice (or create one) —
+not to relax the leaf rule.
+
+### When do you introduce an adapter?
+
+When domain code needs to talk to something external (database, API, filesystem,
+message queue). The domain defines a protocol (port), the adapter implements it.
+
+Don't create an adapter for in-process utilities (string formatting, date math,
+pure computation). Those are just functions.
+
+### When does a use case belong in `app/` vs inside a slice?
+
+- **Inside the slice:** operations on a single domain concept (create order,
+  update order status). These are domain services or methods on the entity.
+- **In `app/use_cases/`:** orchestration across 2+ slices (checkout needs orders +
+  pricing + inventory). The use case imports from multiple slice public APIs.
+
+### When do you use events vs direct imports?
+
+- **Direct import:** slice A needs data from slice B to do its work (orders imports
+  pricing to calculate totals). This is a natural dependency.
+- **Events:** slice B needs to react to something slice A did, but slice A shouldn't
+  know about slice B. This prevents cycles and keeps the emitter independent.
+
+Rule of thumb: if adding the import would create a cycle, use an event.
+
+**Event-direction discipline.** Events are for *reverse* dependencies — the
+emitter must not know who subscribes. If you find yourself reaching for events
+to avoid a forward import that would compile fine, you're using events as a
+generic message bus. Stop. Direct calls are clearer when the dependency
+direction is already correct.
+
+## Dependency direction quick-check
+
+```
+app/           →  domains/*     →  domains/common/
+adapters/      →  domains/*
+
+Never:
+  domains/*    →  adapters/*
+  domains/*    →  app/*
+  adapters/*   →  app/*
+  adapters/*   →  sibling adapters/*
+  common/      →  sibling domains
+```
+
+(Adapters never call other adapters directly. If a Stripe adapter needs to log,
+it depends on the *logging port* defined in `common/`, and `app/` wires the
+logging adapter in. Adapter-to-adapter coupling is how cross-cutting concerns
+become a tangled middle layer.)
+
+## Reviewing against Sliced Bread
+
+When reviewing code for architecture compliance, check:
+
+1. **Import direction** — do all arrows point inward (toward domains)?
+2. **Crust integrity** — are external consumers importing from index files only?
+3. **Model purity** — do domain files import only stdlib, common, and sibling public APIs?
+4. **Growth justification** — does every directory/abstraction have 2+ concrete uses?
+5. **Event usage** — are events used for reverse deps, not passed around as general-purpose messaging?
+6. **Cross-cutting containment** — auth, logging, cache, metrics live in `adapters/*`
+   behind ports, not sprinkled through domain code or wired adapter-to-adapter?
+
+## Companion documents
+
+- [`sb/attribution.md`](./sb/attribution.md) — predecessor lineage and what Sliced Bread inherits, differs on, and drops.
+- [`sb/practice.md`](./sb/practice.md) — applied patterns: CQRS pairing, anti-corruption layers, slice-local duplication, testing strategy, and slice graduation (when to split a slice into its own crate / package / library / service).
+- [`sb/rust.md`](./sb/rust.md) — Rust-specific mechanics (`pub use`, `pub(super)`, `foo.rs` + `foo/` facade, Cargo workspaces).
+- [`sb/go.md`](./sb/go.md) — Go-specific mechanics (`internal/` compile-time enforcement, capitalization, `go.work`).
+- [`sb/ts.md`](./sb/ts.md) — TypeScript-specific mechanics (`package.json` `"exports"` map as the modern facade, why barrel files are now an anti-pattern).

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -34,7 +34,7 @@ When called with a `<slug>`, resolve `.cheese/press/<slug>.md` (if present) for 
 | assertions | medium | weak tests, shallow existence checks, swallowed errors |
 | nih | medium | reinvented dependency, stdlib, or existing project helper |
 
-Per-dimension rubrics and recommendation shapes in `references/dimensions.md`. This reduced workflow intentionally omits the git-history/precedent dimension.
+Per-dimension rubrics and recommendation shapes in `references/dimensions.md`. The encapsulation dimension judges against Sliced Bread architecture — load `references/sliced-bread.md` (repo root) for the dependency direction quick-check and review checklist when grading boundary or import-direction findings. This reduced workflow intentionally omits the git-history/precedent dimension.
 
 ## Flow
 

--- a/skills/age/references/dimensions.md
+++ b/skills/age/references/dimensions.md
@@ -27,13 +27,18 @@ Recommendation shape: "Validate at the boundary" / "Use the project's existing `
 
 ### encapsulation
 
+The reference architecture is Sliced Bread (`references/sliced-bread.md` at the repo root). Use its dependency-direction quick-check (`app → domains → common`; `adapters → domains`; never the reverse, never adapter-to-adapter, never `common → siblings`) and crust rule (external code only imports from a slice's public API) to grade these findings. Language-specific enforcement details — Rust `pub use` / `pub(super)`, Go `internal/`, TypeScript `"exports"` maps — live in `references/sb/{rust,go,ts}.md`.
+
 Look for:
-- Cross-module imports that reach into another slice's internals instead of its public interface.
+- Cross-module imports that reach into another slice's internals instead of its public interface (the crust).
+- Domain code importing infrastructure (database driver, HTTP client, framework SDK) instead of defining a port that an adapter implements.
+- `common/` modules that import from sibling slices, breaking the leaf rule.
+- Adapters calling other adapters directly instead of going through a domain-defined port.
 - Public APIs that leak implementation types (ORM models, framework objects, infra adapters).
 - Functions that take `Context | DI container | App` when they only need one field.
 - New exports added without a use case.
 
-Recommendation shape: "Import from `<slice>/index` instead of `<slice>/internal/foo`" / "Narrow the public surface to `<minimal-type>`".
+Recommendation shape: "Import from `<slice>` (the crust) instead of `<slice>/internal/foo`" / "Define a `<port>` protocol in the domain and move the SDK call to `adapters/<name>`" / "Move shared logic out of `common/` into a named slice — `common/` is a shape-only leaf".
 
 ### spec
 

--- a/skills/cook/SKILL.md
+++ b/skills/cook/SKILL.md
@@ -82,3 +82,4 @@ Pre-select `Run /press` when the cooked diff added new behaviour or touched unte
 - Prefer existing dependencies and patterns.
 - Do not invent architecture already rejected by the spec.
 - Stop and ask when implementation reveals a design decision the spec did not answer.
+- Place new code in the correct Sliced Bread slice: `domains/<name>` for business concepts, `adapters/<name>` for outbound infrastructure, `app/` for composition, `domains/common/` only for shape-without-behavior leaf types. Cross-slice calls go through the crust, never into another slice's internals. Architecture rules and language-specific mechanics live in `references/sliced-bread.md` (with `references/sb/{rust,go,ts}.md` for compile-enforcement details).

--- a/skills/culture/SKILL.md
+++ b/skills/culture/SKILL.md
@@ -55,3 +55,4 @@ When the conversation reveals real work, ask via `AskUserQuestion` which downstr
 - No writes, no commits, no PRs.
 - Ask one useful question at a time when the user is exploring.
 - Prefer clarity over completeness.
+- When the conversation turns to module boundaries, slice ownership, dependency direction, or how a feature should be laid out, treat `references/sliced-bread.md` (and `references/sb/practice.md` for graduation / CQRS / ACL judgement calls) as shared vocabulary — cite it instead of re-deriving the rules. Language-specific mechanics live in `references/sb/{rust,go,ts}.md`.

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -14,7 +14,7 @@ Do not use it for free-form discussion with no artifact intent (`/culture`), dir
 
 1. **Route** — pick a starting mode from the input shape (see `references/modes.md`) and announce it in one line.
 2. **Dialogue** — build shared understanding through the smallest useful question. Ground every load-bearing claim with `cheez-search`, `cheez-read`, or a Validate Cycle (`references/validate-cycle.md`).
-3. **Sketch** — for any feature touching >1 module or a new public interface, lock seams in pseudocode signatures before talking spec content.
+3. **Sketch** — for any feature touching >1 module or a new public interface, lock seams in pseudocode signatures before talking spec content. Each sketch declares the Sliced Bread slice it lives in (`domains/<name>`, `adapters/<name>`, `app`, or `domains/common`); cross-slice calls must go through the crust. Architecture rules in `references/sliced-bread.md` (repo root).
 4. **Two-key handshake** — both the user (explicit verb) and the agent (coherence self-check) must agree before extraction. See `references/handshake.md`.
 5. **Curdle** — write the approved spec to `.cheese/specs/<slug>.md` (and optional `.cheese/issues/<slug>-NNN.md`). Format and slug rules in `references/curdle.md`.
 6. **Hand off** — once the spec is on disk, prompt the next step via `AskUserQuestion` (see `## Handoff` below). Never auto-invoke.

--- a/skills/mold/references/curdle.md
+++ b/skills/mold/references/curdle.md
@@ -55,7 +55,10 @@ gates_overridden: []   # list of unchecked handshake items if `curdle anyway` wa
 - <one-line decision> — <one-line rationale>
 
 ## Interface sketches
+Each sketch declares the Sliced Bread slice it lives in (`domains/<name>`, `adapters/<name>`, `app`, or `domains/common`) before the pseudocode. Cross-slice calls go through the crust. Architecture rules: `references/sliced-bread.md` (repo root).
+
 ```pseudocode
+slice: <domains/<name> | adapters/<name> | app | domains/common>
 <signatures, schemas, seams>
 ```
 

--- a/skills/mold/references/modes.md
+++ b/skills/mold/references/modes.md
@@ -37,9 +37,9 @@ Mold has no fixed entry point. Inspect the input shape and pick a starting mode.
 
 ### Sketch — interface lockdown
 
-**Job:** lock modules, responsibilities, I/O contracts, and seams in pseudocode signatures. Before drafting, parallel `cheez-search` for sibling signatures in the same area so new ones fit conventions.
+**Job:** lock modules, responsibilities, I/O contracts, and seams in pseudocode signatures. Before drafting, parallel `cheez-search` for sibling signatures in the same area so new ones fit conventions. Every signature names its Sliced Bread slice (`domains/<name>`, `adapters/<name>`, `app`, or `domains/common`) before the pseudocode is drafted — slice ownership is part of the contract, not a layout afterthought. Full rules in `references/sliced-bread.md` at the repo root.
 
-**Exit when:** every public seam has a pseudocode signature; every cross-module call goes through public interfaces, not internals.
+**Exit when:** every public seam has a pseudocode signature; every signature declares a slice; every cross-module call goes through the crust, not internals.
 
 ### Grill — adversarial clarification
 


### PR DESCRIPTION
## Summary

- Pulls the Sliced Bread architecture suite from `~/Dev/cheese-flow` into a new top-level `references/` tree (`sliced-bread.md` + `sb/{attribution,practice,rust,go,ts}.md`).
- Wires `/mold` (Sketch + curdle template), `/cook` (Rules), `/age` (encapsulation dimension), and `/culture` (Rules) at the references so slice ownership, dependency direction, and growth decisions share a single vocabulary instead of being re-derived per skill.
- Relaxes the README scope statement from "skills only" to "skills plus references" — the tree is markdown-only, no agent or compiled-harness surface, no MCP requirement.

`/cure` is deliberately untouched: it acts on user-selected findings, and any architectural recommendation is already carried in the `/age` report it consumes.

## Files changed

- New: `references/README.md`, `references/sliced-bread.md`, `references/sb/{attribution,practice,rust,go,ts}.md` (mirrors of cheese-flow).
- Updated: `README.md`, `skills/mold/SKILL.md`, `skills/mold/references/{modes,curdle}.md`, `skills/cook/SKILL.md`, `skills/age/SKILL.md`, `skills/age/references/dimensions.md`, `skills/culture/SKILL.md`.

## Test plan

- [ ] `references/sliced-bread.md` and `references/sb/*.md` are byte-identical to the cheese-flow source.
- [ ] Workflow skills cite the references with relative paths from the repo root that resolve.
- [ ] README scope section, references table, and the "skills plus references" line are internally consistent.
- [ ] No skill claims to write production code outside the slice rules it now points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)