### PR TITLE
fix(ci): repin codeql-action upload-sarif to commit SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,6 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - uses: github/codeql-action/upload-sarif@1521896cd211af95be3f02edf6f436e10b819c27 # v3.35.4
+      - uses: github/codeql-action/upload-sarif@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Scorecard run [#25720855708](https://github.com/paulnsorensen/easy-cheese/actions/runs/25720855708/job/75521439334) failed publishing to scorecard.dev with an `imposter commit` 400.
- The `github/codeql-action/upload-sarif` pin was the **annotated tag object** SHA (`1521896c`) for `v3.35.4`, not the underlying commit SHA. Scorecard's signature verification compares against the commit SHA and rejected it.
- Replaced with the dereferenced commit `7fd177fa680c9881b53cdab4d346d32574c9f7f4` (same `v3.35.4`).

## Test plan
- [ ] `scorecard` workflow run on merge completes successfully (no `imposter commit` error in logs)
- [ ] SARIF still uploads to the Code scanning view

🤖 Generated with [Claude Code](https://claude.com/claude-code)