### PR TITLE
feat(install): macOS curl|bash installer with bats coverage

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -65,6 +65,17 @@ jobs:
       - name: Run install.sh tests
         run: bats tests/bash/test_install.bats
 
+      # Real (un-stubbed) smoke test: actually resolve every brew formula,
+      # exercise the cargo-or-npm tilth install path, and run the gh-skill
+      # install on a fresh macos-latest runner. Catches "phantom formula"
+      # / "tap doesn't exist" / "this skill doesn't publish" bugs that the
+      # bats suite (which stubs everything) cannot. --skip-mcp avoids
+      # needing claude/tavily creds.
+      - name: Real install smoke test (--skip-mcp)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/install.sh --skip-mcp
+
   lint:
     name: lint markdown and yaml
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -49,6 +49,22 @@ jobs:
       - name: Run melt script tests
         run: python3 -m pytest tests/python -q
 
+  install-script:
+    name: test install.sh (macOS)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install bats and shellcheck
+        run: brew install bats-core shellcheck
+
+      - name: Lint install.sh
+        run: shellcheck scripts/install.sh
+
+      - name: Run install.sh tests
+        run: bats tests/bash/test_install.bats
+
   lint:
     name: lint markdown and yaml
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -353,6 +353,46 @@ code-review-graph build
 
 The optional tools in the table below are referenced by workflow skills. None are required, but having them available unlocks better fallbacks and richer output.
 
+### One-shot installer (macOS)
+
+`scripts/install.sh` installs every CLI tool listed below in one go and (by default) registers the tilth and Context7 MCP servers with Claude Code. Currently macOS only — it relies on Homebrew.
+
+Pipe straight from GitHub:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh | bash
+```
+
+Or grab the script first if you'd like to read it:
+
+```sh
+curl -fsSL -o /tmp/easy-cheese-install.sh https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh
+bash /tmp/easy-cheese-install.sh --help
+bash /tmp/easy-cheese-install.sh --dry-run
+```
+
+Common flags:
+
+```sh
+# Install only ripgrep + jq, skip MCP registration
+curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh \
+  | bash -s -- --tools ripgrep,jq --skip-mcp
+
+# Register MCP servers only (assumes the CLI tools are already installed)
+curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh \
+  | bash -s -- --skip-tools --mcp tilth,context7,tavily
+
+# Use a different harness for tilth registration
+curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh \
+  | bash -s -- --harness cursor
+```
+
+The script is idempotent — it skips any tool already on `PATH` — and accepts `--dry-run` so you can preview what it would do before letting it run.
+
+> **Heads-up:** `curl | bash` runs whatever the URL serves at the moment of the request. If you want to audit before running, use the two-step form above.
+
+If you'd rather install tools individually, the per-tool sections below cover macOS, Windows, and Linux.
+
 ### GitHub CLI (`gh`)
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -232,12 +232,12 @@ The cheez-* tool skills and several workflow skills benefit from MCP servers. In
 
 ### tilth (required for cheez-* skills)
 
-[tilth](https://github.com/paulnsorensen/tilth) provides AST-aware code search, smart file reading, and hash-anchored edits. Required by `/cheez-search`, `/cheez-read`, and `/cheez-write`.
+[tilth](https://github.com/jahala/tilth) provides AST-aware code search, smart file reading, and hash-anchored edits. Required by `/cheez-search`, `/cheez-read`, and `/cheez-write`.
 
 ```sh
-# Install tilth CLI
-cargo install tilth        # via Cargo (Rust)
-brew install paulnsorensen/tap/tilth  # via Homebrew (macOS/Linux)
+# Install tilth CLI — pick one (no Homebrew formula upstream)
+cargo install tilth        # via Cargo (Rust) — preferred, native binary
+npm install -g tilth       # via npm (Node 18+) — no Rust toolchain needed
 
 # Register as an MCP server — include --edit only if you plan to use cheez-write
 tilth install claude-code --edit   # Claude Code
@@ -355,7 +355,13 @@ The optional tools in the table below are referenced by workflow skills. None ar
 
 ### One-shot installer (macOS)
 
