### PR TITLE
Fix install commands: stale flags, missing tap, wrong scope value

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ gh skill install paulnsorensen/easy-cheese
 Install every skill in one shot:
 
 ```sh
-gh skill install paulnsorensen/easy-cheese --all
+for s in age briesearch cheese cheez-read cheez-search cheez-write cook culture cure melt mold press; do
+  gh skill install paulnsorensen/easy-cheese "$s"
+done
 ```
 
 Install one specific skill by name:
@@ -169,11 +171,11 @@ gh skill install paulnsorensen/easy-cheese cook@abc123def
 Control which agent and scope to install into:
 
 ```sh
-# User-wide (default)
+# User-wide (recommended for personal toolkits)
 gh skill install paulnsorensen/easy-cheese --agent claude-code --scope user
 
-# Committed into the current project repo
-gh skill install paulnsorensen/easy-cheese --agent claude-code --scope repository
+# Committed into the current project repo (default scope)
+gh skill install paulnsorensen/easy-cheese --agent claude-code --scope project
 ```
 
 Supported `--agent` values include `copilot`, `claude-code`, `cursor`, `codex`, `gemini`, and others. Omit `--agent` to use the harness auto-detected from your environment.
@@ -235,9 +237,10 @@ The cheez-* tool skills and several workflow skills benefit from MCP servers. In
 [tilth](https://github.com/paulnsorensen/tilth) provides AST-aware code search, smart file reading, and hash-anchored edits. Required by `/cheez-search`, `/cheez-read`, and `/cheez-write`.
 
 ```sh
-# Install tilth CLI
+# Install tilth CLI — pick one
 cargo install tilth        # via Cargo (Rust)
-brew install paulnsorensen/tap/tilth  # via Homebrew (macOS/Linux)
+# or run via npx — no global install needed (Node.js v18+):
+#   npx -y tilth install claude-code --edit
 
 # Register as an MCP server — include --edit only if you plan to use cheez-write
 tilth install claude-code --edit   # Claude Code


### PR DESCRIPTION
## Summary

Hit four broken install commands while installing easy-cheese end-to-end. All fixes are to the `## Install → gh skill (recommended)` and `## Installing MCP servers → tilth` sections of the README.

| # | README claim | Reality | Evidence |
|---|---|---|---|
| 1 | `gh skill install paulnsorensen/easy-cheese --all` | unknown flag, exit 1 | `gh skill install --help` lists no `--all` flag (only `gh skill update --all` is valid — left untouched) |
| 2 | `brew install paulnsorensen/tap/tilth` | tap repo 404, `git clone` exits 128 | `gh api repos/paulnsorensen/homebrew-tap` → 404; `tilth`'s own README documents only `cargo install` and `npx` |
| 3 | `# User-wide (default)` next to `--scope user` | default is `project` | `--scope string  Installation scope: {project\|user} (default "project")` per `gh skill install --help` |
| 4 | `--scope repository` (second example block) | `invalid argument "repository" for "--scope" flag: valid values are {project\|user}`, exit 1 | direct test |

#4 is the worst — anyone copy-pasting the "Committed into the current project repo" example gets a hard error.

## Fixes

1. Replaced the `--all` invocation with an explicit per-skill `for` loop over the 12 skills currently in `skills/`.
2. Dropped the brew tap line; added `npx -y tilth install claude-code --edit` as the no-toolchain path (Node.js v18+).
3. Changed the "(default)" annotation to "(recommended for personal toolkits)" since `user` isn't the actual default.
4. Changed `--scope repository` → `--scope project` and updated the comment to flag it as the default scope.

## Tested with

- `gh` v2.92.0 (macOS, Apple Silicon)
- `tilth` 0.7.0 via `npx`
- Node.js v22.19.0

## Heads-up for the maintainer

Several in-flight branches (`paulnsorensen/cheez-skills-audit`, `paulnsorensen/skill-flow-audit`, `paulnsorensen/sliced-bread`, `paulnsorensen/release-on-tag`, `copilot/update-instructions-for-tools`) still reference the broken `--all` flag and/or the dead brew tap. They'll likely need a small rebase against this fix.