### PR TITLE
feat(age): invert handoff — ask which findings to cure, not whether to run /cure

### DIFF
--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: age
-description: This skill should be used when the user wants a code review on a diff, PR, branch, or path — phrases like "review this", "/age", "is this safe to merge", "find bugs", "spot security issues", "check for slop", "review my PR", "look for problems", "what's wrong with this code". Runs eight orthogonal review dimensions (correctness, security, encapsulation, spec, complexity, deslop, assertions, NIH) over the scoped diff and emits a stake-grouped findings report at `.cheese/age/<slug>.md`. Use even when the user only asks for one dimension — the report scopes itself. Findings only — no fixes; route the user to `/cure` when they are ready to select findings. After `/press` (optional); before `/cure`.
+description: This skill should be used when the user wants a code review on a diff, PR, branch, or path — phrases like "review this", "/age", "is this safe to merge", "find bugs", "spot security issues", "check for slop", "review my PR", "look for problems", "what's wrong with this code". Runs eight orthogonal review dimensions (correctness, security, encapsulation, spec, complexity, deslop, assertions, NIH) over the scoped diff and emits a stake-grouped findings report at `.cheese/age/<slug>.md`. Use even when the user only asks for one dimension — the report scopes itself. Findings only — no fixes; after the report lands, age renders the cure-selection table inline and asks which findings to cure (no "should I run /cure?" meta-question), then hands off to `/cure` with the selection locked in. After `/press` (optional); before `/cure`.
 license: MIT
 ---
 
@@ -43,7 +43,7 @@ Per-dimension rubrics and recommendation shapes in `references/dimensions.md`. T
 3. Review every dimension; dimensions with no findings simply omit themselves.
 4. Group findings by stake (high → medium) and by file.
 5. Write the report to `.cheese/age/<slug>.md` and print the path.
-6. Hand off via `AskUserQuestion` (see `## Handoff` below). `/cure` owns the finding-selection gate; age never auto-applies fixes.
+6. Hand off via `AskUserQuestion` (see `## Handoff` below). Age owns the selection gate: it asks the user *which findings to cure*, never *whether to run /cure*. `/cure` still owns the actual fix application — age never auto-applies fixes.
 
 ## Preferred tools and fallbacks
 
@@ -81,7 +81,7 @@ Write to `.cheese/age/<slug>.md`:
 <`certain` | `speculating` | `don't know`> — <one-line justification including which evidence sources were unavailable>
 
 ## Next step
-/cure <slug>   — pick findings to fix
+Selection prompt rendered inline — pick findings to cure or `none` to stop.
 ```
 
 Then print:
@@ -92,18 +92,23 @@ Age report: .cheese/age/<slug>.md
 
 ## Handoff
 
-After the report is on disk, ask via `AskUserQuestion` which downstream to run. Default options:
+After the report is on disk, skip any "should I run /cure?" meta-question and go straight to the selection gate. The user's working memory is on the findings, not on whether a follow-up step exists.
 
-- **Run /cure `<slug>`** *(recommended when there are high-stake findings)* — pick findings to fix.
-- **Stop** — leave the report for later.
+1. Render the numbered selection table per `../cure/references/selection.md` directly inline (one row per finding, grouped by stake).
+2. Ask via `AskUserQuestion` which findings to cure. Offer the recognised selection verbs as options:
+   - **Pick findings** — accept a free-text reply using the verbs from `../cure/references/selection.md` (`1,3,5`, `all-high`, `all`, `none`, `skip N`).
+   - **All high-stake** *(pre-selected when at least one high-stake finding exists)* — equivalent to `all-high`.
+   - **Stop** — equivalent to `none`; leave the report for later.
+3. On a non-empty selection, hand off to `/cure <slug>` with the selection locked in (pass the chosen ids through so `/cure` skips its own selection prompt and goes straight to apply). `/cure` still owns the apply / validate / report loop and may surface the chosen ids for confirmation if the report has shifted underneath it.
+4. On `none` / `Stop`, exit cleanly with the report path.
 
-Pre-select `Run /cure` when at least one high-stake finding exists. `/cure` still owns its selection gate; the user picks individual findings there. Never auto-apply.
+Never auto-apply fixes, and never invoke `/cure` without an explicit non-empty selection. The default selection remains empty.
 
 ## Rules
 
 - Review is not a verdict; explain where to look and why.
 - Do not edit production files.
-- Do not auto-apply fixes. Prompting `/cure` via `AskUserQuestion` is fine; bypassing `/cure`'s selection gate is not.
+- Do not auto-apply fixes. Age owns the *selection* gate (which findings to cure) and dispatches `/cure` only with an explicit non-empty selection; the *application* gate stays inside `/cure`.
 - Do not invent evidence. Cite files, diffs, commands, or unavailable-source notes.
 - Agree when the diff is fine. Do not manufacture findings to fill a dimension; an empty dimension is a valid outcome.
 - Keep confidence qualitative (`certain | speculating | don't know`); never emit a numeric score.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 
 Use this skill to review a diff or scoped path before merging, after `/press`, or whenever the user wants evidence-backed observations rather than an approval verdict.
 
