### PR TITLE
docs: add Copilot review instructions for skills

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,61 @@
+# Copilot review instructions — easy-cheese
+
+This repo is a skills-only collection following the
+[Agent Skills spec](https://agentskills.io/specification). Every change either
+adds, edits, or supports a skill under `skills/<name>/`. There is no
+production runtime: review focuses on **skill quality**, not application
+behavior.
+
+When reviewing a PR, treat it the way the `/skill-creator` skill would: care
+about whether the skill will *trigger* when it should, whether it teaches the
+model *why* not just *what*, and whether bundled resources earn their keep.
+
+## What this repo is and isn't
+
+- **Is**: self-contained `SKILL.md` files for shaping ideas, implementing
+  them, and reviewing the result. Workflow skills (`mold`, `culture`, `cook`,
+  `press`, `age`, `cure`, `melt`, `cheese`, `briesearch`) plus tool skills
+  (`cheez-search`, `cheez-read`, `cheez-write`).
+- **Isn't**: an agent framework, an orchestrator, a mandatory-MCP runtime.
+  The cheez-* skills require tilth MCP and hard-fail without it; every other
+  skill stays portable and degrades to host-native tools.
+
+Keep this scope in mind — flag scope creep (intent classification baked into
+a workflow skill, multi-CLI fan-out inside a tool skill, implicit cross-skill
+invocation) at review time. Cross-skill handoffs belong in the README's
+"Suggested flow" or in the skill's own routing section, not as silent
+auto-dispatch.
+
+## Skill review priorities (in order)
+
+Apply the path-scoped instructions in `.github/instructions/` for the
+specifics. The summary order:
+
+1. **Triggering** — does the description tell Claude when to use this skill,
+   in language users actually type?
+2. **Progressive disclosure** — is `SKILL.md` lean? Does deeper material live
+   in `references/`, `scripts/`, `assets/` instead of inline?
+3. **Why over what** — does the skill explain reasoning, or just bark MUSTs?
+4. **Bundled resources earn their keep** — every `references/<file>.md` and
+   `scripts/<file>` should have a clear pointer from `SKILL.md` telling the
+   model when to load or run it.
+5. **Anti-overfit** — instructions generalize across realistic prompts, not
+   just the examples baked into the skill itself.
+
+## What not to flag
+
+- Cheese / Dune / Mad Max flavor in user-facing docs. It's intentional repo
+  voice. Commit messages and YAML frontmatter stay neutral.
+- Backward-compat shims, deprecation paths, migration plans — this repo is
+  early-stage and treats every release as the new baseline.
+- Style nits already covered by the validators (`markdownlint`, `yamllint`,
+  `.github/scripts/validate_skills.py`). CI catches those; reviewers should
+  focus on skill-design issues that linters miss.
+
+## How to write review comments
+
+- Lead with user impact: "this description would miss users who say X".
+- Quote the smallest section of the skill that needs changing.
+- Suggest the rewrite, don't just diagnose.
+- If a finding is speculative ("might confuse some users"), say so — don't
+  inflate it into a blocker.

--- a/.github/instructions/skills.instructions.md
+++ b/.github/instructions/skills.instructions.md
@@ -1,0 +1,93 @@
+---
+applyTo: "skills/**/SKILL.md"
+---
+
+# SKILL.md review checklist
+
+Review `SKILL.md` changes the way `/skill-creator` would. The validator
+already checks that `name` matches the directory and that frontmatter parses.
+Spend your review budget on the things linters cannot see.
+
+## Frontmatter
+
+- `name` matches the parent directory (validator catches mismatch).
+- `description` is **the** triggering mechanism. It must:
+  - Say what the skill does **and** when to invoke it.
+  - Include realistic user phrases ("review this diff", "fix the conflicts",
+    "shape this into a spec"), not abstract noun phrases ("code review
+    operations").
+  - Lean *slightly* pushy. Skills under-trigger by default. A description
+    like "Use even when the user says 'tighten things up' before review" is
+    fine.
+  - Call out boundaries — what this skill does **not** do — when there's a
+    sibling skill it could be confused with (e.g., `/age` finds vs `/cure`
+    fixes; `/cheez-search` searches vs `/cheez-read` reads).
+- `model`, `allowed-tools`, `license` are optional but should be consistent
+  across siblings unless a skill genuinely needs different values.
+
+## Body length and progressive disclosure
+
+- Aim for `SKILL.md` under ~500 lines. Going over is fine when justified, but
+  if instructions repeat themselves, pull them into `references/<topic>.md`
+  and link from `SKILL.md` with a one-line "read this when …" pointer.
+- For skills that span multiple variants (per-language fixers, per-conflict
+  cascade stages, per-stake findings flows), keep the selection logic in
+  `SKILL.md` and put the variant-specific detail in `references/`. Claude
+  only loads what it needs.
+- Tables of contents only earn their place in reference files >300 lines.
+
+## Bundled resources must pay rent
+
+- Every file under `scripts/`, `references/`, `assets/` has at least one
+  reference from `SKILL.md` saying when to use it.
+- Scripts encode deterministic, repeated work — if every invocation of the
+  skill would re-derive the same shell incantation, bundle it.
+- Templates and static text live in `assets/`, not inlined in `SKILL.md`.
+
+## Writing style
+
+- Imperative voice ("Run `/cheez-search`", not "You should run
+  `/cheez-search`").
+- Explain *why* a step matters when the reasoning isn't self-evident.
+  Heavy-handed `MUST` / `ALWAYS` / `NEVER` is a yellow flag — replace with
+  reasoning where possible. Reserve all-caps for genuine footguns
+  ("**NEVER `git push --force` to `main`**").
+- Examples use the `Input → Output` pattern when demonstrating
+  transformations. Concrete commands beat abstract descriptions.
+- Don't overfit instructions to the examples in the skill. If the rule only
+  works for the three commands shown, it won't survive contact with real
+  users.
+
+## Scope discipline (this repo specifically)
+
+- Workflow skills (`mold`, `cook`, `press`, `age`, `cure`, `melt`, etc.)
+  cover one phase of the lifecycle each. Adding a second phase is a new
+  skill, not a new section.
+- Tool skills (`cheez-*`) wrap one tilth-MCP capability each. Don't fold
+  search and read into the same skill — the chain depends on them being
+  independently invokable.
+- Only the `cheez-*` skills require an MCP server (tilth). Every other skill
+  must degrade cleanly to host-native tools when MCPs are unavailable; do
+  not introduce new mandatory-MCP dependencies in workflow skills.
+- Skills do not invoke other skills programmatically. Documented handoffs
+  (e.g., `/age` → `/cure`, `/cook` → `/press` → `/age`) belong in the
+  README's "Suggested flow" or as explicit user-visible prompts in the
+  skill body — never as silent auto-dispatch.
+- No intent classification, no automatic routing inside a skill body except
+  in `/cheese`, where routing **is** the skill's purpose and dispatch is
+  gated behind `AskUserQuestion`.
+
+## Quick triage prompt for review comments
+
+For each non-trivial change in the diff, ask:
+
+1. **Trigger test** — would a real user phrasing actually pull this skill in?
+2. **Skip test** — could the same outcome land without this paragraph /
+   script / reference file? If yes, suggest dropping it.
+3. **Generalize test** — does this advice survive when the user's repo
+   doesn't look like the example?
+4. **Surprise test** — would invoking this skill do anything the description
+   didn't promise?
+
+If a comment doesn't trace back to one of those four tests, it probably
+belongs in a separate cleanup PR or in CI, not in this review.


### PR DESCRIPTION
## Summary

Add repo-level Copilot review guidance and path-scoped SKILL.md checklist to standardize code review practices across easy-cheese PRs. Guides reviewers on skill quality, triggering, progressive disclosure, scope discipline, and when not to flag style issues already covered by CI.

## Changes

- `.github/copilot-instructions.md` — Overview of review priorities and what to flag/skip specific to this skills-only repo.
- `.github/instructions/skills.instructions.md` — Path-scoped checklist for individual `SKILL.md` files, covering frontmatter, body length, bundled resources, writing style, and scope discipline (adapted from skillz-that-grillz#13, adjusted for easy-cheese's workflow + tool skill categories).

Both files follow the `applyTo` pattern for Copilot path-scoped instructions.