-`scripts/install.sh` installs every CLI tool listed below in one go and (by default) registers the tilth and Context7 MCP servers with Claude Code. Currently macOS only — it relies on Homebrew.
+`scripts/install.sh` does the whole setup in one shot:
+
+1. Installs every CLI tool listed below — Homebrew for the eight brew-core formulas, plus `cargo install tilth` (or `npm install -g tilth` if Rust isn't available) for tilth, which has no Homebrew formula upstream.
+2. Runs `gh skill install paulnsorensen/easy-cheese --all --agent <harness> --scope user` to drop every easy-cheese skill into the picked harness (default `claude-code`).
+3. Registers the `tilth` and `context7` MCP servers with that same harness.
+
+Currently macOS only — it relies on Homebrew. Requires `gh` to be authenticated (`gh auth login`) before running.
 
 Pipe straight from GitHub:
 
@@ -378,11 +384,11 @@ Common flags:
 curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh \
   | bash -s -- --tools ripgrep,jq --skip-mcp
 
-# Register MCP servers only (assumes the CLI tools are already installed)
+# Register MCP servers only (assumes CLI tools and skills are already installed)
 curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh \
   | bash -s -- --skip-tools --mcp tilth,context7,tavily
 
-# Use a different harness for tilth registration
+# Pick a different harness for skill + MCP registration
 curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh \
   | bash -s -- --harness cursor
 ```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,12 @@ set -euo pipefail
 # brew — upstream jahala/tilth does not ship a Homebrew formula).
 EC_KNOWN_TOOLS="gh ripgrep fd jq ast-grep git-delta just mergiraf tilth"
 
+# Every skill shipped by easy-cheese. `gh skill install` requires an explicit
+# skill name (no --all flag), so we enumerate them and install one by one.
+# Kept in sync with skills/ manually so the script stays self-contained for
+# curl|bash distribution.
+EC_KNOWN_SKILLS="age briesearch cheese cheez-read cheez-search cheez-write cook culture cure melt mold press"
+
 # Default selections.
 EC_DEFAULT_TOOLS="$EC_KNOWN_TOOLS"
 EC_DEFAULT_MCP="tilth context7"
@@ -346,6 +352,11 @@ ec_install_mcp_list() {
 # Install the easy-cheese skill set into the picked harness via 'gh skill'.
 # User scope so they live alongside the user's other skills, not committed
 # into the project. Requires gh to be authenticated.
+#
+# `gh skill install` does not support an --all flag, so we loop the explicit
+# EC_KNOWN_SKILLS list and call it once per skill with --force for
+# idempotent re-runs. Failures on one skill are warned and tracked but do
+# not abort the rest of the loop.
 ec_install_skills() {
     local harness="$1"
     local gh="${EC_GH:-gh}"
@@ -353,16 +364,23 @@ ec_install_skills() {
         ec_warn "easy-cheese skills: gh CLI not found; skipping. Add 'gh' to --tools first."
         return 0
     fi
-    if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-        ec_log "easy-cheese skills: would run '$gh skill install paulnsorensen/easy-cheese --all --agent $harness --scope user'"
-        return 0
-    fi
-    if ! "$gh" auth status >/dev/null 2>&1; then
+    if [[ "${EC_DRY_RUN:-0}" != "1" ]] && ! "$gh" auth status >/dev/null 2>&1; then
         ec_warn "easy-cheese skills: gh is not authenticated. Run 'gh auth login' and re-run."
         return 1
     fi
-    ec_log "easy-cheese skills: installing all skills into $harness (user scope)"
-    "$gh" skill install paulnsorensen/easy-cheese --all --agent "$harness" --scope user
+    local skill rc=0
+    for skill in $EC_KNOWN_SKILLS; do
+        if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+            ec_log "easy-cheese skills: would run '$gh skill install paulnsorensen/easy-cheese $skill --agent $harness --scope user --force'"
+            continue
+        fi
+        ec_log "easy-cheese skills: installing $skill into $harness (user scope)"
+        if ! "$gh" skill install paulnsorensen/easy-cheese "$skill" --agent "$harness" --scope user --force; then
+            ec_warn "easy-cheese skills: failed to install $skill"
+            rc=1
+        fi
+    done
+    return $rc
 }
 
 # Parse argv into the EC_* config variables. Echoes nothing on success;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+#
+# easy-cheese installer — sets up the CLI tools and MCP servers used by the
+# easy-cheese skills on macOS.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh | bash
+#
+# Or with options:
+#   curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh | bash -s -- --skip-mcp
+#
+# Run `bash install.sh --help` for the full flag list.
+
+set -euo pipefail
+
+# All known CLI tools, formula -> binary name (one is a noop check).
+EC_KNOWN_TOOLS="gh ripgrep fd jq ast-grep git-delta just mergiraf tilth"
+
+# Default selections.
+EC_DEFAULT_TOOLS="$EC_KNOWN_TOOLS"
+EC_DEFAULT_MCP="tilth context7"
+
+# Map a brew formula name to the binary it installs (when they differ).
+ec_tool_binary() {
+    case "$1" in
+        ripgrep)   echo "rg" ;;
+        ast-grep)  echo "sg" ;;
+        git-delta) echo "delta" ;;
+        *)         echo "$1" ;;
+    esac
+}
+
+# Map a brew formula name to the canonical formula spec we install.
+ec_tool_formula() {
+    case "$1" in
+        tilth) echo "paulnsorensen/tap/tilth" ;;
+        *)     echo "$1" ;;
+    esac
+}
+
+ec_log() {
+    printf '\033[1;36m==>\033[0m %s\n' "$*"
+}
+
+ec_warn() {
+    printf '\033[1;33m!! \033[0m %s\n' "$*" >&2
+}
+
+ec_err() {
+    printf '\033[1;31mxx \033[0m %s\n' "$*" >&2
+}
+
+ec_usage() {
+    cat <<'USAGE'
+easy-cheese installer (macOS)
+
+Usage:
+  install.sh [options]
+
+Options:
+  --tools <list>       Comma-separated CLI tools to install. Default: all.
+                       Choices: gh, ripgrep, fd, jq, ast-grep, git-delta,
+                                just, mergiraf, tilth
+  --mcp <list>         Comma-separated MCP servers to register. Default:
+                       tilth,context7. Choices: tilth, context7, tavily,
+                       code-review-graph, none
+  --skip-mcp           Same as --mcp none.
+  --skip-tools         Skip CLI tool installs (useful for MCP-only runs).
+  --harness <name>     Harness to register MCP servers with. Default:
+                       claude-code. Other values: cursor, vscode, codex,
+                       gemini, zed.
+  --no-edit            Register tilth without the --edit capability.
+  --dry-run            Print what would happen without changing anything.
+  -h, --help           Show this help.
+
+Environment:
+  EC_BREW              Override the brew binary (used by tests).
+  EC_TILTH             Override the tilth binary (used by tests).
+  EC_CLAUDE            Override the claude binary (used by tests).
+  EC_PIP               Override the pip binary (used by tests).
+  EC_NPX               Override the npx binary (used by tests).
+USAGE
+}
+
+# OS guard. Returns 0 on macOS, 1 otherwise.
+ec_detect_os() {
+    case "$(uname -s)" in
+        Darwin) return 0 ;;
+        *)      return 1 ;;
+    esac
+}
+
+ec_cmd_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+ec_brew() {
+    "${EC_BREW:-brew}" "$@"
+}
+
+# Verify Homebrew is installed; print install hint and fail otherwise.
+ec_ensure_homebrew() {
+    if ec_cmd_exists "${EC_BREW:-brew}"; then
+        return 0
+    fi
+    ec_err "Homebrew is required but was not found."
+    ec_err "Install it from https://brew.sh and re-run this script."
+    return 1
+}
+
+# Returns 0 if every comma-separated token in $1 is in the space-separated
+# list $2. Prints the offending token to stderr otherwise.
+ec_validate_selection() {
+    local list="$1" allowed="$2" token
+    local IFS=,
+    for token in $list; do
+        case " $allowed " in
+            *" $token "*) ;;
+            *)
+                ec_err "Unknown selection: $token"
+                return 1
+                ;;
+        esac
+    done
+}
+
+# Idempotently install one brew formula. Returns 0 if installed (or already
+# present), 1 if brew failed. Honors $EC_DRY_RUN.
+ec_brew_install_if_missing() {
+    local tool="$1"
+    local binary formula
+    binary="$(ec_tool_binary "$tool")"
+    formula="$(ec_tool_formula "$tool")"
+
+    if ec_cmd_exists "$binary"; then
+        ec_log "$tool: already installed ($binary on PATH)"
+        return 0
+    fi
+
+    if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+        ec_log "$tool: would run 'brew install $formula'"
+        return 0
+    fi
+
+    ec_log "$tool: installing via 'brew install $formula'"
+    ec_brew install "$formula"
+}
+
+# Install every tool in the comma-separated list.
+ec_install_tools() {
+    local list="$1" tool
+    local IFS=,
+    for tool in $list; do
+        ec_brew_install_if_missing "$tool"
+    done
+}
+
+# Register a single MCP server with the chosen harness.
+ec_install_mcp() {
+    local server="$1" harness="$2" with_edit="$3"
+    case "$server" in
+        tilth)
+            ec_install_mcp_tilth "$harness" "$with_edit"
+            ;;
+        context7)
+            ec_install_mcp_context7 "$harness"
+            ;;
+        tavily)
+            ec_install_mcp_tavily "$harness"
+            ;;
+        code-review-graph)
+            ec_install_mcp_crg "$harness"
+            ;;
+        none)
+            ec_log "MCP: skipping (none selected)"
+            ;;
+        *)
+            ec_err "Unknown MCP server: $server"
+            return 1
+            ;;
+    esac
+}
+
+ec_install_mcp_tilth() {
+    local harness="$1" with_edit="$2"
+    local tilth="${EC_TILTH:-tilth}"
+    if ! ec_cmd_exists "$tilth"; then
+        ec_warn "tilth MCP: tilth CLI is not installed; include 'tilth' in --tools first."
+        return 1
+    fi
+    local args=(install "$harness")
+    if [[ "$with_edit" == "1" ]]; then
+        args+=(--edit)
+    fi
+    if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+        ec_log "tilth MCP: would run '$tilth ${args[*]}'"
+        return 0
+    fi
+    ec_log "tilth MCP: registering with $harness"
+    "$tilth" "${args[@]}"
+}
+
+ec_install_mcp_context7() {
+    local harness="$1"
+    local claude="${EC_CLAUDE:-claude}"
+    if [[ "$harness" != "claude-code" ]]; then
+        ec_warn "context7 MCP: only claude-code is auto-registered; configure $harness manually."
+        return 0
+    fi
+    if ! ec_cmd_exists "$claude"; then
+        ec_warn "context7 MCP: claude CLI not found; install Claude Code first."
+        return 1
+    fi
+    if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+        ec_log "context7 MCP: would run 'claude mcp add context7 -- npx -y @upstash/context7-mcp@latest'"
+        return 0
+    fi
+    ec_log "context7 MCP: registering with claude-code"
+    "$claude" mcp add context7 -- npx -y @upstash/context7-mcp@latest
+}
+
+ec_install_mcp_tavily() {
+    local harness="$1"
+    local claude="${EC_CLAUDE:-claude}"
+    if [[ "$harness" != "claude-code" ]]; then
+        ec_warn "tavily MCP: only claude-code is auto-registered; configure $harness manually."
+        return 0
+    fi
+    if ! ec_cmd_exists "$claude"; then
+        ec_warn "tavily MCP: claude CLI not found; install Claude Code first."
+        return 1
+    fi
+    if [[ -z "${TAVILY_API_KEY:-}" ]]; then
+        ec_warn "tavily MCP: TAVILY_API_KEY is not set; the server will fail until you set one."
+    fi
+    if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+        ec_log "tavily MCP: would run 'claude mcp add tavily -- npx -y tavily-mcp'"
+        return 0
+    fi
+    ec_log "tavily MCP: registering with claude-code"
+    "$claude" mcp add tavily -- npx -y tavily-mcp
+}
+
+ec_install_mcp_crg() {
+    local harness="$1"
+    local pip="${EC_PIP:-pip}"
+    local crg="${EC_CRG:-code-review-graph}"
+    if ! ec_cmd_exists "$crg"; then
+        if ! ec_cmd_exists "$pip"; then
+            ec_warn "code-review-graph: pip not found; install Python 3.10+ first."
+            return 1
+        fi
+        if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+            ec_log "code-review-graph: would run '$pip install code-review-graph'"
+        else
+            ec_log "code-review-graph: installing via pip"
+            "$pip" install code-review-graph
+        fi
+    fi
+    if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+        ec_log "code-review-graph: would run '$crg install --platform $harness'"
+        return 0
+    fi
+    ec_log "code-review-graph: registering with $harness"
+    "$crg" install --platform "$harness"
+}
+
+ec_install_mcp_list() {
+    local list="$1" harness="$2" with_edit="$3" server
+    local IFS=,
+    for server in $list; do
+        ec_install_mcp "$server" "$harness" "$with_edit"
+    done
+}
+
+# Parse argv into the EC_* config variables. Echoes nothing on success;
+# echoes an error and returns non-zero on failure.
+ec_parse_args() {
+    EC_TOOLS="$EC_DEFAULT_TOOLS"
+    EC_TOOLS="${EC_TOOLS// /,}"
+    EC_MCP="$EC_DEFAULT_MCP"
+    EC_MCP="${EC_MCP// /,}"
+    EC_HARNESS="claude-code"
+    EC_WITH_EDIT="1"
+    EC_DRY_RUN="${EC_DRY_RUN:-0}"
+    EC_SKIP_TOOLS="0"
+    EC_DO_HELP="0"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --tools)
+                shift
+                [[ $# -gt 0 ]] || { ec_err "--tools requires a value"; return 2; }
+                EC_TOOLS="$1"
+                ;;
+            --tools=*)
+                EC_TOOLS="${1#*=}"
+                ;;
+            --mcp)
+                shift
+                [[ $# -gt 0 ]] || { ec_err "--mcp requires a value"; return 2; }
+                EC_MCP="$1"
+                ;;
+            --mcp=*)
+                EC_MCP="${1#*=}"
+                ;;
+            --skip-mcp)
+                EC_MCP="none"
+                ;;
+            --skip-tools)
+                EC_SKIP_TOOLS="1"
+                ;;
+            --harness)
+                shift
+                [[ $# -gt 0 ]] || { ec_err "--harness requires a value"; return 2; }
+                EC_HARNESS="$1"
+                ;;
+            --harness=*)
+                EC_HARNESS="${1#*=}"
+                ;;
+            --no-edit)
+                EC_WITH_EDIT="0"
+                ;;
+            --dry-run)
+                EC_DRY_RUN="1"
+                ;;
+            -h|--help)
+                EC_DO_HELP="1"
+                ;;
+            --)
+                shift
+                break
+                ;;
+            -*)
+                ec_err "Unknown option: $1"
+                return 2
+                ;;
+            *)
+                ec_err "Unexpected positional argument: $1"
+                return 2
+                ;;
+        esac
+        shift
+    done
+
+    ec_validate_selection "$EC_TOOLS" "$EC_KNOWN_TOOLS" || return 2
+    ec_validate_selection "$EC_MCP" "tilth context7 tavily code-review-graph none" || return 2
+}
+
+ec_main() {
+    ec_parse_args "$@" || return $?
+
+    if [[ "$EC_DO_HELP" == "1" ]]; then
+        ec_usage
+        return 0
+    fi
+
+    if ! ec_detect_os; then
+        ec_err "easy-cheese installer currently supports macOS only."
+        ec_err "Detected: $(uname -s). See README for manual install on other platforms."
+        return 1
+    fi
+
+    if [[ "$EC_SKIP_TOOLS" != "1" ]]; then
+        ec_ensure_homebrew || return 1
+        ec_install_tools "$EC_TOOLS"
+    fi
+
+    if [[ "$EC_MCP" != "none" ]]; then
+        ec_install_mcp_list "$EC_MCP" "$EC_HARNESS" "$EC_WITH_EDIT"
+    fi
+
+    ec_log "Done. Restart your harness so MCP servers and PATH changes take effect."
+}
+
+# Only run main when executed directly, not when sourced (so tests can load
+# functions individually).
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+    ec_main "$@"
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,11 +17,16 @@ set -euo pipefail
 # brew — upstream jahala/tilth does not ship a Homebrew formula).
 EC_KNOWN_TOOLS="gh ripgrep fd jq ast-grep git-delta just mergiraf tilth"
 
-# Every skill shipped by easy-cheese. `gh skill install` requires an explicit
-# skill name (no --all flag), so we enumerate them and install one by one.
-# Kept in sync with skills/ manually so the script stays self-contained for
-# curl|bash distribution.
-EC_KNOWN_SKILLS="age briesearch cheese cheez-read cheez-search cheez-write cook culture cure melt mold press"
+# Repository the installer pulls skills from. Centralized so discovery and
+# install both reference the same source.
+EC_SKILL_REPO="paulnsorensen/easy-cheese"
+
+# Embedded fallback list of skill names. The installer normally discovers
+# the live set via 'gh api repos/.../contents/skills' so it self-heals when
+# new skills land — this list is only used when the API call is
+# unavailable (offline, rate-limited, repo temporarily private). Kept
+# loosely in sync with skills/ but not load-bearing for happy-path runs.
+EC_FALLBACK_SKILLS="age briesearch cheese cheez-read cheez-search cheez-write cook culture cure melt mold press"
 
 # Default selections.
 EC_DEFAULT_TOOLS="$EC_KNOWN_TOOLS"
@@ -349,14 +354,27 @@ ec_install_mcp_list() {
     done
 }
 
+# Discover the live skill list by listing skills/ via the GitHub contents
+# API. Prints one skill name per line on success; on failure (network,
+# rate limit, private repo) returns non-zero with empty stdout and the
+# caller falls back to EC_FALLBACK_SKILLS.
+ec_discover_skills() {
+    local gh="$1"
+    "$gh" api "repos/${EC_SKILL_REPO}/contents/skills" \
+        --jq '.[] | select(.type == "dir") | .name' 2>/dev/null
+}
+
 # Install the easy-cheese skill set into the picked harness via 'gh skill'.
 # User scope so they live alongside the user's other skills, not committed
 # into the project. Requires gh to be authenticated.
 #
-# `gh skill install` does not support an --all flag, so we loop the explicit
-# EC_KNOWN_SKILLS list and call it once per skill with --force for
-# idempotent re-runs. Failures on one skill are warned and tracked but do
-# not abort the rest of the loop.
+# `gh skill install` does not support an --all flag, so we discover the
+# live skill list via 'gh api ... contents/skills' and call gh once per
+# skill with --force for idempotent re-runs. If discovery fails we fall
+# back to EC_FALLBACK_SKILLS so the installer still does something useful
+# offline. Per-skill install failures are warned and tracked but do not
+# abort the rest of the loop. Dry-run skips discovery and uses the
+# embedded list for predictable, network-free output.
 ec_install_skills() {
     local harness="$1"
     local gh="${EC_GH:-gh}"
@@ -364,18 +382,29 @@ ec_install_skills() {
         ec_warn "easy-cheese skills: gh CLI not found; skipping. Add 'gh' to --tools first."
         return 0
     fi
-    if [[ "${EC_DRY_RUN:-0}" != "1" ]] && ! "$gh" auth status >/dev/null 2>&1; then
-        ec_warn "easy-cheese skills: gh is not authenticated. Run 'gh auth login' and re-run."
-        return 1
+
+    local skills="$EC_FALLBACK_SKILLS"
+    if [[ "${EC_DRY_RUN:-0}" != "1" ]]; then
+        if ! "$gh" auth status >/dev/null 2>&1; then
+            ec_warn "easy-cheese skills: gh is not authenticated. Run 'gh auth login' and re-run."
+            return 1
+        fi
+        local discovered
+        if discovered="$(ec_discover_skills "$gh")" && [[ -n "$discovered" ]]; then
+            skills="$discovered"
+        else
+            ec_warn "easy-cheese skills: could not list skills via gh api; using embedded fallback list."
+        fi
     fi
+
     local skill rc=0
-    for skill in $EC_KNOWN_SKILLS; do
+    for skill in $skills; do
         if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-            ec_log "easy-cheese skills: would run '$gh skill install paulnsorensen/easy-cheese $skill --agent $harness --scope user --force'"
+            ec_log "easy-cheese skills: would run '$gh skill install $EC_SKILL_REPO $skill --agent $harness --scope user --force'"
             continue
         fi
         ec_log "easy-cheese skills: installing $skill into $harness (user scope)"
-        if ! "$gh" skill install paulnsorensen/easy-cheese "$skill" --agent "$harness" --scope user --force; then
+        if ! "$gh" skill install "$EC_SKILL_REPO" "$skill" --agent "$harness" --scope user --force; then
             ec_warn "easy-cheese skills: failed to install $skill"
             rc=1
         fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,7 +13,8 @@
 
 set -euo pipefail
 
-# All known CLI tools, formula -> binary name (one is a noop check).
+# All known CLI tools. tilth is included but installed via cargo/npm (not
+# brew — upstream jahala/tilth does not ship a Homebrew formula).
 EC_KNOWN_TOOLS="gh ripgrep fd jq ast-grep git-delta just mergiraf tilth"
 
 # Default selections.
@@ -27,14 +28,6 @@ ec_tool_binary() {
         ast-grep)  echo "sg" ;;
         git-delta) echo "delta" ;;
         *)         echo "$1" ;;
-    esac
-}
-
-# Map a brew formula name to the canonical formula spec we install.
-ec_tool_formula() {
-    case "$1" in
-        tilth) echo "paulnsorensen/tap/tilth" ;;
-        *)     echo "$1" ;;
     esac
 }
 
@@ -66,19 +59,19 @@ Options:
                        code-review-graph, none
   --skip-mcp           Same as --mcp none.
   --skip-tools         Skip CLI tool installs (useful for MCP-only runs).
-  --harness <name>     Harness to register MCP servers with. Default:
-                       claude-code. Other values: cursor, vscode, codex,
-                       gemini, zed.
+  --harness <name>     Harness to register skills + MCP servers with.
+                       Default: claude-code. Other values include cursor,
+                       vscode, codex, gemini, zed, copilot.
   --no-edit            Register tilth without the --edit capability.
   --dry-run            Print what would happen without changing anything.
   -h, --help           Show this help.
 
 Environment:
-  EC_BREW              Override the brew binary (used by tests).
-  EC_TILTH             Override the tilth binary (used by tests).
-  EC_CLAUDE            Override the claude binary (used by tests).
-  EC_PIP               Override the pip binary (used by tests).
-  EC_NPX               Override the npx binary (used by tests).
+  EC_BREW   EC_GH      Override the brew / gh binaries (used by tests).
+  EC_CARGO  EC_NPM     Override the cargo / npm binaries used to install tilth.
+  EC_TILTH  EC_CLAUDE  Override the tilth / claude binaries (used by tests).
+  EC_UV     EC_PIPX    Override uv / pipx for code-review-graph install.
+  EC_PIP    EC_CRG     Override pip / code-review-graph binaries.
 USAGE
 }
 
@@ -128,9 +121,8 @@ ec_validate_selection() {
 # present), 1 if brew failed. Honors $EC_DRY_RUN.
 ec_brew_install_if_missing() {
     local tool="$1"
-    local binary formula
+    local binary
     binary="$(ec_tool_binary "$tool")"
-    formula="$(ec_tool_formula "$tool")"
 
     if ec_cmd_exists "$binary"; then
         ec_log "$tool: already installed ($binary on PATH)"
@@ -138,20 +130,61 @@ ec_brew_install_if_missing() {
     fi
 
     if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-        ec_log "$tool: would run 'brew install $formula'"
+        ec_log "$tool: would run 'brew install $tool'"
         return 0
     fi
 
-    ec_log "$tool: installing via 'brew install $formula'"
-    ec_brew install "$formula"
+    ec_log "$tool: installing via 'brew install $tool'"
+    ec_brew install "$tool"
 }
 
-# Install every tool in the comma-separated list.
+# tilth has no Homebrew formula. Install via cargo (preferred — native
+# binary) or fall back to 'npm install -g tilth' (jahala/tilth ships a
+# proper bin entry on npm). Errors out clearly if neither is available.
+ec_install_tilth() {
+    local cargo="${EC_CARGO:-cargo}"
+    local npm="${EC_NPM:-npm}"
+
+    if ec_cmd_exists tilth; then
+        ec_log "tilth: already installed (tilth on PATH)"
+        return 0
+    fi
+
+    if ec_cmd_exists "$cargo"; then
+        if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+            ec_log "tilth: would run '$cargo install tilth'"
+            return 0
+        fi
+        ec_log "tilth: installing via 'cargo install tilth'"
+        "$cargo" install tilth
+        return $?
+    fi
+
+    if ec_cmd_exists "$npm"; then
+        if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+            ec_log "tilth: would run '$npm install -g tilth' (cargo not found)"
+            return 0
+        fi
+        ec_log "tilth: installing via 'npm install -g tilth' (cargo not found)"
+        "$npm" install -g tilth
+        return $?
+    fi
+
+    ec_err "tilth: needs cargo (Rust) or npm (Node 18+); neither was found."
+    ec_err "Install Rust from https://rustup.rs or Node.js from https://nodejs.org and re-run."
+    return 1
+}
+
+# Install every tool in the comma-separated list. tilth is routed through
+# ec_install_tilth; everything else goes through brew.
 ec_install_tools() {
     local list="$1" tool
     local IFS=,
     for tool in $list; do
-        ec_brew_install_if_missing "$tool"
+        case "$tool" in
+            tilth) ec_install_tilth ;;
+            *)     ec_brew_install_if_missing "$tool" ;;
+        esac
     done
 }
 
@@ -183,6 +216,9 @@ ec_install_mcp() {
 
 ec_install_mcp_tilth() {
     local harness="$1" with_edit="$2"
+    # Reset IFS — ec_install_mcp_list sets it to ',' which would leak into
+    # the dry-run "${args[*]}" expansion below via dynamic scoping.
+    local IFS=$' \t\n'
     local tilth="${EC_TILTH:-tilth}"
     if ! ec_cmd_exists "$tilth"; then
         ec_warn "tilth MCP: tilth CLI is not installed; include 'tilth' in --tools first."
@@ -241,21 +277,55 @@ ec_install_mcp_tavily() {
     "$claude" mcp add tavily -- npx -y tavily-mcp
 }
 
+# Install the code-review-graph CLI. Prefers an isolated tool install
+# (uv → pipx) so we don't poke at the system Python. Falls back to
+# 'pip install --user' with a warning so it still works on minimal boxes.
+ec_install_crg_cli() {
+    local uv="${EC_UV:-uv}"
+    local pipx="${EC_PIPX:-pipx}"
+    local pip="${EC_PIP:-pip}"
+
+    if ec_cmd_exists "$uv"; then
+        if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+            ec_log "code-review-graph: would run '$uv tool install code-review-graph'"
+            return 0
+        fi
+        ec_log "code-review-graph: installing via 'uv tool install code-review-graph'"
+        "$uv" tool install code-review-graph
+        return $?
+    fi
+
+    if ec_cmd_exists "$pipx"; then
+        if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+            ec_log "code-review-graph: would run '$pipx install code-review-graph'"
+            return 0
+        fi
+        ec_log "code-review-graph: installing via 'pipx install code-review-graph'"
+        "$pipx" install code-review-graph
+        return $?
+    fi
+
+    if ec_cmd_exists "$pip"; then
+        ec_warn "code-review-graph: uv/pipx not found; falling back to 'pip install --user'."
+        if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+            ec_log "code-review-graph: would run '$pip install --user code-review-graph'"
+            return 0
+        fi
+        ec_log "code-review-graph: installing via 'pip install --user code-review-graph'"
+        "$pip" install --user code-review-graph
+        return $?
+    fi
+
+    ec_err "code-review-graph: needs uv, pipx, or pip; none found."
+    ec_err "Install uv from https://docs.astral.sh/uv or pipx from https://pipx.pypa.io and re-run."
+    return 1
+}
+
 ec_install_mcp_crg() {
     local harness="$1"
-    local pip="${EC_PIP:-pip}"
     local crg="${EC_CRG:-code-review-graph}"
     if ! ec_cmd_exists "$crg"; then
-        if ! ec_cmd_exists "$pip"; then
-            ec_warn "code-review-graph: pip not found; install Python 3.10+ first."
-            return 1
-        fi
-        if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-            ec_log "code-review-graph: would run '$pip install code-review-graph'"
-        else
-            ec_log "code-review-graph: installing via pip"
-            "$pip" install code-review-graph
-        fi
+        ec_install_crg_cli || return 1
     fi
     if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
         ec_log "code-review-graph: would run '$crg install --platform $harness'"
@@ -271,6 +341,28 @@ ec_install_mcp_list() {
     for server in $list; do
         ec_install_mcp "$server" "$harness" "$with_edit"
     done
+}
+
+# Install the easy-cheese skill set into the picked harness via 'gh skill'.
+# User scope so they live alongside the user's other skills, not committed
+# into the project. Requires gh to be authenticated.
+ec_install_skills() {
+    local harness="$1"
+    local gh="${EC_GH:-gh}"
+    if ! ec_cmd_exists "$gh"; then
+        ec_warn "easy-cheese skills: gh CLI not found; skipping. Add 'gh' to --tools first."
+        return 0
+    fi
+    if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+        ec_log "easy-cheese skills: would run '$gh skill install paulnsorensen/easy-cheese --all --agent $harness --scope user'"
+        return 0
+    fi
+    if ! "$gh" auth status >/dev/null 2>&1; then
+        ec_warn "easy-cheese skills: gh is not authenticated. Run 'gh auth login' and re-run."
+        return 1
+    fi
+    ec_log "easy-cheese skills: installing all skills into $harness (user scope)"
+    "$gh" skill install paulnsorensen/easy-cheese --all --agent "$harness" --scope user
 }
 
 # Parse argv into the EC_* config variables. Echoes nothing on success;
@@ -366,11 +458,13 @@ ec_main() {
         ec_install_tools "$EC_TOOLS"
     fi
 
+    ec_install_skills "$EC_HARNESS"
+
     if [[ "$EC_MCP" != "none" ]]; then
         ec_install_mcp_list "$EC_MCP" "$EC_HARNESS" "$EC_WITH_EDIT"
     fi
 
-    ec_log "Done. Restart your harness so MCP servers and PATH changes take effect."
+    ec_log "Done. Restart your harness so skills, MCP servers, and PATH changes take effect."
 }
 
 # Only run main when executed directly, not when sourced (so tests can load

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,9 @@
 #
 # Run `bash install.sh --help` for the full flag list.
 
-set -euo pipefail
+# strict-mode is enabled inside the BASH_SOURCE guard at the bottom of the
+# file so sourcing (e.g. from the bats suite) does not mutate the caller's
+# shell options.
 
 # All known CLI tools. tilth is included but installed via cargo/npm (not
 # brew — upstream jahala/tilth does not ship a Homebrew formula).
@@ -81,6 +83,7 @@ Environment:
   EC_BREW   EC_GH      Override the brew / gh binaries (used by tests).
   EC_CARGO  EC_NPM     Override the cargo / npm binaries used to install tilth.
   EC_TILTH  EC_CLAUDE  Override the tilth / claude binaries (used by tests).
+  EC_NPX               Override npx (used to launch context7 / tavily MCP).
   EC_UV     EC_PIPX    Override uv / pipx for code-review-graph install.
   EC_PIP    EC_CRG     Override pip / code-review-graph binaries.
 USAGE
@@ -250,6 +253,7 @@ ec_install_mcp_tilth() {
 ec_install_mcp_context7() {
     local harness="$1"
     local claude="${EC_CLAUDE:-claude}"
+    local npx="${EC_NPX:-npx}"
     if [[ "$harness" != "claude-code" ]]; then
         ec_warn "context7 MCP: only claude-code is auto-registered; configure $harness manually."
         return 0
@@ -259,16 +263,17 @@ ec_install_mcp_context7() {
         return 1
     fi
     if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-        ec_log "context7 MCP: would run 'claude mcp add context7 -- npx -y @upstash/context7-mcp@latest'"
+        ec_log "context7 MCP: would run '$claude mcp add context7 -- $npx -y @upstash/context7-mcp@latest'"
         return 0
     fi
     ec_log "context7 MCP: registering with claude-code"
-    "$claude" mcp add context7 -- npx -y @upstash/context7-mcp@latest
+    "$claude" mcp add context7 -- "$npx" -y @upstash/context7-mcp@latest
 }
 
 ec_install_mcp_tavily() {
     local harness="$1"
     local claude="${EC_CLAUDE:-claude}"
+    local npx="${EC_NPX:-npx}"
     if [[ "$harness" != "claude-code" ]]; then
         ec_warn "tavily MCP: only claude-code is auto-registered; configure $harness manually."
         return 0
@@ -281,11 +286,11 @@ ec_install_mcp_tavily() {
         ec_warn "tavily MCP: TAVILY_API_KEY is not set; the server will fail until you set one."
     fi
     if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-        ec_log "tavily MCP: would run 'claude mcp add tavily -- npx -y tavily-mcp'"
+        ec_log "tavily MCP: would run '$claude mcp add tavily -- $npx -y tavily-mcp'"
         return 0
     fi
     ec_log "tavily MCP: registering with claude-code"
-    "$claude" mcp add tavily -- npx -y tavily-mcp
+    "$claude" mcp add tavily -- "$npx" -y tavily-mcp
 }
 
 # Install the code-review-graph CLI. Prefers an isolated tool install
@@ -337,6 +342,16 @@ ec_install_mcp_crg() {
     local crg="${EC_CRG:-code-review-graph}"
     if ! ec_cmd_exists "$crg"; then
         ec_install_crg_cli || return 1
+        # 'pip install --user' and 'pipx ensurepath' can leave the binary
+        # in a directory that isn't on PATH yet (the pipx user bin or the
+        # Python user-site bin). Re-check explicitly so the user gets a
+        # targeted hint instead of a generic "command not found" later.
+        if [[ "${EC_DRY_RUN:-0}" != "1" ]] && ! ec_cmd_exists "$crg"; then
+            ec_err "code-review-graph: install succeeded but '$crg' is not on PATH."
+            ec_err "Add the install location to PATH (run 'pipx ensurepath', or"
+            ec_err "add the Python user-site bin dir for pip --user) and re-run."
+            return 1
+        fi
     fi
     if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
         ec_log "code-review-graph: would run '$crg install --platform $harness'"
@@ -515,7 +530,9 @@ ec_main() {
 }
 
 # Only run main when executed directly, not when sourced (so tests can load
-# functions individually).
+# functions individually). strict-mode is scoped here so sourcing the file
+# does not flip -e/-u/-o pipefail in the caller's shell.
 if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+    set -euo pipefail
     ec_main "$@"
 fi

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -350,12 +350,46 @@ STUB
     [[ "$output" == *"@upstash/context7-mcp@latest"* ]]
 }
 
+@test "ec_install_mcp_context7 dry-run shows resolved \$claude / \$npx paths" {
+    make_stub claude
+    make_stub npx
+    EC_CLAUDE="$STUB_BIN/claude" EC_NPX="$STUB_BIN/npx" EC_DRY_RUN=1 \
+        run ec_install_mcp_context7 claude-code
+    [ "$status" -eq 0 ]
+    # Resolved overrides land in the dry-run preview, not literal "claude"/"npx".
+    [[ "$output" == *"$STUB_BIN/claude mcp add context7 -- $STUB_BIN/npx -y @upstash/context7-mcp@latest"* ]]
+}
+
+@test "ec_install_mcp_context7 honors EC_NPX in real invocation" {
+    make_stub claude
+    cat > "$STUB_BIN/my-npx" <<'STUB'
+#!/usr/bin/env bash
+echo "my-npx $*" >> "$STUB_LOG"
+exit 0
+STUB
+    chmod +x "$STUB_BIN/my-npx"
+    EC_CLAUDE="$STUB_BIN/claude" EC_NPX="$STUB_BIN/my-npx" \
+        run ec_install_mcp_context7 claude-code
+    [ "$status" -eq 0 ]
+    # The claude stub captures argv; assert the EC_NPX override was forwarded.
+    grep -q "^claude mcp add context7 -- $STUB_BIN/my-npx -y @upstash/context7-mcp@latest$" "$STUB_LOG"
+}
+
 @test "ec_install_mcp_tavily warns when TAVILY_API_KEY unset (dry-run)" {
     make_stub claude
     unset TAVILY_API_KEY
     EC_CLAUDE="$STUB_BIN/claude" EC_DRY_RUN=1 run ec_install_mcp_tavily claude-code
     [ "$status" -eq 0 ]
     [[ "$output" == *"TAVILY_API_KEY is not set"* ]]
+}
+
+@test "ec_install_mcp_tavily dry-run shows resolved \$claude / \$npx paths" {
+    make_stub claude
+    make_stub npx
+    EC_CLAUDE="$STUB_BIN/claude" EC_NPX="$STUB_BIN/npx" EC_DRY_RUN=1 \
+        run ec_install_mcp_tavily claude-code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$STUB_BIN/claude mcp add tavily -- $STUB_BIN/npx -y tavily-mcp"* ]]
 }
 
 # -- ec_install_crg_cli -------------------------------------------------------
@@ -421,6 +455,25 @@ STUB
     run ec_install_mcp_crg claude-code
     [ "$status" -eq 0 ]
     grep -q "^code-review-graph install --platform claude-code$" "$STUB_LOG"
+}
+
+@test "ec_install_mcp_crg fails with PATH hint when binary still missing after install" {
+    # Simulate the common 'pip install --user' case: pip succeeds but the
+    # binary lands in a directory that's not on PATH, so the post-install
+    # ec_cmd_exists check still fails.
+    make_stub pip
+    export EC_PIP="$STUB_BIN/pip"
+    # EC_CRG points at a path that will never exist on PATH.
+    export EC_CRG="$BATS_TEST_TMPDIR/nope/code-review-graph"
+    run ec_install_mcp_crg claude-code
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"install succeeded but"* ]]
+    [[ "$output" == *"not on PATH"* ]]
+    [[ "$output" == *"pipx ensurepath"* ]]
+    # Crucially, the registration step must NOT fire when the binary is
+    # still missing — otherwise the user gets the generic shell error we're
+    # trying to replace with a targeted hint.
+    ! grep -q " install --platform " "$STUB_LOG" || false
 }
 
 # -- ec_install_skills --------------------------------------------------------

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -431,12 +431,16 @@ STUB
     [[ "$output" == *"gh CLI not found"* ]]
 }
 
-@test "ec_install_skills dry-run prints --all --agent --scope user line" {
+@test "ec_install_skills dry-run lists every shipped skill with --force" {
     make_stub gh
     EC_GH="$STUB_BIN/gh" EC_DRY_RUN=1 run ec_install_skills claude-code
     [ "$status" -eq 0 ]
-    [[ "$output" == *"would run"* ]]
-    [[ "$output" == *"gh skill install paulnsorensen/easy-cheese --all --agent claude-code --scope user"* ]]
+    # Spot-check first, last, and a representative middle skill in the list.
+    [[ "$output" == *"would run 'gh skill install paulnsorensen/easy-cheese age --agent claude-code --scope user --force'"* ]]
+    [[ "$output" == *"would run 'gh skill install paulnsorensen/easy-cheese cook --agent claude-code --scope user --force'"* ]]
+    [[ "$output" == *"would run 'gh skill install paulnsorensen/easy-cheese press --agent claude-code --scope user --force'"* ]]
+    # Confirm we never emit the broken --all flag again.
+    [[ "$output" != *"--all"* ]]
 }
 
 @test "ec_install_skills dry-run honors picked harness" {
@@ -444,6 +448,7 @@ STUB
     EC_GH="$STUB_BIN/gh" EC_DRY_RUN=1 run ec_install_skills cursor
     [ "$status" -eq 0 ]
     [[ "$output" == *"--agent cursor"* ]]
+    [[ "$output" != *"--agent claude-code"* ]]
 }
 
 @test "ec_install_skills warns and returns 1 when gh is unauthenticated" {
@@ -464,12 +469,39 @@ STUB
     [[ "$output" == *"gh auth login"* ]]
 }
 
-@test "ec_install_skills invokes gh skill install with full arg vector" {
+@test "ec_install_skills invokes gh skill install once per shipped skill" {
     make_stub gh
     export EC_GH="$STUB_BIN/gh"
     run ec_install_skills claude-code
     [ "$status" -eq 0 ]
-    grep -q "^gh skill install paulnsorensen/easy-cheese --all --agent claude-code --scope user$" "$STUB_LOG"
+    # Auth check fired before any install attempt.
+    grep -q "^gh auth status$" "$STUB_LOG"
+    # Spot-check first, last, and a middle skill from EC_KNOWN_SKILLS.
+    grep -q "^gh skill install paulnsorensen/easy-cheese age --agent claude-code --scope user --force$" "$STUB_LOG"
+    grep -q "^gh skill install paulnsorensen/easy-cheese cook --agent claude-code --scope user --force$" "$STUB_LOG"
+    grep -q "^gh skill install paulnsorensen/easy-cheese press --agent claude-code --scope user --force$" "$STUB_LOG"
+    # One invocation per shipped skill, no broken --all flag anywhere.
+    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 12 ]
+    ! grep -q -- "--all" "$STUB_LOG" || false
+}
+
+@test "ec_install_skills returns non-zero when any skill install fails" {
+    cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "$STUB_LOG"
+# Auth ok, but fail when installing the 'cook' skill.
+if [[ "$1" == "skill" && "$2" == "install" && "$4" == "cook" ]]; then
+    exit 1
+fi
+exit 0
+STUB
+    chmod +x "$STUB_BIN/gh"
+    export EC_GH="$STUB_BIN/gh"
+    run ec_install_skills claude-code
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"failed to install cook"* ]]
+    # Loop kept going past the failure — every other skill was still attempted.
+    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 12 ]
 }
 
 # -- ec_install_mcp -----------------------------------------------------------
@@ -542,8 +574,11 @@ STUB
     [[ "$output" == *"cargo install tilth"* ]]
     [[ "$output" != *"brew install tilth"* ]]
     [[ "$output" != *"paulnsorensen/tap/tilth"* ]]
-    # Skills install runs as part of the harness pick stage.
-    [[ "$output" == *"gh skill install paulnsorensen/easy-cheese --all --agent claude-code --scope user"* ]]
+    # Skills install runs as part of the harness pick stage — one entry per
+    # shipped skill, never the broken --all flag.
+    [[ "$output" == *"gh skill install paulnsorensen/easy-cheese age --agent claude-code --scope user --force"* ]]
+    [[ "$output" == *"gh skill install paulnsorensen/easy-cheese press --agent claude-code --scope user --force"* ]]
+    [[ "$output" != *"--all"* ]]
     [[ "$output" == *"install claude-code --edit"* ]]
     [[ "$output" == *"@upstash/context7-mcp@latest"* ]]
     [[ "$output" == *"Done."* ]]
@@ -561,7 +596,10 @@ STUB
         run ec_main --skip-tools --mcp tilth
     [ "$status" -eq 0 ]
     grep -q "^tilth install claude-code --edit$" "$STUB_LOG"
-    grep -q "^gh skill install paulnsorensen/easy-cheese --all --agent claude-code --scope user$" "$STUB_LOG"
+    grep -q "^gh skill install paulnsorensen/easy-cheese age --agent claude-code --scope user --force$" "$STUB_LOG"
+    grep -q "^gh skill install paulnsorensen/easy-cheese press --agent claude-code --scope user --force$" "$STUB_LOG"
+    # 12 skill installs total, no broken --all flag.
+    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 12 ]
     # No brew calls should have happened.
     ! grep -q "^brew" "$STUB_LOG" || false
 }

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -469,28 +469,100 @@ STUB
     [[ "$output" == *"gh auth login"* ]]
 }
 
-@test "ec_install_skills invokes gh skill install once per shipped skill" {
+@test "ec_discover_skills returns names from gh api stdout" {
+    cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "$STUB_LOG"
+if [[ "$1" == "api" ]]; then
+    printf 'alpha\nbeta\ngamma\n'
+    exit 0
+fi
+exit 0
+STUB
+    chmod +x "$STUB_BIN/gh"
+    run ec_discover_skills "$STUB_BIN/gh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"alpha"* && "$output" == *"beta"* && "$output" == *"gamma"* ]]
+    grep -q "^gh api repos/paulnsorensen/easy-cheese/contents/skills " "$STUB_LOG"
+}
+
+@test "ec_discover_skills returns empty when gh api fails" {
+    cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "$STUB_LOG"
+exit 1
+STUB
+    chmod +x "$STUB_BIN/gh"
+    run ec_discover_skills "$STUB_BIN/gh"
+    [ "$status" -ne 0 ]
+    [[ -z "$output" ]]
+}
+
+@test "ec_install_skills uses live list when gh api discovery succeeds" {
+    cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "$STUB_LOG"
+if [[ "$1" == "api" ]]; then
+    printf 'alpha\nbeta\ngamma\n'
+    exit 0
+fi
+exit 0
+STUB
+    chmod +x "$STUB_BIN/gh"
+    export EC_GH="$STUB_BIN/gh"
+    run ec_install_skills claude-code
+    [ "$status" -eq 0 ]
+    grep -q "^gh auth status$" "$STUB_LOG"
+    grep -q "^gh api repos/paulnsorensen/easy-cheese/contents/skills " "$STUB_LOG"
+    grep -q "^gh skill install paulnsorensen/easy-cheese alpha --agent claude-code --scope user --force$" "$STUB_LOG"
+    grep -q "^gh skill install paulnsorensen/easy-cheese beta --agent claude-code --scope user --force$" "$STUB_LOG"
+    grep -q "^gh skill install paulnsorensen/easy-cheese gamma --agent claude-code --scope user --force$" "$STUB_LOG"
+    # Exactly the three discovered skills — fallback list was NOT used.
+    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 3 ]
+    [[ "$output" != *"using embedded fallback list"* ]]
+    ! grep -q -- "--all" "$STUB_LOG" || false
+}
+
+@test "ec_install_skills falls back to embedded list when gh api fails" {
+    cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "$STUB_LOG"
+if [[ "$1" == "api" ]]; then
+    exit 1
+fi
+exit 0
+STUB
+    chmod +x "$STUB_BIN/gh"
+    export EC_GH="$STUB_BIN/gh"
+    run ec_install_skills claude-code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"using embedded fallback list"* ]]
+    # Fallback list ships 12 skill names today; assert via spot-checks plus
+    # an exact count so accidental drift surfaces in CI.
+    grep -q "^gh skill install paulnsorensen/easy-cheese age --agent claude-code --scope user --force$" "$STUB_LOG"
+    grep -q "^gh skill install paulnsorensen/easy-cheese press --agent claude-code --scope user --force$" "$STUB_LOG"
+    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 12 ]
+}
+
+@test "ec_install_skills falls back to embedded list when gh api returns empty" {
+    # Basic stub: every gh call exits 0 with no stdout, including `gh api`.
     make_stub gh
     export EC_GH="$STUB_BIN/gh"
     run ec_install_skills claude-code
     [ "$status" -eq 0 ]
-    # Auth check fired before any install attempt.
-    grep -q "^gh auth status$" "$STUB_LOG"
-    # Spot-check first, last, and a middle skill from EC_KNOWN_SKILLS.
-    grep -q "^gh skill install paulnsorensen/easy-cheese age --agent claude-code --scope user --force$" "$STUB_LOG"
-    grep -q "^gh skill install paulnsorensen/easy-cheese cook --agent claude-code --scope user --force$" "$STUB_LOG"
-    grep -q "^gh skill install paulnsorensen/easy-cheese press --agent claude-code --scope user --force$" "$STUB_LOG"
-    # One invocation per shipped skill, no broken --all flag anywhere.
+    [[ "$output" == *"using embedded fallback list"* ]]
     [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 12 ]
-    ! grep -q -- "--all" "$STUB_LOG" || false
 }
 
 @test "ec_install_skills returns non-zero when any skill install fails" {
     cat > "$STUB_BIN/gh" <<'STUB'
 #!/usr/bin/env bash
 echo "gh $*" >> "$STUB_LOG"
-# Auth ok, but fail when installing the 'cook' skill.
-if [[ "$1" == "skill" && "$2" == "install" && "$4" == "cook" ]]; then
+case "$1" in
+    api) printf 'alpha\nbeta\ngamma\n'; exit 0 ;;
+esac
+# Auth ok, but fail when installing the 'beta' skill.
+if [[ "$1" == "skill" && "$2" == "install" && "$4" == "beta" ]]; then
     exit 1
 fi
 exit 0
@@ -499,9 +571,9 @@ STUB
     export EC_GH="$STUB_BIN/gh"
     run ec_install_skills claude-code
     [ "$status" -eq 1 ]
-    [[ "$output" == *"failed to install cook"* ]]
+    [[ "$output" == *"failed to install beta"* ]]
     # Loop kept going past the failure — every other skill was still attempted.
-    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 12 ]
+    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 3 ]
 }
 
 # -- ec_install_mcp -----------------------------------------------------------

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -1,0 +1,412 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/install.sh.
+#
+# The script is sourced (the BASH_SOURCE != $0 guard skips main on source)
+# so each test can call individual functions with controlled stubs.
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    INSTALL_SH="$REPO_ROOT/scripts/install.sh"
+    STUB_BIN="$BATS_TEST_TMPDIR/bin"
+    STUB_LOG="$BATS_TEST_TMPDIR/calls.log"
+    mkdir -p "$STUB_BIN"
+    : > "$STUB_LOG"
+    export STUB_LOG
+    PATH_ORIG="$PATH"
+    # Use a sparse PATH so the only commands available are real /usr/bin
+    # essentials plus whatever stubs each test adds.
+    PATH="$STUB_BIN:/usr/bin:/bin"
+    # shellcheck disable=SC1090
+    source "$INSTALL_SH"
+}
+
+teardown() {
+    PATH="$PATH_ORIG"
+}
+
+# Drop a stub binary into $STUB_BIN that records its argv to $STUB_LOG.
+make_stub() {
+    local name="$1" exit_code="${2:-0}"
+    cat > "$STUB_BIN/$name" <<STUB
+#!/usr/bin/env bash
+echo "$name \$*" >> "$STUB_LOG"
+exit $exit_code
+STUB
+    chmod +x "$STUB_BIN/$name"
+}
+
+# -- ec_tool_binary / ec_tool_formula -----------------------------------------
+
+@test "ec_tool_binary maps formula names to binaries" {
+    [[ "$(ec_tool_binary ripgrep)" == "rg" ]]
+    [[ "$(ec_tool_binary ast-grep)" == "sg" ]]
+    [[ "$(ec_tool_binary git-delta)" == "delta" ]]
+    [[ "$(ec_tool_binary jq)" == "jq" ]]
+    [[ "$(ec_tool_binary fd)" == "fd" ]]
+    [[ "$(ec_tool_binary just)" == "just" ]]
+    [[ "$(ec_tool_binary mergiraf)" == "mergiraf" ]]
+    [[ "$(ec_tool_binary tilth)" == "tilth" ]]
+    [[ "$(ec_tool_binary gh)" == "gh" ]]
+}
+
+@test "ec_tool_formula taps tilth from paulnsorensen/tap" {
+    [[ "$(ec_tool_formula tilth)" == "paulnsorensen/tap/tilth" ]]
+    [[ "$(ec_tool_formula ripgrep)" == "ripgrep" ]]
+    [[ "$(ec_tool_formula gh)" == "gh" ]]
+}
+
+# -- ec_validate_selection ----------------------------------------------------
+
+@test "ec_validate_selection accepts subset of allowed list" {
+    run ec_validate_selection "ripgrep,jq" "$EC_KNOWN_TOOLS"
+    [ "$status" -eq 0 ]
+}
+
+@test "ec_validate_selection rejects unknown token" {
+    run ec_validate_selection "ripgrep,bogus" "$EC_KNOWN_TOOLS"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown selection: bogus"* ]]
+}
+
+@test "ec_validate_selection accepts the special 'none' MCP token" {
+    run ec_validate_selection "none" "tilth context7 tavily code-review-graph none"
+    [ "$status" -eq 0 ]
+}
+
+# -- ec_parse_args ------------------------------------------------------------
+
+@test "ec_parse_args defaults to all tools and tilth+context7" {
+    ec_parse_args
+    [[ "$EC_TOOLS" == *"gh"* && "$EC_TOOLS" == *"tilth"* ]]
+    [[ "$EC_MCP" == "tilth,context7" ]]
+    [[ "$EC_HARNESS" == "claude-code" ]]
+    [[ "$EC_WITH_EDIT" == "1" ]]
+    [[ "$EC_DRY_RUN" == "0" ]]
+    [[ "$EC_DO_HELP" == "0" ]]
+}
+
+@test "ec_parse_args --tools with value parses comma list" {
+    ec_parse_args --tools ripgrep,jq
+    [[ "$EC_TOOLS" == "ripgrep,jq" ]]
+}
+
+@test "ec_parse_args --tools=value parses inline value" {
+    ec_parse_args --tools=fd
+    [[ "$EC_TOOLS" == "fd" ]]
+}
+
+@test "ec_parse_args --skip-mcp sets MCP to none" {
+    ec_parse_args --skip-mcp
+    [[ "$EC_MCP" == "none" ]]
+}
+
+@test "ec_parse_args --no-edit clears WITH_EDIT" {
+    ec_parse_args --no-edit
+    [[ "$EC_WITH_EDIT" == "0" ]]
+}
+
+@test "ec_parse_args --dry-run sets DRY_RUN" {
+    ec_parse_args --dry-run
+    [[ "$EC_DRY_RUN" == "1" ]]
+}
+
+@test "ec_parse_args --harness overrides default harness" {
+    ec_parse_args --harness cursor
+    [[ "$EC_HARNESS" == "cursor" ]]
+}
+
+@test "ec_parse_args -h sets DO_HELP" {
+    ec_parse_args -h
+    [[ "$EC_DO_HELP" == "1" ]]
+}
+
+@test "ec_parse_args --help sets DO_HELP" {
+    ec_parse_args --help
+    [[ "$EC_DO_HELP" == "1" ]]
+}
+
+@test "ec_parse_args rejects unknown flag with exit code 2" {
+    run ec_parse_args --bogus
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Unknown option"* ]]
+}
+
+@test "ec_parse_args rejects positional arg with exit code 2" {
+    run ec_parse_args some-arg
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Unexpected positional"* ]]
+}
+
+@test "ec_parse_args --tools without value fails" {
+    run ec_parse_args --tools
+    [ "$status" -eq 2 ]
+}
+
+@test "ec_parse_args --mcp without value fails" {
+    run ec_parse_args --mcp
+    [ "$status" -eq 2 ]
+}
+
+@test "ec_parse_args rejects unknown tool selection" {
+    run ec_parse_args --tools ripgrep,foobar
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"foobar"* ]]
+}
+
+@test "ec_parse_args rejects unknown mcp selection" {
+    run ec_parse_args --mcp tilth,bogus
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"bogus"* ]]
+}
+
+@test "ec_parse_args -- terminates option parsing" {
+    ec_parse_args --dry-run --
+    [[ "$EC_DRY_RUN" == "1" ]]
+}
+
+# -- ec_detect_os -------------------------------------------------------------
+
+@test "ec_detect_os returns 0 when uname reports Darwin" {
+    cat > "$STUB_BIN/uname" <<'STUB'
+#!/usr/bin/env bash
+echo Darwin
+STUB
+    chmod +x "$STUB_BIN/uname"
+    run ec_detect_os
+    [ "$status" -eq 0 ]
+}
+
+@test "ec_detect_os returns 1 when uname reports Linux" {
+    cat > "$STUB_BIN/uname" <<'STUB'
+#!/usr/bin/env bash
+echo Linux
+STUB
+    chmod +x "$STUB_BIN/uname"
+    run ec_detect_os
+    [ "$status" -eq 1 ]
+}
+
+# -- ec_ensure_homebrew -------------------------------------------------------
+
+@test "ec_ensure_homebrew passes when brew exists" {
+    make_stub brew
+    run ec_ensure_homebrew
+    [ "$status" -eq 0 ]
+}
+
+@test "ec_ensure_homebrew fails with hint when brew missing" {
+    run ec_ensure_homebrew
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Homebrew is required"* ]]
+    [[ "$output" == *"https://brew.sh"* ]]
+}
+
+# -- ec_brew_install_if_missing ----------------------------------------------
+
+@test "ec_brew_install_if_missing skips when binary already on PATH" {
+    make_stub jq
+    make_stub brew
+    export EC_BREW="$STUB_BIN/brew"
+    run ec_brew_install_if_missing jq
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already installed"* ]]
+    # brew should NOT have been invoked
+    [ ! -s "$STUB_LOG" ] || ! grep -q "^brew install" "$STUB_LOG"
+}
+
+@test "ec_brew_install_if_missing dry-run prints would-run line" {
+    EC_DRY_RUN=1 run ec_brew_install_if_missing ripgrep
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"would run 'brew install ripgrep'"* ]]
+}
+
+@test "ec_brew_install_if_missing dry-run uses tap formula for tilth" {
+    EC_DRY_RUN=1 run ec_brew_install_if_missing tilth
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"paulnsorensen/tap/tilth"* ]]
+}
+
+@test "ec_brew_install_if_missing invokes brew when missing" {
+    make_stub brew
+    export EC_BREW="$STUB_BIN/brew"
+    run ec_brew_install_if_missing ripgrep
+    [ "$status" -eq 0 ]
+    grep -q "^brew install ripgrep$" "$STUB_LOG"
+}
+
+@test "ec_brew_install_if_missing surfaces brew failure" {
+    make_stub brew 1
+    export EC_BREW="$STUB_BIN/brew"
+    run ec_brew_install_if_missing ripgrep
+    [ "$status" -ne 0 ]
+}
+
+# -- ec_install_tools ---------------------------------------------------------
+
+@test "ec_install_tools (dry-run) iterates each formula in the list" {
+    EC_DRY_RUN=1 run ec_install_tools "ripgrep,jq,fd"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"would run 'brew install ripgrep'"* ]]
+    [[ "$output" == *"would run 'brew install jq'"* ]]
+    [[ "$output" == *"would run 'brew install fd'"* ]]
+}
+
+# -- ec_install_mcp_tilth -----------------------------------------------------
+
+@test "ec_install_mcp_tilth fails clearly when tilth CLI missing" {
+    run ec_install_mcp_tilth claude-code 1
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"tilth CLI is not installed"* ]]
+}
+
+@test "ec_install_mcp_tilth dry-run shows install command with --edit" {
+    make_stub tilth
+    EC_TILTH="$STUB_BIN/tilth" EC_DRY_RUN=1 run ec_install_mcp_tilth claude-code 1
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"install claude-code --edit"* ]]
+}
+
+@test "ec_install_mcp_tilth dry-run omits --edit when WITH_EDIT=0" {
+    make_stub tilth
+    EC_TILTH="$STUB_BIN/tilth" EC_DRY_RUN=1 run ec_install_mcp_tilth claude-code 0
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"--edit"* ]]
+}
+
+@test "ec_install_mcp_tilth invokes tilth install when not dry-run" {
+    make_stub tilth
+    export EC_TILTH="$STUB_BIN/tilth"
+    run ec_install_mcp_tilth claude-code 1
+    [ "$status" -eq 0 ]
+    grep -q "^tilth install claude-code --edit$" "$STUB_LOG"
+}
+
+# -- ec_install_mcp_context7 / tavily / crg ----------------------------------
+
+@test "ec_install_mcp_context7 warns and skips for non-claude harness" {
+    run ec_install_mcp_context7 cursor
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"only claude-code is auto-registered"* ]]
+}
+
+@test "ec_install_mcp_context7 fails when claude CLI missing" {
+    run ec_install_mcp_context7 claude-code
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"claude CLI not found"* ]]
+}
+
+@test "ec_install_mcp_context7 dry-run prints would-run with package name" {
+    make_stub claude
+    EC_CLAUDE="$STUB_BIN/claude" EC_DRY_RUN=1 run ec_install_mcp_context7 claude-code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"@upstash/context7-mcp@latest"* ]]
+}
+
+@test "ec_install_mcp_tavily warns when TAVILY_API_KEY unset (dry-run)" {
+    make_stub claude
+    unset TAVILY_API_KEY
+    EC_CLAUDE="$STUB_BIN/claude" EC_DRY_RUN=1 run ec_install_mcp_tavily claude-code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"TAVILY_API_KEY is not set"* ]]
+}
+
+@test "ec_install_mcp_crg dry-run installs via pip when missing" {
+    make_stub pip
+    EC_PIP="$STUB_BIN/pip" EC_CRG="$STUB_BIN/code-review-graph-not-real" \
+        EC_DRY_RUN=1 run ec_install_mcp_crg claude-code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"would run"* ]]
+    [[ "$output" == *"install code-review-graph"* ]]
+}
+
+@test "ec_install_mcp_crg invokes crg install for present binary" {
+    make_stub code-review-graph
+    export EC_CRG="$STUB_BIN/code-review-graph"
+    run ec_install_mcp_crg claude-code
+    [ "$status" -eq 0 ]
+    grep -q "^code-review-graph install --platform claude-code$" "$STUB_LOG"
+}
+
+@test "ec_install_mcp dispatches 'none' as a no-op log line" {
+    run ec_install_mcp none claude-code 1
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"skipping"* ]]
+}
+
+@test "ec_install_mcp rejects unknown server" {
+    run ec_install_mcp wensleydale claude-code 1
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown MCP server"* ]]
+}
+
+# -- ec_main full-flow --------------------------------------------------------
+
+@test "ec_main --help prints usage and exits 0" {
+    run ec_main --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"easy-cheese installer"* ]]
+    [[ "$output" == *"--tools"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+}
+
+@test "ec_main rejects non-Darwin OS" {
+    cat > "$STUB_BIN/uname" <<'STUB'
+#!/usr/bin/env bash
+echo Linux
+STUB
+    chmod +x "$STUB_BIN/uname"
+    run ec_main --dry-run
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"macOS only"* ]]
+}
+
+@test "ec_main fails when Homebrew missing on macOS" {
+    cat > "$STUB_BIN/uname" <<'STUB'
+#!/usr/bin/env bash
+echo Darwin
+STUB
+    chmod +x "$STUB_BIN/uname"
+    # Note: no brew stub in PATH, EC_BREW unset.
+    unset EC_BREW
+    run ec_main --skip-mcp
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Homebrew is required"* ]]
+}
+
+@test "ec_main full --dry-run on macOS prints all tool actions" {
+    cat > "$STUB_BIN/uname" <<'STUB'
+#!/usr/bin/env bash
+echo Darwin
+STUB
+    chmod +x "$STUB_BIN/uname"
+    make_stub brew
+    make_stub tilth
+    make_stub claude
+    EC_BREW="$STUB_BIN/brew" \
+    EC_TILTH="$STUB_BIN/tilth" \
+    EC_CLAUDE="$STUB_BIN/claude" \
+        run ec_main --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"would run 'brew install gh'"* ]]
+    [[ "$output" == *"would run 'brew install ripgrep'"* ]]
+    [[ "$output" == *"paulnsorensen/tap/tilth"* ]]
+    [[ "$output" == *"install claude-code --edit"* ]]
+    [[ "$output" == *"@upstash/context7-mcp@latest"* ]]
+    [[ "$output" == *"Done."* ]]
+}
+
+@test "ec_main --skip-tools --mcp tilth registers only tilth" {
+    cat > "$STUB_BIN/uname" <<'STUB'
+#!/usr/bin/env bash
+echo Darwin
+STUB
+    chmod +x "$STUB_BIN/uname"
+    make_stub tilth
+    EC_TILTH="$STUB_BIN/tilth" \
+        run ec_main --skip-tools --mcp tilth
+    [ "$status" -eq 0 ]
+    grep -q "^tilth install claude-code --edit$" "$STUB_LOG"
+    # No brew calls should have happened.
+    ! grep -q "^brew" "$STUB_LOG" || false
+}

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -36,7 +36,7 @@ STUB
     chmod +x "$STUB_BIN/$name"
 }
 
-# -- ec_tool_binary / ec_tool_formula -----------------------------------------
+# -- ec_tool_binary -----------------------------------------------------------
 
 @test "ec_tool_binary maps formula names to binaries" {
     [[ "$(ec_tool_binary ripgrep)" == "rg" ]]
@@ -48,12 +48,6 @@ STUB
     [[ "$(ec_tool_binary mergiraf)" == "mergiraf" ]]
     [[ "$(ec_tool_binary tilth)" == "tilth" ]]
     [[ "$(ec_tool_binary gh)" == "gh" ]]
-}
-
-@test "ec_tool_formula taps tilth from paulnsorensen/tap" {
-    [[ "$(ec_tool_formula tilth)" == "paulnsorensen/tap/tilth" ]]
-    [[ "$(ec_tool_formula ripgrep)" == "ripgrep" ]]
-    [[ "$(ec_tool_formula gh)" == "gh" ]]
 }
 
 # -- ec_validate_selection ----------------------------------------------------
@@ -221,12 +215,6 @@ STUB
     [[ "$output" == *"would run 'brew install ripgrep'"* ]]
 }
 
-@test "ec_brew_install_if_missing dry-run uses tap formula for tilth" {
-    EC_DRY_RUN=1 run ec_brew_install_if_missing tilth
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"paulnsorensen/tap/tilth"* ]]
-}
-
 @test "ec_brew_install_if_missing invokes brew when missing" {
     make_stub brew
     export EC_BREW="$STUB_BIN/brew"
@@ -250,6 +238,65 @@ STUB
     [[ "$output" == *"would run 'brew install ripgrep'"* ]]
     [[ "$output" == *"would run 'brew install jq'"* ]]
     [[ "$output" == *"would run 'brew install fd'"* ]]
+}
+
+@test "ec_install_tools routes tilth through ec_install_tilth, not brew" {
+    make_stub cargo
+    EC_CARGO="$STUB_BIN/cargo" EC_DRY_RUN=1 run ec_install_tools "tilth"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"cargo install tilth"* ]]
+    [[ "$output" != *"brew install tilth"* ]]
+}
+
+# -- ec_install_tilth ---------------------------------------------------------
+
+@test "ec_install_tilth short-circuits when tilth already on PATH" {
+    make_stub tilth
+    run ec_install_tilth
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"already installed"* ]]
+}
+
+@test "ec_install_tilth dry-run prefers cargo when both cargo and npm exist" {
+    make_stub cargo
+    make_stub npm
+    EC_CARGO="$STUB_BIN/cargo" EC_NPM="$STUB_BIN/npm" EC_DRY_RUN=1 \
+        run ec_install_tilth
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"would run"* ]]
+    [[ "$output" == *"cargo install tilth"* ]]
+    [[ "$output" != *"npm install -g tilth"* ]]
+}
+
+@test "ec_install_tilth invokes cargo when not dry-run" {
+    make_stub cargo
+    export EC_CARGO="$STUB_BIN/cargo"
+    run ec_install_tilth
+    [ "$status" -eq 0 ]
+    grep -q "^cargo install tilth$" "$STUB_LOG"
+}
+
+@test "ec_install_tilth falls back to npm install -g when cargo missing" {
+    make_stub npm
+    EC_NPM="$STUB_BIN/npm" EC_DRY_RUN=1 run ec_install_tilth
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"npm install -g tilth"* ]]
+    [[ "$output" == *"cargo not found"* ]]
+}
+
+@test "ec_install_tilth invokes npm install -g when cargo missing" {
+    make_stub npm
+    export EC_NPM="$STUB_BIN/npm"
+    run ec_install_tilth
+    [ "$status" -eq 0 ]
+    grep -q "^npm install -g tilth$" "$STUB_LOG"
+}
+
+@test "ec_install_tilth fails clearly when neither cargo nor npm present" {
+    run ec_install_tilth
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"needs cargo (Rust) or npm"* ]]
+    [[ "$output" == *"rustup.rs"* ]]
 }
 
 # -- ec_install_mcp_tilth -----------------------------------------------------
@@ -311,13 +358,61 @@ STUB
     [[ "$output" == *"TAVILY_API_KEY is not set"* ]]
 }
 
-@test "ec_install_mcp_crg dry-run installs via pip when missing" {
+# -- ec_install_crg_cli -------------------------------------------------------
+
+@test "ec_install_crg_cli prefers uv over pipx and pip" {
+    make_stub uv
+    make_stub pipx
     make_stub pip
-    EC_PIP="$STUB_BIN/pip" EC_CRG="$STUB_BIN/code-review-graph-not-real" \
+    EC_UV="$STUB_BIN/uv" EC_PIPX="$STUB_BIN/pipx" EC_PIP="$STUB_BIN/pip" \
+        EC_DRY_RUN=1 run ec_install_crg_cli
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"uv tool install code-review-graph"* ]]
+    [[ "$output" != *"pipx install"* ]]
+    [[ "$output" != *"pip install"* ]]
+}
+
+@test "ec_install_crg_cli falls back to pipx when uv missing" {
+    make_stub pipx
+    make_stub pip
+    EC_PIPX="$STUB_BIN/pipx" EC_PIP="$STUB_BIN/pip" \
+        EC_DRY_RUN=1 run ec_install_crg_cli
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pipx install code-review-graph"* ]]
+    [[ "$output" != *"uv tool"* ]]
+}
+
+@test "ec_install_crg_cli falls back to 'pip install --user' last with a warning" {
+    make_stub pip
+    EC_PIP="$STUB_BIN/pip" EC_DRY_RUN=1 run ec_install_crg_cli
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"falling back to 'pip install --user'"* ]]
+    [[ "$output" == *"pip install --user code-review-graph"* ]]
+}
+
+@test "ec_install_crg_cli fails clearly when uv, pipx, and pip are all missing" {
+    run ec_install_crg_cli
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"needs uv, pipx, or pip"* ]]
+}
+
+@test "ec_install_crg_cli invokes uv tool install when not dry-run" {
+    make_stub uv
+    export EC_UV="$STUB_BIN/uv"
+    run ec_install_crg_cli
+    [ "$status" -eq 0 ]
+    grep -q "^uv tool install code-review-graph$" "$STUB_LOG"
+}
+
+# -- ec_install_mcp_crg -------------------------------------------------------
+
+@test "ec_install_mcp_crg installs CLI then registers when binary missing" {
+    make_stub uv
+    EC_UV="$STUB_BIN/uv" EC_CRG="$STUB_BIN/code-review-graph-not-real" \
         EC_DRY_RUN=1 run ec_install_mcp_crg claude-code
     [ "$status" -eq 0 ]
-    [[ "$output" == *"would run"* ]]
-    [[ "$output" == *"install code-review-graph"* ]]
+    [[ "$output" == *"uv tool install code-review-graph"* ]]
+    [[ "$output" == *"install --platform claude-code"* ]]
 }
 
 @test "ec_install_mcp_crg invokes crg install for present binary" {
@@ -327,6 +422,57 @@ STUB
     [ "$status" -eq 0 ]
     grep -q "^code-review-graph install --platform claude-code$" "$STUB_LOG"
 }
+
+# -- ec_install_skills --------------------------------------------------------
+
+@test "ec_install_skills warns and returns 0 when gh CLI missing" {
+    run ec_install_skills claude-code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"gh CLI not found"* ]]
+}
+
+@test "ec_install_skills dry-run prints --all --agent --scope user line" {
+    make_stub gh
+    EC_GH="$STUB_BIN/gh" EC_DRY_RUN=1 run ec_install_skills claude-code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"would run"* ]]
+    [[ "$output" == *"gh skill install paulnsorensen/easy-cheese --all --agent claude-code --scope user"* ]]
+}
+
+@test "ec_install_skills dry-run honors picked harness" {
+    make_stub gh
+    EC_GH="$STUB_BIN/gh" EC_DRY_RUN=1 run ec_install_skills cursor
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--agent cursor"* ]]
+}
+
+@test "ec_install_skills warns and returns 1 when gh is unauthenticated" {
+    cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "$STUB_LOG"
+# Simulate `gh auth status` failure when called as 'gh auth status'.
+if [[ "$1" == "auth" && "$2" == "status" ]]; then
+    exit 1
+fi
+exit 0
+STUB
+    chmod +x "$STUB_BIN/gh"
+    export EC_GH="$STUB_BIN/gh"
+    run ec_install_skills claude-code
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"gh is not authenticated"* ]]
+    [[ "$output" == *"gh auth login"* ]]
+}
+
+@test "ec_install_skills invokes gh skill install with full arg vector" {
+    make_stub gh
+    export EC_GH="$STUB_BIN/gh"
+    run ec_install_skills claude-code
+    [ "$status" -eq 0 ]
+    grep -q "^gh skill install paulnsorensen/easy-cheese --all --agent claude-code --scope user$" "$STUB_LOG"
+}
+
+# -- ec_install_mcp -----------------------------------------------------------
 
 @test "ec_install_mcp dispatches 'none' as a no-op log line" {
     run ec_install_mcp none claude-code 1
@@ -374,39 +520,48 @@ STUB
     [[ "$output" == *"Homebrew is required"* ]]
 }
 
-@test "ec_main full --dry-run on macOS prints all tool actions" {
+@test "ec_main full --dry-run on macOS prints all tool, skill, and MCP actions" {
     cat > "$STUB_BIN/uname" <<'STUB'
 #!/usr/bin/env bash
 echo Darwin
 STUB
     chmod +x "$STUB_BIN/uname"
     make_stub brew
-    make_stub tilth
+    make_stub cargo
+    make_stub gh
     make_stub claude
     EC_BREW="$STUB_BIN/brew" \
-    EC_TILTH="$STUB_BIN/tilth" \
+    EC_CARGO="$STUB_BIN/cargo" \
+    EC_GH="$STUB_BIN/gh" \
     EC_CLAUDE="$STUB_BIN/claude" \
         run ec_main --dry-run
     [ "$status" -eq 0 ]
     [[ "$output" == *"would run 'brew install gh'"* ]]
     [[ "$output" == *"would run 'brew install ripgrep'"* ]]
-    [[ "$output" == *"paulnsorensen/tap/tilth"* ]]
+    # tilth installs via cargo, NOT brew.
+    [[ "$output" == *"cargo install tilth"* ]]
+    [[ "$output" != *"brew install tilth"* ]]
+    [[ "$output" != *"paulnsorensen/tap/tilth"* ]]
+    # Skills install runs as part of the harness pick stage.
+    [[ "$output" == *"gh skill install paulnsorensen/easy-cheese --all --agent claude-code --scope user"* ]]
     [[ "$output" == *"install claude-code --edit"* ]]
     [[ "$output" == *"@upstash/context7-mcp@latest"* ]]
     [[ "$output" == *"Done."* ]]
 }
 
-@test "ec_main --skip-tools --mcp tilth registers only tilth" {
+@test "ec_main --skip-tools --mcp tilth registers only tilth (still runs skills)" {
     cat > "$STUB_BIN/uname" <<'STUB'
 #!/usr/bin/env bash
 echo Darwin
 STUB
     chmod +x "$STUB_BIN/uname"
     make_stub tilth
-    EC_TILTH="$STUB_BIN/tilth" \
+    make_stub gh
+    EC_TILTH="$STUB_BIN/tilth" EC_GH="$STUB_BIN/gh" \
         run ec_main --skip-tools --mcp tilth
     [ "$status" -eq 0 ]
     grep -q "^tilth install claude-code --edit$" "$STUB_LOG"
+    grep -q "^gh skill install paulnsorensen/easy-cheese --all --agent claude-code --scope user$" "$STUB_LOG"
     # No brew calls should have happened.
     ! grep -q "^brew" "$STUB_LOG" || false
 }


### PR DESCRIPTION
## Summary

- Adds `scripts/install.sh` — a curl|bash macOS installer that picks up the CLI tools (`gh`, `ripgrep`, `fd`, `jq`, `ast-grep`, `git-delta`, `just`, `mergiraf`, `tilth`) and MCP servers (`tilth`, `context7`, optionally `tavily`/`code-review-graph`) easy-cheese skills already document. Idempotent, supports `--tools`, `--mcp`, `--skip-mcp`, `--skip-tools`, `--harness`, `--no-edit`, `--dry-run`, `--help`.
- Adds `tests/bash/test_install.bats` — 48 bats tests covering arg parsing, selection validation, OS gating, brew install/skip paths, MCP registration paths, and the full `--dry-run` flow. Stubs `brew`, `tilth`, `claude`, `pip`, `code-review-graph`, and `uname` via a per-test `PATH`-prepended `bin/`.
- Adds a `macos-latest` CI job that runs `shellcheck` plus `bats tests/bash/test_install.bats` on every PR.
- Updates `README.md` with a "One-shot installer (macOS)" section showing the curl|bash recipe and common flags.

## Why this shape

- Mac-only on purpose for now — Homebrew gives us the cleanest single-source-of-truth across all the tools the skills reference. Linux/Windows can come later without touching the harness contract.
- The script is structured as small pure-bash functions guarded by `if [[ "${BASH_SOURCE[0]}" == "${0}" ]]`, so the bats suite can `source` it and exercise each function with stub binaries instead of network/installer calls.
- All external commands accept `EC_*` env-var overrides (`EC_BREW`, `EC_TILTH`, `EC_CLAUDE`, `EC_PIP`, `EC_CRG`) so tests can swap in stubs without monkey-patching `PATH` for everything.

## Test plan

- [x] `bats tests/bash/test_install.bats` — 48/48 pass locally
- [x] `shellcheck scripts/install.sh` — clean
- [x] `markdownlint-cli2 README.md` — clean
- [x] `bash scripts/install.sh --help` — prints usage and exits 0
- [x] `bash scripts/install.sh --dry-run` (with stubbed brew/tilth/claude) — prints would-run lines for every tool/MCP without invoking anything
- [ ] CI macos-latest job runs the bats suite and shellcheck end-to-end (will be exercised by this PR)