-Do not use it to apply fixes directly. Hand fix work to `/cure`, which owns selecting and applying findings.
+Do not use it to apply fixes directly. Hand fix work to `/cure`, which owns applying findings.
 
 ## Inputs
 
@@ -95,9 +95,9 @@ Age report: .cheese/age/<slug>.md
 After the report is on disk, skip any "should I run /cure?" meta-question and go straight to the selection gate. The user's working memory is on the findings, not on whether a follow-up step exists.
 
 1. Render the numbered selection table per `../cure/references/selection.md` directly inline (one row per finding, grouped by stake).
-2. Ask via `AskUserQuestion` which findings to cure. Offer the recognised selection verbs as options:
+2. Ask via `AskUserQuestion` which findings to cure. Offer the recognized selection verbs as options:
    - **Pick findings** — accept a free-text reply using the verbs from `../cure/references/selection.md` (`1,3,5`, `all-high`, `all`, `none`, `skip N`).
-   - **All high-stake** *(pre-selected when at least one high-stake finding exists)* — equivalent to `all-high`.
+   - **All high-stake** *(recommended when at least one high-stake finding exists)* — equivalent to `all-high`.
    - **Stop** — equivalent to `none`; leave the report for later.
 3. On a non-empty selection, hand off to `/cure <slug>` with the selection locked in (pass the chosen ids through so `/cure` skips its own selection prompt and goes straight to apply). `/cure` still owns the apply / validate / report loop and may surface the chosen ids for confirmation if the report has shifted underneath it.
 4. On `none` / `Stop`, exit cleanly with the report path.

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -12,14 +12,14 @@ Do not use it to apply every suggestion automatically. The user chooses what to 
 
 ## Inputs
 
-Accept any of: a `/age` slug (`/cure <slug>` reads `.cheese/age/<slug>.md`), a pasted findings list, a CI failure summary, or a scoped instruction like "fix the high-stake age findings".
+Accept any of: a `/age` slug (`/cure <slug>` reads `.cheese/age/<slug>.md`), a pasted findings list, a CI failure summary, or a scoped instruction like "fix the high-stake age findings". `/age` may also hand off with a pre-locked selection (e.g. `/cure <slug> --select 1,3,5` or an inline selection string in the dispatch); when that happens, skip rendering the selection list and go straight to apply.
 
-If selection is ambiguous, render a numbered selection list per `references/selection.md` and ask what to apply. The default selection is empty.
+If selection is ambiguous *and* not pre-locked from `/age`, render a numbered selection list per `references/selection.md` and ask what to apply. The default selection is empty.
 
 ## Flow
 
 1. **Load** — read the findings (markdown, not JSON sidecars).
