### PR TITLE
feat(skills): shape-check + route review skills to specific code-review-graph tools

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -79,6 +79,24 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: bash scripts/install.sh --skip-mcp
 
+      # Real install of the code-review-graph CLI with the [embeddings]
+      # extra. Sourcing the script and calling the function directly skips
+      # the MCP-registration step that needs a claude CLI on the runner,
+      # while still exercising the actual pip/pipx/uv install path. Catches
+      # cases where 'code-review-graph[embeddings]' stops being a valid
+      # PyPI target or the embeddings extra fails to resolve.
+      - name: CRG embeddings install smoke test
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          source scripts/install.sh
+          ec_install_crg_cli
+          # Cover every install-path bin location: pipx + uv tool install
+          # land in $HOME/.local/bin; pip --user lands under the Python
+          # user-base bin dir.
+          export PATH="$HOME/.local/bin:$(python3 -m site --user-base)/bin:$PATH"
+          code-review-graph --version
+
   lint:
     name: lint markdown and yaml
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -340,13 +340,13 @@ TAVILY_API_KEY=your-key npx -y tavily-mcp
 
 Requires Node.js v18+.
 
-### code-review-graph (review impact radius)
+### code-review-graph (review impact radius, architecture, semantic search)
 
-[code-review-graph](https://github.com/tirth8205/code-review-graph) builds a call graph of your codebase and exposes it as MCP tools. Used by `/age` and `/cure` to scope reviews.
+[code-review-graph](https://github.com/tirth8205/code-review-graph) builds a persistent call graph of your codebase with Tree-sitter, Louvain communities, betweenness-centrality, and optional vector embeddings. Used by `/age`, `/press`, and `/cure` for risk-scored impact (`get_impact_radius_tool`, `detect_changes_tool`), curated review context (`get_review_context_tool`, `get_minimal_context_tool`), affected flows (`get_affected_flows_tool`), architecture framing (`get_architecture_overview_tool`, `get_hub_nodes_tool`, `get_bridge_nodes_tool`), and cross-repo / semantic search (`cross_repo_search_tool`, `semantic_search_nodes_tool`). Tilth handles AST search, callers, and hash-anchored edits; code-review-graph covers the graph-algorithmic and cross-repo dimensions tilth does not.
 
 ```sh
-# Install (Python 3.10+ required)
-pip install code-review-graph   # or: pipx install code-review-graph
+# Install with the local sentence-transformers embeddings extra (Python 3.10+ required)
+pip install 'code-review-graph[embeddings]'   # or: pipx install 'code-review-graph[embeddings]'
 
 # Auto-detect and configure your harness
 code-review-graph install
@@ -358,7 +358,12 @@ code-review-graph install --platform codex
 
 # Build the graph for the current project (re-run after large changes)
 code-review-graph build
+
+# Compute embeddings for semantic_search_nodes_tool (one-time, then incremental)
+code-review-graph embed
 ```
+
+The `[embeddings]` extra pulls in `sentence-transformers` so `semantic_search_nodes_tool` works out of the box with the default `all-MiniLM-L6-v2` model. Override with `CRG_EMBEDDING_MODEL=<model-id>`. Other embedding providers (Google Gemini, MiniMax, OpenAI-compatible endpoints) are also supported — see the upstream README for `[google-embeddings]` and the `CRG_OPENAI_*` env vars.
 
 ## Installing CLI tools
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -293,42 +293,49 @@ ec_install_mcp_tavily() {
     "$claude" mcp add tavily -- "$npx" -y tavily-mcp
 }
 
-# Install the code-review-graph CLI. Prefers an isolated tool install
-# (uv → pipx) so we don't poke at the system Python. Falls back to
-# 'pip install --user' with a warning so it still works on minimal boxes.
+# Install the code-review-graph CLI with the local sentence-transformers
+# embeddings extra so 'code-review-graph embed' works out of the box.
+# Prefers an isolated tool install (uv → pipx) so we don't poke at the
+# system Python. Falls back to 'pip install --user' with a warning so it
+# still works on minimal boxes.
+#
+# The package spec is quoted because '[embeddings]' contains shell glob
+# characters; inside an array invocation the quoting is implicit, but the
+# dry-run log line uses a literal single-quoted form to match.
 ec_install_crg_cli() {
     local uv="${EC_UV:-uv}"
     local pipx="${EC_PIPX:-pipx}"
     local pip="${EC_PIP:-pip}"
+    local spec='code-review-graph[embeddings]'
 
     if ec_cmd_exists "$uv"; then
         if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-            ec_log "code-review-graph: would run '$uv tool install code-review-graph'"
+            ec_log "code-review-graph: would run '$uv tool install $spec'"
             return 0
         fi
-        ec_log "code-review-graph: installing via 'uv tool install code-review-graph'"
-        "$uv" tool install code-review-graph
+        ec_log "code-review-graph: installing via '$uv tool install $spec'"
+        "$uv" tool install "$spec"
         return $?
     fi
 
     if ec_cmd_exists "$pipx"; then
         if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-            ec_log "code-review-graph: would run '$pipx install code-review-graph'"
+            ec_log "code-review-graph: would run '$pipx install $spec'"
             return 0
         fi
-        ec_log "code-review-graph: installing via 'pipx install code-review-graph'"
-        "$pipx" install code-review-graph
+        ec_log "code-review-graph: installing via '$pipx install $spec'"
+        "$pipx" install "$spec"
         return $?
     fi
 
     if ec_cmd_exists "$pip"; then
         ec_warn "code-review-graph: uv/pipx not found; falling back to 'pip install --user'."
         if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-            ec_log "code-review-graph: would run '$pip install --user code-review-graph'"
+            ec_log "code-review-graph: would run '$pip install --user $spec'"
             return 0
         fi
-        ec_log "code-review-graph: installing via 'pip install --user code-review-graph'"
-        "$pip" install --user code-review-graph
+        ec_log "code-review-graph: installing via '$pip install --user $spec'"
+        "$pip" install --user "$spec"
         return $?
     fi
 

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -51,7 +51,7 @@ Per-dimension rubrics and recommendation shapes in `references/dimensions.md`. T
 | --- | --- | --- |
 | Diff inspection | `delta` | `git diff --unified=3` |
 | Structural search | `sg`, Serena or LSP | `ripgrep`, `find`, targeted reads |
-| Caller / dependency graph | `tilth_deps` + `cheez-search kind: "callers"` | import searches, caller searches, test references |
+| Caller / dependency graph | `tilth_deps` + `cheez-search` callers (`tilth_search kind: "callers"`) | import searches, caller searches, test references |
 | Risk-scored impact + curated review context | code-review-graph: `get_review_context_tool`, `get_impact_radius_tool`, `detect_changes_tool` | `tilth_deps` + manual scoping |
 | Architecture / hotspot framing for large diffs | code-review-graph: `get_architecture_overview_tool`, `get_hub_nodes_tool`, `get_bridge_nodes_tool` | skip and note in confidence |
 | GitHub/PR context | `gh` | local git commands or user-provided PR data |

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -51,7 +51,9 @@ Per-dimension rubrics and recommendation shapes in `references/dimensions.md`. T
 | --- | --- | --- |
 | Diff inspection | `delta` | `git diff --unified=3` |
 | Structural search | `sg`, Serena or LSP | `ripgrep`, `find`, targeted reads |
-| Dependency/caller graph | code review graph, tilth deps | import searches, caller searches, test references |
+| Caller / dependency graph | `tilth_deps` + `cheez-search kind: "callers"` | import searches, caller searches, test references |
+| Risk-scored impact + curated review context | code-review-graph: `get_review_context_tool`, `get_impact_radius_tool`, `detect_changes_tool` | `tilth_deps` + manual scoping |
+| Architecture / hotspot framing for large diffs | code-review-graph: `get_architecture_overview_tool`, `get_hub_nodes_tool`, `get_bridge_nodes_tool` | skip and note in confidence |
 | GitHub/PR context | `gh` | local git commands or user-provided PR data |
 | Merge/conflict awareness | mergiraf | manual conflict checks |
 

--- a/skills/briesearch/references/unavailable.md
+++ b/skills/briesearch/references/unavailable.md
@@ -9,7 +9,7 @@ Optional MCP servers (Context7, Tavily, code-review-graph, tilth) are not always
 | Context7 | Read repo docs, package README, vendor pages, then web search | Medium → low for version-specific questions |
 | Tavily | Host web search or user-provided links | Medium → low when freshness matters |
 | Codebase (cheez-*) | Fall back to Serena or LSP, `sg`, `ripgrep`, `find`, and targeted reads | Medium → low when local precedent is central |
-| code-review-graph (`get_review_context_tool`, `get_impact_radius_tool`, `get_architecture_overview_tool`, `get_hub_nodes_tool`, `cross_repo_search_tool`, `semantic_search_nodes_tool`) | Use `tilth_deps` + `cheez-search` callers (`tilth_search kind: "callers"`) for blast radius; skip cross-repo and architecture framing | Medium → low for cross-repo or large-architecture questions |
+| code-review-graph (full tool list in [README → code-review-graph](../../../README.md#code-review-graph-review-impact-radius-architecture-semantic-search)) | Use `tilth_deps` + `cheez-search` callers (`tilth_search kind: "callers"`) for blast radius; skip cross-repo, semantic search, and architecture framing | Medium → low for cross-repo or large-architecture questions |
 | GitHub (`gh`) | Note absence; user-supplied URLs are acceptable | Skip with a confidence note |
 
 ## Reporting an unavailable source

--- a/skills/briesearch/references/unavailable.md
+++ b/skills/briesearch/references/unavailable.md
@@ -9,6 +9,7 @@ Optional MCP servers (Context7, Tavily, code-review-graph, tilth) are not always
 | Context7 | Read repo docs, package README, vendor pages, then web search | Medium → low for version-specific questions |
 | Tavily | Host web search or user-provided links | Medium → low when freshness matters |
 | Codebase (cheez-*) | Fall back to Serena or LSP, `sg`, `ripgrep`, `find`, and targeted reads | Medium → low when local precedent is central |
+| code-review-graph (`get_review_context_tool`, `get_impact_radius_tool`, `get_architecture_overview_tool`, `get_hub_nodes_tool`, `cross_repo_search_tool`, `semantic_search_nodes_tool`) | Use `tilth_deps` + `cheez-search kind: "callers"` for blast radius; skip cross-repo and architecture framing | Medium → low for cross-repo or large-architecture questions |
 | GitHub (`gh`) | Note absence; user-supplied URLs are acceptable | Skip with a confidence note |
 
 ## Reporting an unavailable source

--- a/skills/briesearch/references/unavailable.md
+++ b/skills/briesearch/references/unavailable.md
@@ -9,7 +9,7 @@ Optional MCP servers (Context7, Tavily, code-review-graph, tilth) are not always
 | Context7 | Read repo docs, package README, vendor pages, then web search | Medium → low for version-specific questions |
 | Tavily | Host web search or user-provided links | Medium → low when freshness matters |
 | Codebase (cheez-*) | Fall back to Serena or LSP, `sg`, `ripgrep`, `find`, and targeted reads | Medium → low when local precedent is central |
-| code-review-graph (`get_review_context_tool`, `get_impact_radius_tool`, `get_architecture_overview_tool`, `get_hub_nodes_tool`, `cross_repo_search_tool`, `semantic_search_nodes_tool`) | Use `tilth_deps` + `cheez-search kind: "callers"` for blast radius; skip cross-repo and architecture framing | Medium → low for cross-repo or large-architecture questions |
+| code-review-graph (`get_review_context_tool`, `get_impact_radius_tool`, `get_architecture_overview_tool`, `get_hub_nodes_tool`, `cross_repo_search_tool`, `semantic_search_nodes_tool`) | Use `tilth_deps` + `cheez-search` callers (`tilth_search kind: "callers"`) for blast radius; skip cross-repo and architecture framing | Medium → low for cross-repo or large-architecture questions |
 | GitHub (`gh`) | Note absence; user-supplied URLs are acceptable | Skip with a confidence note |
 
 ## Reporting an unavailable source

--- a/skills/culture/SKILL.md
+++ b/skills/culture/SKILL.md
@@ -18,7 +18,7 @@ Do not use it when the user wants a written spec (`/mold`), implementation (`/co
 
 1. Restate the question or tension in one sentence.
 2. Identify assumptions, constraints, and decision criteria.
-3. Explore trade-offs and likely blast radius. When the trade-off hinges on "what does this touch", run a read-only shape check on the candidate seam — `cheez-search kind: "callers"` plus `tilth_deps` — and label each option `[low | medium | high blast radius]`. Procedure mirrors `../mold/references/shape-check.md`; culture stops at the verdict and never drafts signatures.
+3. Explore trade-offs and likely blast radius. When the trade-off hinges on "what does this touch", run a read-only shape check on the candidate seam — a `cheez-search` callers query (`tilth_search kind: "callers"`) plus `tilth_deps` — and label each option `[low | medium | high blast radius]`. Procedure mirrors `../mold/references/shape-check.md`; culture stops at the verdict and never drafts signatures.
 4. Use evidence only when it helps the conversation; avoid deep research unless the user asks.
 5. End with a compact summary, open questions, and a `## Handoff` prompt (see below).
 
@@ -27,7 +27,7 @@ Do not use it when the user wants a written spec (`/mold`), implementation (`/co
 | Need | Prefer | Fallback |
 | --- | --- | --- |
 | Quick code orientation | `cheez-search`, `cheez-read`, LSP | `ripgrep`, file tree, targeted reads |
-| Blast-radius read | `cheez-search kind: "callers"` + `tilth_deps` (read-only shape check) | guess and label option `[?]` |
+| Blast-radius read | `cheez-search` callers (`tilth_search kind: "callers"`) + `tilth_deps` (read-only shape check) | guess and label option `[?]` |
 | Visualizing diffs or examples | `delta` | plain `git diff` |
 | External sanity check | `/briesearch` | clearly mark as an assumption |
 

--- a/skills/culture/SKILL.md
+++ b/skills/culture/SKILL.md
@@ -18,7 +18,7 @@ Do not use it when the user wants a written spec (`/mold`), implementation (`/co
 
 1. Restate the question or tension in one sentence.
 2. Identify assumptions, constraints, and decision criteria.
-3. Explore trade-offs and likely blast radius.
+3. Explore trade-offs and likely blast radius. When the trade-off hinges on "what does this touch", run a read-only shape check on the candidate seam — `cheez-search kind: "callers"` plus `tilth_deps` — and label each option `[low | medium | high blast radius]`. Procedure mirrors `../mold/references/shape-check.md`; culture stops at the verdict and never drafts signatures.
 4. Use evidence only when it helps the conversation; avoid deep research unless the user asks.
 5. End with a compact summary, open questions, and a `## Handoff` prompt (see below).
 
@@ -26,7 +26,8 @@ Do not use it when the user wants a written spec (`/mold`), implementation (`/co
 
 | Need | Prefer | Fallback |
 | --- | --- | --- |
-| Quick code orientation | Serena or LSP, `sg` | `ripgrep`, file tree, targeted reads |
+| Quick code orientation | `cheez-search`, `cheez-read`, LSP | `ripgrep`, file tree, targeted reads |
+| Blast-radius read | `cheez-search kind: "callers"` + `tilth_deps` (read-only shape check) | guess and label option `[?]` |
 | Visualizing diffs or examples | `delta` | plain `git diff` |
 | External sanity check | `/briesearch` | clearly mark as an assumption |
 

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -31,7 +31,7 @@ If selection is ambiguous, render a numbered selection list per `references/sele
 | Need | Prefer | Fallback |
 | --- | --- | --- |
 | Applying precise fixes | tilth edit | harness edit tools or patch application |
-| Understanding findings | `/age` report plus code review graph | diff, touched files, tests, and `ripgrep` |
+| Understanding findings | `/age` report plus code-review-graph: `get_minimal_context_tool`, `get_review_context_tool` | diff, touched files, tests, and `ripgrep` |
 | CI and PR context | `gh` | local test output or user-provided logs |
 | Diffs | `delta` | plain `git diff` |
 | Conflict resolution | mergiraf | manual resolution with targeted tests |

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -38,7 +38,7 @@ Full mode definitions, exit criteria, and user knobs in `references/modes.md`.
 | --- | --- | --- |
 | External validation | `/briesearch` with Context7/Tavily | user-provided docs, repo docs, or note as unverified |
 | Codebase grounding | Serena or LSP, `sg`, tilth read/search | `ripgrep`, `find`, targeted file reads |
-| Dependency/blast-radius checks | shape check (`references/shape-check.md`): `cheez-search kind: "callers"` + `tilth_deps` | import searches, caller searches, test references |
+| Dependency/blast-radius checks | shape check (`references/shape-check.md`): `cheez-search` callers (`tilth_search kind: "callers"`) + `tilth_deps` | import searches, caller searches, test references |
 | Spec writing | precise edit tooling | create/update markdown directly after approval |
 
 Optional tools accelerate the work; missing tools do not block the dialogue. When a fallback is weaker, mark the affected claim `[?]` until settled.

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -14,7 +14,7 @@ Do not use it for free-form discussion with no artifact intent (`/culture`), dir
 
 1. **Route** — pick a starting mode from the input shape (see `references/modes.md`) and announce it in one line.
 2. **Dialogue** — build shared understanding through the smallest useful question. Ground every load-bearing claim with `cheez-search`, `cheez-read`, or a Validate Cycle (`references/validate-cycle.md`).
-3. **Sketch** — for any feature touching >1 module or a new public interface, lock seams in pseudocode signatures before talking spec content.
+3. **Sketch** — for any feature touching >1 module or a new public interface, run the shape check (`references/shape-check.md`) on the touched symbols, then lock seams in pseudocode signatures before talking spec content.
 4. **Two-key handshake** — both the user (explicit verb) and the agent (coherence self-check) must agree before extraction. See `references/handshake.md`.
 5. **Curdle** — write the approved spec to `.cheese/specs/<slug>.md` (and optional `.cheese/issues/<slug>-NNN.md`). Format and slug rules in `references/curdle.md`.
 6. **Hand off** — once the spec is on disk, prompt the next step via `AskUserQuestion` (see `## Handoff` below). Never auto-invoke.
@@ -38,7 +38,7 @@ Full mode definitions, exit criteria, and user knobs in `references/modes.md`.
 | --- | --- | --- |
 | External validation | `/briesearch` with Context7/Tavily | user-provided docs, repo docs, or note as unverified |
 | Codebase grounding | Serena or LSP, `sg`, tilth read/search | `ripgrep`, `find`, targeted file reads |
-| Dependency/blast-radius checks | code review graph, tilth deps | import searches, caller searches, test references |
+| Dependency/blast-radius checks | shape check (`references/shape-check.md`): `cheez-search kind: "callers"` + `tilth_deps` | import searches, caller searches, test references |
 | Spec writing | precise edit tooling | create/update markdown directly after approval |
 
 Optional tools accelerate the work; missing tools do not block the dialogue. When a fallback is weaker, mark the affected claim `[?]` until settled.

--- a/skills/mold/references/handshake.md
+++ b/skills/mold/references/handshake.md
@@ -35,7 +35,7 @@ These are not soft suggestions — Curdle hard-blocks until they are addressed:
 - **Ground gate:** ≥1 Ground pass with a citation before Shape's options. Exception: pure greenfield (the agent must say so out loud).
 - **Shape gate:** ≥1 Option block weighed (Do Nothing counts).
 - **Sketch gate:** mandatory when the chosen option touches more than one module or introduces a new public interface. Skip only for trivial single-function changes (the agent must say so out loud).
-- **Grill gate:** mandatory for high-blast-radius decisions. "High blast radius" = `cheez-search` callers/imports for the touched symbols returns multiple non-test files.
+- **Grill gate:** mandatory for high-blast-radius decisions. The shape check (`shape-check.md`) ranks blast radius `low | medium | high` from `cheez-search kind: "callers"` and `tilth_deps`. A `high` verdict — multi-module callers or more than five importers — makes Grill mandatory.
 - **Open hypotheses:** any Validate Cycle launched but unjudged blocks Curdle unless the user accepts it as `[TBD]`.
 
 ## Override semantics

--- a/skills/mold/references/handshake.md
+++ b/skills/mold/references/handshake.md
@@ -35,7 +35,7 @@ These are not soft suggestions — Curdle hard-blocks until they are addressed:
 - **Ground gate:** ≥1 Ground pass with a citation before Shape's options. Exception: pure greenfield (the agent must say so out loud).
 - **Shape gate:** ≥1 Option block weighed (Do Nothing counts).
 - **Sketch gate:** mandatory when the chosen option touches more than one module or introduces a new public interface. Skip only for trivial single-function changes (the agent must say so out loud).
-- **Grill gate:** mandatory for high-blast-radius decisions. The shape check (`shape-check.md`) ranks blast radius `low | medium | high` from `cheez-search kind: "callers"` and `tilth_deps`. A `high` verdict — multi-module callers or more than five importers — makes Grill mandatory.
+- **Grill gate:** mandatory for high-blast-radius decisions. The shape check (`shape-check.md`) ranks blast radius `low | medium | high` from a `cheez-search` callers query (`tilth_search kind: "callers"`) and `tilth_deps`. A `high` verdict — multi-module callers or more than five importers — makes Grill mandatory.
 - **Open hypotheses:** any Validate Cycle launched but unjudged blocks Curdle unless the user accepts it as `[TBD]`.
 
 ## Override semantics

--- a/skills/mold/references/modes.md
+++ b/skills/mold/references/modes.md
@@ -37,7 +37,7 @@ Mold has no fixed entry point. Inspect the input shape and pick a starting mode.
 
 ### Sketch — interface lockdown
 
-**Job:** lock modules, responsibilities, I/O contracts, and seams in pseudocode signatures. Before drafting, run the shape check (`shape-check.md`) — signatures, callers (`cheez-search kind: "callers"`), and `tilth_deps` blast radius — for every touched symbol so new seams fit existing convention and the impact is bounded. Print the four-line shape-check summary before any pseudocode.
+**Job:** lock modules, responsibilities, I/O contracts, and seams in pseudocode signatures. Before drafting, run the shape check (`shape-check.md`) — signatures, callers (via `cheez-search`, i.e. `tilth_search kind: "callers"`), and `tilth_deps` blast radius — for every touched symbol so new seams fit existing convention and the impact is bounded. Print the shape-check summary block before any pseudocode.
 
 **Exit when:** every public seam has a pseudocode signature; every cross-module call goes through public interfaces, not internals; shape-check verdict is recorded.
 

--- a/skills/mold/references/modes.md
+++ b/skills/mold/references/modes.md
@@ -37,9 +37,9 @@ Mold has no fixed entry point. Inspect the input shape and pick a starting mode.
 
 ### Sketch — interface lockdown
 
-**Job:** lock modules, responsibilities, I/O contracts, and seams in pseudocode signatures. Before drafting, parallel `cheez-search` for sibling signatures in the same area so new ones fit conventions.
+**Job:** lock modules, responsibilities, I/O contracts, and seams in pseudocode signatures. Before drafting, run the shape check (`shape-check.md`) — signatures, callers (`cheez-search kind: "callers"`), and `tilth_deps` blast radius — for every touched symbol so new seams fit existing convention and the impact is bounded. Print the four-line shape-check summary before any pseudocode.
 
-**Exit when:** every public seam has a pseudocode signature; every cross-module call goes through public interfaces, not internals.
+**Exit when:** every public seam has a pseudocode signature; every cross-module call goes through public interfaces, not internals; shape-check verdict is recorded.
 
 ### Grill — adversarial clarification
 

--- a/skills/mold/references/modes.md
+++ b/skills/mold/references/modes.md
@@ -37,9 +37,9 @@ Mold has no fixed entry point. Inspect the input shape and pick a starting mode.
 
 ### Sketch — interface lockdown
 
-**Job:** lock modules, responsibilities, I/O contracts, and seams in pseudocode signatures. Before drafting, run the shape check (`shape-check.md`) — signatures, callers (via `cheez-search`, i.e. `tilth_search kind: "callers"`), and `tilth_deps` blast radius — for every touched symbol so new seams fit existing convention and the impact is bounded. Print the shape-check summary block before any pseudocode.
+**Job:** lock modules, responsibilities, I/O contracts, and seams in pseudocode signatures. Before drafting, when the change touches more than one module or introduces a new public interface, run the shape check (`shape-check.md`) — signatures, callers (via `cheez-search`, i.e. `tilth_search kind: "callers"`), and `tilth_deps` blast radius — on the touched symbols so new seams fit existing convention and the impact is bounded. Print the shape-check summary block before any pseudocode. Single-module, internals-only sketches may skip the gate; note "shape check skipped: single-module change" instead.
 
-**Exit when:** every public seam has a pseudocode signature; every cross-module call goes through public interfaces, not internals; shape-check verdict is recorded.
+**Exit when:** every public seam has a pseudocode signature; every cross-module call goes through public interfaces, not internals; shape-check verdict is recorded (or explicitly skipped per the gate above).
 
 ### Grill — adversarial clarification
 

--- a/skills/mold/references/shape-check.md
+++ b/skills/mold/references/shape-check.md
@@ -42,6 +42,14 @@ The `callees` line is optional — print it only when the symbol query's `──
 
 A `high` verdict (multi-module callers or more than five importers) makes the Grill gate mandatory in mold (see `handshake.md`) and forces culture to label the option `[high blast radius]` before continuing trade-off talk.
 
+## When tilth / cheez-search is unavailable
+
+Shape-check should not block the dialogue when its preferred tools are missing. Substitute and degrade the verdict:
+
+- **Callers / callees**: fall back to LSP `find_references` / `prepare_call_hierarchy` (or `ripgrep` against the symbol name when LSP is also down). Note the substitution out loud.
+- **Imports / blast radius**: fall back to `ripgrep` for `import .*<module>` and reverse-import patterns; counts will be approximate.
+- **Verdict**: cap at `[?]` instead of `low | medium | high` — a guessed verdict is worse than an honest unknown. Sketch and culture should treat `[?]` like `high` for gating purposes (Grill gate engages, option labelled `[high blast radius]`) until the user accepts the gap.
+
 ## When to skip
 
 - The touched symbol has zero callers (greenfield) — say so out loud.

--- a/skills/mold/references/shape-check.md
+++ b/skills/mold/references/shape-check.md
@@ -1,0 +1,55 @@
+# The shape check
+
+Run this before drafting in Sketch mode, and any time the discussion in any mode hinges on "what does this touch" or "what depends on this". The check is read-only — culture and mold both run it; only the artifact stage differs.
+
+## What it answers
+
+- **Signatures**: what does the touched function/type look like today? What sibling signatures already exist in the same module so a new one fits convention?
+- **Callers** (upstream): who calls the touched symbol, and from which modules?
+- **Callees** (downstream): what does the touched symbol call into? Surfaced by the same symbol query — `kind: "symbol"` returns a `── calls ──` footer with one-hop callees. No extra call.
+- **Imports / blast radius**: which files import this module? Which does this module import?
+
+These four answers together describe the shape of the change and bound its blast radius — both upstream (who breaks if I change this) and downstream (what could I drag into the change). The downstream half is what InlineCoder-style bidirectional inlining is empirically worth on repo-level edits; ignoring it leaves a known gap.
+
+## Procedure
+
+Run all three. Cheap when the answers are small; the cost of skipping is silent misrouting later.
+
+| Question | Tool | Call |
+| --- | --- | --- |
+| Current signature? Sibling signatures? Downstream callees (`── calls ──` footer)? | `cheez-search` | `tilth_search(query: "<symbol>", kind: "symbol", expand: 2, scope: "<module>")` |
+| Who calls this? (upstream) | `cheez-search` | `tilth_search(query: "<symbol>", kind: "callers", scope: ".")` |
+| What's the import / blast radius? | `cheez-search` | `tilth_deps(path: "<file>")` |
+
+The first call does double duty — its `── calls ──` footer is the cheap callee read; do not issue a separate query for it.
+
+For multi-symbol changes, batch up to five symbols in a single `cheez-search` call (`query: "a, b, c"`). Re-run only when a new symbol enters scope.
+
+## Output expected before exit
+
+A summary at the top of the Sketch turn (or culture's blast-radius step):
+
+```
+Shape check on <symbol(s)>:
+  signature(s):  <one line per touched seam>
+  callers:       <count> sites in <N> non-test files (paths)
+  callees:       <count> one-hop calls (names) — omit line if empty
+  blast radius:  imported by <count> files; imports <count> modules
+  verdict:       low | medium | high
+```
+
+The `callees` line is optional — print it only when the symbol query's `── calls ──` footer is non-empty. A leaf function with no callees should drop the line, not print `0`.
+
+A `high` verdict (multi-module callers or more than five importers) makes the Grill gate mandatory in mold (see `handshake.md`) and forces culture to label the option `[high blast radius]` before continuing trade-off talk.
+
+## When to skip
+
+- The touched symbol has zero callers (greenfield) — say so out loud.
+- The change is contained to one private function inside a single file with no exports — sibling signature lookup still applies; deps and callers can be skipped.
+- The user explicitly said `skip the shape check`.
+
+## Why
+
+Trade-offs and seams discussed without a shape check rely on the agent's guess at impact. The check converts that guess into numbers — caller count, callee count, importer count — the user can argue with.
+
+The directionality matters: upstream (callers) tells you who breaks if the seam changes; downstream (callees) tells you what the change might drag in. Bidirectional structural context is empirically worth a measurable accuracy lift on repo-level edits, and the downstream half rides for free on the existing symbol query.

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -26,7 +26,7 @@ Do not use it to implement broad new behavior. Press may add or strengthen tests
 | Need | Prefer | Fallback |
 | --- | --- | --- |
 | Diff review | `delta` | plain `git diff` |
-| Coverage / blast radius | `tilth_deps` + `cheez-search kind: "callers"` | Serena/LSP, `ripgrep` callers/imports |
+| Coverage / blast radius | `tilth_deps` + `cheez-search` callers (`tilth_search kind: "callers"`) | Serena/LSP, `ripgrep` callers/imports |
 | Affected execution flows + risk scoring | code-review-graph: `get_affected_flows_tool`, `get_impact_radius_tool` | manual flow tracing from callers |
 | Precise test edits | tilth edit | harness edit tools or patch application |
 | Test discovery | `sg`, ripgrep | package manager test listings or file tree |

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -26,7 +26,8 @@ Do not use it to implement broad new behavior. Press may add or strengthen tests
 | Need | Prefer | Fallback |
 | --- | --- | --- |
 | Diff review | `delta` | plain `git diff` |
-| Coverage/blast radius | code review graph, Serena or LSP | `ripgrep` callers/imports and test references |
+| Coverage / blast radius | `tilth_deps` + `cheez-search kind: "callers"` | Serena/LSP, `ripgrep` callers/imports |
+| Affected execution flows + risk scoring | code-review-graph: `get_affected_flows_tool`, `get_impact_radius_tool` | manual flow tracing from callers |
 | Precise test edits | tilth edit | harness edit tools or patch application |
 | Test discovery | `sg`, ripgrep | package manager test listings or file tree |
 

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -401,7 +401,7 @@ STUB
     EC_UV="$STUB_BIN/uv" EC_PIPX="$STUB_BIN/pipx" EC_PIP="$STUB_BIN/pip" \
         EC_DRY_RUN=1 run ec_install_crg_cli
     [ "$status" -eq 0 ]
-    [[ "$output" == *"uv tool install code-review-graph"* ]]
+    [[ "$output" == *"uv tool install code-review-graph[embeddings]"* ]]
     [[ "$output" != *"pipx install"* ]]
     [[ "$output" != *"pip install"* ]]
 }
@@ -412,7 +412,7 @@ STUB
     EC_PIPX="$STUB_BIN/pipx" EC_PIP="$STUB_BIN/pip" \
         EC_DRY_RUN=1 run ec_install_crg_cli
     [ "$status" -eq 0 ]
-    [[ "$output" == *"pipx install code-review-graph"* ]]
+    [[ "$output" == *"pipx install code-review-graph[embeddings]"* ]]
     [[ "$output" != *"uv tool"* ]]
 }
 
@@ -421,7 +421,7 @@ STUB
     EC_PIP="$STUB_BIN/pip" EC_DRY_RUN=1 run ec_install_crg_cli
     [ "$status" -eq 0 ]
     [[ "$output" == *"falling back to 'pip install --user'"* ]]
-    [[ "$output" == *"pip install --user code-review-graph"* ]]
+    [[ "$output" == *"pip install --user code-review-graph[embeddings]"* ]]
 }
 
 @test "ec_install_crg_cli fails clearly when uv, pipx, and pip are all missing" {
@@ -430,12 +430,12 @@ STUB
     [[ "$output" == *"needs uv, pipx, or pip"* ]]
 }
 
-@test "ec_install_crg_cli invokes uv tool install when not dry-run" {
+@test "ec_install_crg_cli invokes uv tool install with embeddings extra when not dry-run" {
     make_stub uv
     export EC_UV="$STUB_BIN/uv"
     run ec_install_crg_cli
     [ "$status" -eq 0 ]
-    grep -q "^uv tool install code-review-graph$" "$STUB_LOG"
+    grep -q "^uv tool install code-review-graph\[embeddings\]$" "$STUB_LOG"
 }
 
 # -- ec_install_mcp_crg -------------------------------------------------------
@@ -445,7 +445,7 @@ STUB
     EC_UV="$STUB_BIN/uv" EC_CRG="$STUB_BIN/code-review-graph-not-real" \
         EC_DRY_RUN=1 run ec_install_mcp_crg claude-code
     [ "$status" -eq 0 ]
-    [[ "$output" == *"uv tool install code-review-graph"* ]]
+    [[ "$output" == *"uv tool install code-review-graph[embeddings]"* ]]
     [[ "$output" == *"install --platform claude-code"* ]]
 }
 


### PR DESCRIPTION
## Summary

- Adds a read-only **shape-check** procedure (`skills/mold/references/shape-check.md`) that `/mold` (Sketch) and `/culture` (blast-radius step) must run before drafting. Three calls — `cheez-search` kind `"symbol"` (signatures + downstream callees via the `── calls ──` footer), `cheez-search` kind `"callers"` (upstream), and `tilth_deps` (importers) — produce a summary block with a `low | medium | high` verdict.
- Routes `/age`, `/press`, `/cure`, and briesearch unavailable.md at **specific code-review-graph tools** instead of name-checking the server generically. Tilth stays the default for AST search, callers, deps, and hash-anchored edits; code-review-graph covers the graph-algorithmic and cross-repo dimensions tilth does not (impact radius, curated review context, affected flows, hubs/bridges, architecture overview, cross-repo, semantic search).
- Updates README install for code-review-graph to use `pip install 'code-review-graph[embeddings]'` so `semantic_search_nodes_tool` works out of the box with sentence-transformers, plus documents the new tool routing.
- **Follow-up cleanup (2dcf7f2)** — clarifies that `kind:` is a `tilth_search` argument (the underlying tool the `cheez-search` skill invokes), not a skill-level argument; renames "four-line shape-check summary" to "shape-check summary block" since the optional callees line makes the count variable; adds a "When tilth / cheez-search is unavailable" section to `shape-check.md` describing LSP/ripgrep fallbacks and `[?]` verdict capping so the gate doesn't wedge when MCP is missing.

## Why

Two prior briesearch passes on this branch surfaced (1) bidirectional structural context (callers + callees) is empirically worth a measurable accuracy lift on repo-level edits, while shape-check previously had only the upstream half; and (2) Claude Code does not support per-tool MCP filtering, so the right move is to keep code-review-graph installed (Tool Search defers schemas above 10K tokens — ~85% context reduction) and route at its unique tools rather than letting it be dead weight.

Research artifacts persisted in `.cheese/research/llm-ast-grounding/` and `.cheese/research/mcp-overlap-tilth-vs-crg/` (gitignored).

## Test plan

- [ ] Verify `skills/mold/references/shape-check.md` renders cleanly (markdown only, no executable surface)
- [ ] Run `/mold` on a small change and confirm the shape-check summary block appears before any pseudocode
- [ ] Run `/culture` with a "what does this touch" prompt and confirm options get `[low | medium | high blast radius]` labels
- [ ] Run `/age` on a recent diff and confirm it actually invokes `get_review_context_tool` / `get_impact_radius_tool` (not just name-checks them)
- [ ] Confirm `pip install 'code-review-graph[embeddings]'` followed by `code-review-graph embed` enables `semantic_search_nodes_tool`
- [ ] Disable tilth MCP and confirm shape-check degrades to LSP/ripgrep with a `[?]` verdict instead of blocking the dialogue

🤖 Generated with [Claude Code](https://claude.com/claude-code)