### PR TITLE
docs(skills): refresh code-review-graph via MCP + when to use semantic search

### DIFF
--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -61,6 +61,8 @@ Beyond cheez-* there are review-specific tools:
 | GitHub/PR context | `gh` | local git commands or user-provided PR data |
 | Merge/conflict awareness | mergiraf | manual conflict checks |
 
+**Freshness:** before the first code-review-graph query in a run, call `build_or_update_graph_tool` (and `embed_graph_tool` if you'll use `semantic_search_nodes_tool`). The graph is persistent and goes stale between sessions. See [`/cheez-search`](../cheez-search/SKILL.md#when-code-review-graph-beats-tilth-if-your-harness-has-it) for the full freshness contract and when semantic search beats tilth — steel threads across renamed layers, concepts under divergent names, spec-vs-code vocabulary mismatch.
+
 Missing optional tools should not block review. State which evidence was unavailable and reduce confidence accordingly.
 
 ## Sub-agent context gate

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -144,7 +144,25 @@ It wins on five questions tilth structurally cannot answer:
 | Architecture framing for a large diff (hubs, bridges, communities) | `get_architecture_overview_tool`, `get_hub_nodes_tool`, `get_bridge_nodes_tool`, `list_communities_tool` | tilth has no global graph view |
 | Affected execution flows for a change | `get_affected_flows_tool` | tilth follows callers one hop at a time; this returns full flows |
 
-**Freshness caveat — this is the trade-off vs tilth.** code-review-graph's graph is materialised by an explicit `code-review-graph build` step (and `code-review-graph embed` for the semantic search index). Unlike tilth, it goes stale if the build wasn't refreshed after recent edits. Re-run `build` (and, if you've added concept-shaped code, `embed`) before relying on its answers on a hot branch.
+**Before the first query — refresh the graph via MCP.** code-review-graph keeps a persistent graph that goes stale between sessions. From inside an agent, prefer the MCP tools over the CLI:
+
+- Call `build_or_update_graph_tool` once at the start of a run. It's incremental — on a warm repo this is fast.
+- If you'll use `semantic_search_nodes_tool` *or* you've added concept-shaped code since the last embed, also call `embed_graph_tool` once. Embedding is the slow step — skip it otherwise.
+
+The CLI equivalents (`code-review-graph build` / `embed`) are for first-time setup; inside a run, the MCP tools let the agent own the lifecycle.
+
+**When `semantic_search_nodes_tool` beats tilth.** Reach for it when the question is concept-shaped, not name-shaped:
+
+- **Steel threads** — trace a feature end-to-end when each layer names the concept differently (controller → service → repo → migration → telemetry). tilth makes you guess the next layer's vocabulary; embeddings surface the chain.
+- **Shared concepts under divergent names** — "where do we handle idempotency?" when the code uses `dedupeKey`, `requestSig`, `OnceToken`. Grep is blind to the concept; embeddings find it.
+- **Vocabulary mismatch between spec and code** — product says "session continuity", code says `KeepaliveToken`. Map the stakeholder term to the implementation without an SME.
+- **Analog mining** — before adding another retry / rate-limit / cache layer, ask what already exists under different names.
+- **Cross-repo concept discovery** — pair with `cross_repo_search_tool` to find auth (or any concept) across services that named it differently.
+- **Onboarding orientation** — "what's in this repo for observability?" returns conceptually adjacent nodes ranked by graph centrality. Faster first read than walking imports.
+
+**Stay on tilth when** you know the symbol name; you need literal text or regex; you're doing a one-hop caller walk; the branch is hot and you haven't re-embedded; or the change is a mechanical rename or move.
+
+**Two gotchas.** Ranking blends similarity with graph centrality — `semantic_search_nodes_tool` biases toward hub nodes, sometimes against the leaf where the bug actually lives; after a hit, follow callers in tilth. Default embedding model is `all-MiniLM-L6-v2` (384-dim), which blurs nuanced distinctions like "session timeout" vs "session revocation" — override via `CRG_EMBEDDING_MODEL` if your domain needs it.
 
 If code-review-graph is unavailable, the cheez-search fallbacks are: name-shaped questions stay on tilth; semantic / cross-repo / architecture questions either degrade to a manual `tilth_deps` + `kind: "callers"` walk or get noted as unavailable evidence (cap confidence at `speculating`).
 

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -44,6 +44,8 @@ Beyond cheez-* there are cure-specific tools:
 | Diffs | `delta` | plain `git diff` |
 | Conflict resolution | mergiraf | manual resolution with targeted tests |
 
+**Freshness:** before the first code-review-graph query in a run, call `build_or_update_graph_tool` (and `embed_graph_tool` if you'll use `semantic_search_nodes_tool` to find sibling code with the same concept under a different name). See [`/cheez-search`](../cheez-search/SKILL.md#when-code-review-graph-beats-tilth-if-your-harness-has-it) for the full freshness contract and when semantic search beats tilth.
+
 If a preferred tool is missing, continue with the fallback. If a missing tool prevents safe application, stop and explain the blocker.
 
 ## Validation

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -32,6 +32,8 @@ Beyond cheez-* there are press-specific tools:
 | Diff review | `delta` | plain `git diff` |
 | Affected execution flows + risk scoring | code-review-graph: `get_affected_flows_tool`, `get_impact_radius_tool` | manual flow tracing from callers |
 
+**Freshness:** before the first code-review-graph query in a run, call `build_or_update_graph_tool` (and `embed_graph_tool` if you'll use `semantic_search_nodes_tool` to find shared-concept tests under divergent names). See [`/cheez-search`](../cheez-search/SKILL.md#when-code-review-graph-beats-tilth-if-your-harness-has-it) for the full freshness contract and when semantic search beats tilth.
+
 If optional tools are missing, press a narrower surface and state the residual risk.
 
 ## Testing priority


### PR DESCRIPTION
## Summary

- **Problem:** `age`, `press`, and `cure` lean on code-review-graph tools (`get_review_context_tool`, `get_impact_radius_tool`, `get_affected_flows_tool`, `get_minimal_context_tool`, etc.) but never tell the agent that the underlying graph is persistent and can be stale. The only freshness note lived in `cheez-search` as a soft caveat and mentioned only the CLI (`code-review-graph build` / `embed`), which agents don't and shouldn't run mid-session.
- **Fix:** rewrite the cheez-search caveat as an explicit MCP-first step (`build_or_update_graph_tool`; `embed_graph_tool` when semantic search is in play) and add the same short Freshness pointer in `age`, `press`, and `cure`.
- **Bonus:** the cheez-search section now spells out when `semantic_search_nodes_tool` actually beats tilth — steel threads across renamed layers, shared concepts under divergent names, spec/code vocabulary mismatch, analog mining, cross-repo concept discovery, onboarding orientation — plus two gotchas (centrality bias toward hub nodes, default `all-MiniLM-L6-v2` nuance).

## Files

- `skills/cheez-search/SKILL.md` — canonical freshness contract + semantic-search-vs-tilth rubric.
- `skills/age/SKILL.md`, `skills/press/SKILL.md`, `skills/cure/SKILL.md` — short Freshness line under the code-review-graph row of each tool table, with skill-specific framing for when semantic search applies.

## Test plan

- [ ] Skim the new cheez-search section end-to-end; confirm tone and length match the surrounding doc.
- [ ] Verify the three anchor links from age/press/cure resolve to `#when-code-review-graph-beats-tilth-if-your-harness-has-it`.
- [ ] Sanity-check that a fresh `/age` (or `/press`, `/cure`) session now refreshes the graph before its first code-review-graph query.