-2. **Select** — gate on explicit user selection. See `references/selection.md` for the recognized verbs.
+2. **Select** — if `/age` handed off a pre-locked selection, adopt it as-is (re-confirm the cited ids still exist in the report). Otherwise gate on explicit user selection. See `references/selection.md` for the recognized verbs.
 3. **Apply** — fix one logical group at a time via `cheez-read` (re-confirm anchor location) and `cheez-write` (apply).
 4. **Validate** — run the narrowest tests that prove each fix, then any relevant project-wide gates (lint, typecheck, build).
 5. **Re-review hand-off** — recommend `/age --scope <touched-path>` so review runs through the proper skill rather than reimplementing it inline. `/cure` does not re-grade its own work. If the user picks re-age, the resulting report can feed a fresh `/cure` invocation.

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -12,7 +12,7 @@ Do not use it to apply every suggestion automatically. The user chooses what to 
 
 ## Inputs
 
-Accept any of: a `/age` slug (`/cure <slug>` reads `.cheese/age/<slug>.md`), a pasted findings list, a CI failure summary, or a scoped instruction like "fix the high-stake age findings". `/age` may also hand off with a pre-locked selection (e.g. `/cure <slug> --select 1,3,5` or an inline selection string in the dispatch); when that happens, skip rendering the selection list and go straight to apply.
+Accept any of: a `/age` slug (`/cure <slug>` reads `.cheese/age/<slug>.md`), a pasted findings list, a CI failure summary, or a scoped instruction like "fix the high-stake age findings". `/age` may also hand off with a pre-locked selection by passing the chosen ids inline in the dispatch (see `references/selection.md#handoff-from-age` for the canonical format); when that happens, skip rendering the selection list and go straight to apply.
 
 If selection is ambiguous *and* not pre-locked from `/age`, render a numbered selection list per `references/selection.md` and ask what to apply. The default selection is empty.
 

--- a/skills/cure/references/selection.md
+++ b/skills/cure/references/selection.md
@@ -2,6 +2,8 @@
 
 `/cure` never applies findings without an explicit selection. The default selection is empty.
 
+`/age` is the preferred place to render this gate — it inverts the path so the user is asked *which findings to cure* immediately after the report lands, rather than first being asked *whether to run /cure*. When `/age` hands off with a pre-locked selection, `/cure` adopts it and skips re-rendering the table; otherwise `/cure` renders the table itself using the same shape below.
+
 ## Rendering the selection list
 
 When invoked with a slug, load `.cheese/age/<slug>.md` and render a numbered table grouped by stake:

--- a/skills/cure/references/selection.md
+++ b/skills/cure/references/selection.md
@@ -4,6 +4,12 @@
 
 `/age` is the preferred place to render this gate — it inverts the path so the user is asked *which findings to cure* immediately after the report lands, rather than first being asked *whether to run /cure*. When `/age` hands off with a pre-locked selection, `/cure` adopts it and skips re-rendering the table; otherwise `/cure` renders the table itself using the same shape below.
 
+## Handoff from /age
+
+When `/age` completes the selection gate and the user picks a non-empty set, it dispatches `/cure` with the selection locked in by passing the chosen ids as plain text in the invocation context — the same verbs accepted at the prompt (`1,3,5`, `all-high`, etc.). `/cure` reads this from the dispatch context, skips rendering the selection table, and goes straight to apply.
+
+There is no CLI flag (`--select` is not a supported syntax). The selection travels as prose context in the `AskUserQuestion` resolution, not as a parsed argument.
+
 ## Rendering the selection list
 
 When invoked with a slug, load `.cheese/age/<slug>.md` and render a numbered table grouped by stake:


### PR DESCRIPTION
## Summary

After the age report lands, `/age` now renders the cure selection table inline and asks the user *which findings to cure* via `AskUserQuestion`, instead of first asking the meta-question "should I run /cure?". On a non-empty selection it dispatches `/cure <slug>` with the ids locked in, so `/cure` skips its own selection prompt and goes straight to apply. `/cure` still owns the apply/validate/report loop and re-confirms the locked-in ids against the report. Selection vocabulary (`1,3,5`, `all-high`, `all`, `none`, `skip N`) and the empty-default rule are unchanged — the gate just moved up one step.

## Test plan

- [ ] Run `/age` on a diff with high-stake findings; confirm the inline selection prompt renders and there is no "Run /cure?" meta-question.
- [ ] Pick a subset; confirm `/cure` adopts the selection without re-prompting.
- [ ] Pick `none`/`Stop`; confirm clean exit with the report path printed.