### PR TITLE
chore: scaffold OSS hygiene baseline

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://buymeacoffee.com/paulnsorensen"]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Something is broken or behaves incorrectly
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill out the fields
+        below — the more concrete the repro, the faster the fix.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: When I run X, Y happens instead of Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, copy-pasteable steps.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Output of `<tool> --version` or the commit SHA.
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: OS / runtime
+      description: e.g. macOS 14.5, Ubuntu 24.04, Node 20.11
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / output
+      description: Paste relevant log output. Will be auto-formatted as code.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true
+        - label: I am running the latest released version
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# Disable blank issues so users start from a template, and surface
+# alternative support channels for non-bug, non-feature questions.
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/paulnsorensen/easy-cheese/discussions
+    about: Ask a question or start a conversation in Discussions.
+  - name: Security vulnerability
+    url: https://github.com/paulnsorensen/easy-cheese/security/advisories/new
+    about: Report a vulnerability privately via a draft security advisory.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest an enhancement or new capability
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the user-facing pain, not the implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why they did not fit.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, screenshots, prior art.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!-- markdownlint-disable-file MD041 -->
+<!--
+Thanks for opening a PR. Please fill out the sections below — short is fine,
+but blank is not. The reviewer should be able to understand intent and risk
+from the description alone.
+-->
+
+## What changed
+
+<!-- One or two sentences. The "what". -->
+
+## Why
+
+<!-- The motivation. Link any tracking issue: `Fixes #123`. -->
+
+## How to verify
+
+<!-- Commands the reviewer can run, or what to click in the UI. -->
+
+## Risk / rollout notes
+
+<!-- Anything reviewers should pay extra attention to. Migrations, breaking
+     changes, feature flags, follow-ups, etc. Write "none" if there is none. -->
+
+## Checklist
+
+- [ ] Conventional Commits PR title (`feat:`, `fix:`, `chore:`, `docs:`, ...)
+- [ ] Tests added or updated (or N/A)
+- [ ] Documentation updated (or N/A)
+- [ ] No secrets or credentials added

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Dependabot configuration — version updates only.
+# See: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# No top-level Python manifest; the only Python is in .github/scripts/
+# (CI helpers) with versions pinned inline in workflows. No pip ecosystem
+# entry — Dependabot can't track inline `pip install foo==x.y.z` lines.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        update-types: [minor, patch]

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+# Dependency Review — gates PRs that introduce vulnerable or
+# disallowed-license dependencies. Public repos: free.
+# Private repos: requires GitHub Advanced Security.
+# See: https://github.com/actions/dependency-review-action
+name: dependency review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,8 +15,8 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/dependency-review-action@38ecb5b593bf0eb19e335c03f97670f792489a8b # v4.7.0
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: on-failure

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+# OpenSSF Scorecard — runs on push to main and weekly.
+# Publishes results to scorecard.dev (badge data) and uploads SARIF
+# to the repo's Code scanning view.
+# See: https://github.com/ossf/scorecard-action
+name: scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "26 4 * * 1"
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,22 +23,22 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: ossf/scorecard-action@v2
+      - uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@1521896cd211af95be3f02edf6f436e10b819c27 # v3.35.4
         with:
           sarif_file: results.sarif

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+This project adopts the
+[**Contributor Covenant**, version 2.1][cc-2-1] as its Code of Conduct.
+
+The full text of the Code of Conduct is available at the link above
+and applies to all community spaces associated with this project,
+including issues, pull requests, discussions, and any project-related
+chat or events.
+
+## Reporting
+
+Reports of behaviour that does not align with the Code of Conduct
+should be sent to the maintainers at:
+
+> **<paulnsorensen@gmail.com>**
+
+All reports will be reviewed and investigated promptly and fairly.
+The maintainers are obligated to respect the privacy and safety of
+the reporter.
+
+## Enforcement
+
+Maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by
+other members of the project's leadership, in line with the
+[Enforcement Guidelines][cc-2-1-guidelines] published with the
+Contributor Covenant.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][cc],
+version 2.1.
+
+For answers to common questions, see the [FAQ][cc-faq], or read the
+[full text][cc-2-1].
+
+[cc]: https://www.contributor-covenant.org
+[cc-2-1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+[cc-2-1-guidelines]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines
+[cc-faq]: https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to easy-cheese
+
+Thanks for your interest. Contributions of all sizes are welcome — a
+typo fix is just as useful as a feature. This document describes how
+to get from "I want to help" to "my change is merged".
+
+## Filing issues
+
+- Search [open issues](https://github.com/paulnsorensen/easy-cheese/issues)
+  before opening a new one.
+- Use the bug-report or feature-request template.
+- For security vulnerabilities, do **not** open a public issue — see
+  [`SECURITY.md`](./SECURITY.md).
+
+## Setting up locally
+
+```sh
+git clone https://github.com/paulnsorensen/easy-cheese.git
+cd easy-cheese
+# project-specific install + build instructions go here
+```
+
+## Running tests
+
+```sh
+# project-specific test command goes here
+```
+
+Please run the full test suite before opening a PR.
+
+## Submitting a pull request
+
+1. Fork the repo and create a topic branch from `main`.
+2. Make your change. Keep commits focused; one concern per commit is
+   easier to review than a kitchen-sink commit.
+3. Use [Conventional Commits](https://www.conventionalcommits.org)
+   for the PR title (e.g. `feat: add X`, `fix: handle Y`,
+   `docs: explain Z`). Squash-merge will use the PR title as the
+   commit subject.
+4. Fill out the PR template — the "why" matters more than the "what".
+5. Wait for CI to go green and address review feedback.
+
+## Code of Conduct
+
+Participation in this project is governed by the
+[Contributor Covenant](./CODE_OF_CONDUCT.md). By contributing you
+agree to abide by it.
+
+## Licensing
+
+By submitting a contribution you agree that it will be licensed under
+the same terms as the project itself (see [`LICENSE`](./LICENSE)).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,16 +14,28 @@ to get from "I want to help" to "my change is merged".
 
 ## Setting up locally
 
+Requires Python 3.12+ and (for bash tests) bats-core + shellcheck.
+
 ```sh
 git clone https://github.com/paulnsorensen/easy-cheese.git
 cd easy-cheese
-# project-specific install + build instructions go here
+pip install pyyaml==6.0.2 pytest==9.0.3   # validation + Python tests
+brew install bats-core shellcheck           # macOS — bash tests
 ```
 
 ## Running tests
 
 ```sh
-# project-specific test command goes here
+# Skill YAML/frontmatter validation
+python3 .github/scripts/test_validate_skills.py -v
+python3 .github/scripts/validate_skills.py
+
+# Python unit tests
+python3 -m pytest tests/python -q
+
+# Bash tests (requires bats + shellcheck)
+shellcheck scripts/install.sh
+bats tests/bash/test_install.bats
 ```
 
 Please run the full test suite before opening a PR.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security policy
+
+## Supported versions
+
+The `main` branch and the most recent tagged release receive security
+fixes. Older releases are best-effort.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities **privately** via GitHub's
+private advisory flow:
+
+<https://github.com/paulnsorensen/easy-cheese/security/advisories/new>
+
+If that is not available, email <paulnsorensen@gmail.com>. Encrypted email
+is welcome.
+
+When reporting, please include:
+
+- A description of the issue and its impact.
+- Steps to reproduce, or a proof-of-concept.
+- Affected version(s) or commit SHA.
+- Any suggested mitigation, if you have one.
+
+We aim to acknowledge reports within **3 business days** and to share
+a remediation timeline within **10 business days**. Please give us a
+reasonable window to ship a fix before public disclosure — typically
+**90 days**, sooner if a fix is shipped earlier or if the issue is
+already public.
+
+## Scope
+
+In scope:
+
+- The source code in this repository.
+- Released artifacts (binaries, packages) produced from this repo.
+
+Out of scope:
+
+- Third-party dependencies — please report those upstream.
+- Self-hosted deployments configured outside the project's
+  documented defaults.
+- Social-engineering or physical-access attacks.
+
+Thanks for helping keep the project safe.


### PR DESCRIPTION
## Summary

Applied the `oss-hygiene` skill from [`paulnsorensen/skillz-that-grillz`](https://github.com/paulnsorensen/skillz-that-grillz/tree/main/skills/oss-hygiene) to bring this repo to the GitHub Community Standards baseline and the OpenSSF Scorecard supply-chain baseline.

### Scaffolded — Community Standards

- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
- `CONTRIBUTING.md`
- `SECURITY.md` (private advisory + `paulnsorensen@gmail.com` fallback)
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/FUNDING.yml` → Buy Me a Coffee (`paulnsorensen`)

### Scaffolded — Supply chain

- `.github/dependabot.yml` — `github-actions` ecosystem only
- `.github/workflows/dependency-review.yml`
- `.github/workflows/scorecard.yml`

### Skipped (intentional)

- **CodeQL workflow** — the only Python is `.github/scripts/validate_skills.py` (CI helper, not project code).
- **`pip` ecosystem in `dependabot.yml`** — no top-level Python manifest. Inline `pip install foo==x.y.z` lines in workflows aren't trackable by Dependabot without a real manifest.
- **Native security toggles** — no `gh` CLI / API endpoint was available in the agent's environment. See the checklist below.

### Workflow audit (Token-Permissions + Dangerous-Workflow)

Both existing workflows are clean:

- `release.yml` — top-level `permissions: { contents: write }` (justified by release publish), SHA-pinned actions, no `pull_request_target`. ✓
- `validate.yml` — top-level `permissions: { contents: read }`, SHA-pinned actions, safe `pull_request` trigger. ✓

## Manual follow-ups (you have to run these)

### 1. Flip the GitHub-native security features

These are repo-settings toggles, not files. Dependabot alerts + dependency graph are auto-on for public repos, but secret scanning + push protection are opt-in:

```bash
# Dependabot security updates (auto-PRs against advisories)
gh api -X PUT   repos/paulnsorensen/easy-cheese/automated-security-fixes

# Dependabot alerts (idempotent, no-op if already on)
gh api -X PUT   repos/paulnsorensen/easy-cheese/vulnerability-alerts

# Secret scanning + push protection
gh api -X PATCH repos/paulnsorensen/easy-cheese \
  -F security_and_analysis[secret_scanning][status]=enabled \
  -F security_and_analysis[secret_scanning_push_protection][status]=enabled
```

### 2. Register for the OpenSSF Best Practices Badge

Self-attested at <https://www.bestpractices.dev>. The skill doesn't fill out the questionnaire — that's a maintainer-attestation step.

```text
Register at: https://www.bestpractices.dev/en/projects/new
Repo URL:    https://github.com/paulnsorensen/easy-cheese
```

Once you have a project ID, paste this near the top of `README.md` (CodeQL line stripped since CodeQL was skipped):

```markdown
[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/paulnsorensen/easy-cheese/badge)](https://scorecard.dev/viewer/?uri=github.com/paulnsorensen/easy-cheese)
[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/<id>/badge)](https://www.bestpractices.dev/projects/<id>)
```

### 3. (Optional) Re-pin the new workflows to commit SHAs

The three scaffolded workflows use floating tags (`@v4`, `@v2`, `@v3`) to match the OSSF reference templates. Scorecard's `Pinned-Dependencies` check will flag this on first run. Dependabot will keep them current automatically; convert to SHA pins after the first Dependabot PR lands if you want a clean `Pinned-Dependencies` score.

## Test plan

- [ ] Verify Community Standards checklist hits 100% at <https://github.com/paulnsorensen/easy-cheese/community>
- [ ] Confirm `.github/workflows/dependency-review.yml` runs on this PR (you'll see a `dependency review` check)
- [ ] After merge: confirm `.github/workflows/scorecard.yml` runs on push to `main` and publishes to <https://scorecard.dev/viewer/?uri=github.com/paulnsorensen/easy-cheese>
- [ ] Run the three `gh api` commands above; re-run them — they should be no-ops the second time
- [ ] Register the project on bestpractices.dev and add the badge snippet to `README.md`

https://claude.ai/code/session_01B7S5qKAKiuL8HUVFu1zWdw

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7S5qKAKiuL8HUVFu1zWdw)_