### PR TITLE
docs(press): relax --auto stop conditions, add hardening-test floor

### DIFF
--- a/skills/cook/SKILL.md
+++ b/skills/cook/SKILL.md
@@ -100,7 +100,7 @@ When invoked with `--auto`, skip this `AskUserQuestion` entirely and proceed str
 ### What auto mode does
 
 1. After cook's package-ready report, invoke `/press <slug> --auto`.
-2. `/press --auto` runs its hardening pass and, if readiness is `ready for /age`, invokes `/age <slug> --auto`. If readiness is `follow-up recommended` or `blocked`, auto mode stops and surfaces the press report to the user.
+2. `/press --auto` runs its hardening pass and, if readiness is `ready for /age` or `follow-up recommended`, invokes `/age <slug> --auto`. Both states mean the cooked contract is sound and every changed behaviour has a hardening test; documented follow-ups are review-safe. Only `blocked` stops auto — false premise, unfixable level-1/2 gap, a changed behaviour with no stable hardening test, or spinning wheels (three attempts at one gap without green).
 3. `/age <slug> --auto` writes the report and invokes `/cure <slug> --auto --stake medium+`.
 4. `/cure --auto --stake medium+` bypasses the selection gate, applies every finding of `medium` or `high` stake, then invokes `/age --scope <touched-paths> --auto` for verification.
 5. The age → cure cycle is capped at **two cure passes total**. Pass 1 fixes the initial findings. Pass 2 fixes anything the re-age surfaces. After pass 2 the chain stops with a final summary, regardless of whether new findings remain.
@@ -109,7 +109,7 @@ When invoked with `--auto`, skip this `AskUserQuestion` entirely and proceed str
 ### When auto mode stops early
 
 - A quality gate (test, lint, type, build) fails and the failure cannot be attributed to a single revertible finding.
-- `/press` returns `blocked` or `follow-up recommended`.
+- `/press` returns `blocked` (false premise, unfixable level-1/2 gap, missing hardening test, or spinning wheels at three attempts).
 - A cure pass cannot apply any finding (every selected fix breaks tests on revert-or-keep evaluation).
 - Two cure passes complete (success path).
 

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -76,37 +76,36 @@ artifact: <path-if-any>
 
 ## Next step
 <ready for /age>:           /age <slug>           — review the cooked + pressed diff
-<follow-up recommended>:    address open findings, then /age <slug>
+<follow-up recommended>:    /age <slug>           — review-safe; documented follow-ups addressed after review
 <blocked>:                  resolve blocking issues before proceeding
 ```
 
-`status: ok` maps to readiness `ready for /age`; `status: halt: <reason>` maps to readiness `blocked` or `follow-up recommended` with the reason filled in. `next: age` when readiness is `ready for /age`; `next: done` when readiness is `blocked` or `follow-up recommended` so the orchestrator stops the chain.
+`status: ok` maps to readiness `ready for /age` or `follow-up recommended` (both are review-safe — the cooked contract is sound and every changed behaviour has a hardening test). `status: halt: <reason>` maps to readiness `blocked` with the reason filled in. `next: age` when readiness is `ready for /age` or `follow-up recommended`; `next: done` only when readiness is `blocked` so the orchestrator stops the chain.
 
 Then print:
 
 ```
 Press report: .cheese/press/<slug>.md
-Next step:    /age <slug>                       (when ready for /age)
-              address open findings, then /age  (when follow-up recommended)
-              blocked — resolve before continuing (when blocked)
+Next step:    /age <slug>                          (when ready for /age or follow-up recommended)
+              blocked — resolve before continuing  (when blocked)
 ```
 
 ## Handoff
 
 After the press report is on disk, ask via `AskUserQuestion` which downstream to run. Default options:
 
-- **Run /age `<slug>`** *(recommended when readiness is `ready for /age`)* — review the diff.
-- **Stop** — address `follow-up recommended` items before review.
+- **Run /age `<slug>`** *(recommended when readiness is `ready for /age` or `follow-up recommended`)* — review the diff. For `follow-up recommended`, the cooked contract is sound and every changed behaviour has a hardening test; documented follow-ups can be addressed after review.
+- **Stop** — defer review (use this if you want to harden manually before /age, even though the contract is review-safe).
 
-Pre-select `Run /age` only when readiness is `ready for /age`. If the report is `blocked`, do not pre-select anything; the user decides whether to fix or escalate.
+Pre-select `Run /age` when readiness is `ready for /age` or `follow-up recommended`. If the report is `blocked`, do not pre-select anything; the user decides whether to fix or escalate.
 
 ### Auto mode
 
 When invoked with `--auto` (propagated from `/cook --auto`):
 
 - Skip the `AskUserQuestion` entirely.
-- If readiness is `ready for /age`, invoke `/age <slug> --auto` directly.
-- If readiness is `follow-up recommended` or `blocked`, stop the auto chain and surface the press report to the user. Do not paper over a non-green press in auto mode — those statuses exist precisely because human judgement is needed.
+- If readiness is `ready for /age` or `follow-up recommended`, invoke `/age <slug> --auto` directly. Both states mean the cooked contract is sound and every changed behaviour has a hardening test; follow-ups are documented and review-safe.
+- If readiness is `blocked`, stop the auto chain and surface the press report to the user. `blocked` is reserved for cases where human judgement is genuinely required: a false premise on the cooked contract, an unfixable level-1/2 gap inside cooked scope, a changed behaviour press could not lock with a stable hardening test, or spinning wheels (three attempts at the same gap without green).
 
 ### When invoked from /ultracook
 
@@ -116,6 +115,8 @@ When invoked with `--auto` (propagated from `/cook --auto`):
 
 - Do not weaken assertions.
 - Do not broaden implementation beyond the cooked contract.
+- **Every changed behaviour in the cooked diff leaves press with an executable hardening test that would fail if the change regressed.** Even on a 3-line off-by-one fix, press writes (or confirms cook wrote) a test like `test_off_by_one_at_boundary` that locks the fix in. If press cannot produce a stable hardening test for a changed behaviour (flaky seam, missing infrastructure, design decision required), readiness is `blocked` — never `ready for /age` or `follow-up recommended`.
+- **Cap iteration at three attempts per gap.** Count test-edit + run cycles. On the third failed cycle on the same gap, mark readiness `blocked` with reason `spinning: <gap-description>` and surface the report. Do not loop indefinitely.
 - Surface medium and high findings explicitly; summarize low findings.
 - If the cooked diff or spec rests on a false premise (the contract is wrong, or the test surface is solving the wrong problem), stop and surface the premise before adding tests; do not harden the wrong angle.
 - Apply the shared voice kernel (lives at `skills/age/references/voice.md` in this repo): lead the press report with the readiness verdict, flag residual risk as `certain | speculating | don't know`, agree when coverage is already sufficient without manufacturing tests.

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: press
-description: This skill should be used right after `/cook` produces green changes, when the user wants the test surface hardened before review or shipping — phrases like "press the changes", "harden this", "check coverage", "strengthen the tests", "are the tests good enough", "press before /age", "/press". Reads the spec + cooked diff, maps changed behavior to tests, finds weak assertions and missing boundaries, adds focused hardening tests, writes a press report to `.cheese/press/<slug>.md`, and prompts `/age` next. Supports `--auto` (propagated from `/cook --auto`) to skip its handoff and chain straight into `/age --auto` when readiness is `ready for /age`. Use even when the user wants to "tighten things up" before review. Do NOT use to add broad new behavior — only corrective fixes that hardening tests force. After `/cook`; before `/age` → `/cure`.
+description: This skill should be used right after `/cook` produces green changes, when the user wants the test surface hardened before review or shipping — phrases like "press the changes", "harden this", "check coverage", "strengthen the tests", "are the tests good enough", "press before /age", "/press". Reads the spec + cooked diff, maps changed behavior to tests, finds weak assertions and missing boundaries, adds focused hardening tests, writes a press report to `.cheese/press/<slug>.md`, and prompts `/age` next. Supports `--auto` (propagated from `/cook --auto`) to skip its handoff and chain straight into `/age --auto` when readiness is `ready for /age` or `follow-up recommended`; only `blocked` halts the auto chain. Use even when the user wants to "tighten things up" before review. Do NOT use to add broad new behavior — only corrective fixes that hardening tests force. After `/cook`; before `/age` → `/cure`.
 license: MIT
 ---
 
@@ -19,7 +19,7 @@ Do not use it to implement broad new behavior. Press may add or strengthen tests
 5. **Corrective fixes** — only for defects the hardening tests expose. No new behaviour.
 6. **Run checks** — narrowest useful tests, then relevant wider gates already in the project.
 7. **Report** — write `.cheese/press/<slug>.md` (slug carried from `/cook`, or derived from branch/task) and print the path. Mark readiness: `ready for /age`, `follow-up recommended`, or `blocked`.
-8. **Hand off** — prompt the next step via `AskUserQuestion` (see `## Handoff` below). Never auto-invoke.
+8. **Hand off** — in manual mode, prompt the next step via `AskUserQuestion` (see `## Handoff` below); in `--auto` mode, chain forward per `### Auto mode`.
 
 ## Preferred tools and fallbacks
 

--- a/skills/press/references/gap-analysis.md
+++ b/skills/press/references/gap-analysis.md
@@ -37,7 +37,7 @@ Then address remaining gaps in this order — stop when the time-budget runs out
 
 Mapping to readiness:
 
-- **`blocked`** — hard floor unmet (a changed behaviour has no stable hardening test press can write), an unfixable level-1/2 gap inside cooked scope, or spinning wheels (three attempts at one gap without green).
+- **`blocked`** — false premise on the cooked contract, hard floor unmet (a changed behaviour has no stable hardening test press can write), an unfixable level-1/2 gap inside cooked scope, or spinning wheels (three attempts at one gap without green).
 - **`follow-up recommended`** — hard floor met. Only level-4/5 gaps remain, plus out-of-scope findings and untouched-code coverage. Cooked contract is review-safe; follow-ups are documented for post-review attention.
 - **`ready for /age`** — hard floor met. Levels 1-3 closed on cooked scope.
 

--- a/skills/press/references/gap-analysis.md
+++ b/skills/press/references/gap-analysis.md
@@ -25,7 +25,9 @@ For each function or module touched by the cooked diff:
 
 ## Priority order
 
-Address gaps in this order — stop when the time-budget runs out:
+**Hard floor — every changed behaviour gets a hardening test.** Before working through the priority list, lock each behaviour in the cooked diff with an executable test that would fail on regression. Even a 3-line off-by-one fix gets a `test_off_by_one_at_boundary`. If press cannot produce a stable hardening test for a changed behaviour, readiness is `blocked`.
+
+Then address remaining gaps in this order — stop when the time-budget runs out:
 
 1. **Spec compliance:** every promised behaviour has executable coverage.
 2. **Assertion strength:** tests fail for wrong values, wrong errors, or wrong state.
@@ -33,7 +35,13 @@ Address gaps in this order — stop when the time-budget runs out:
 4. **Integration seams:** filesystem, subprocess, network, time, dependency failure when in scope.
 5. **Happy path regression:** the primary user path still passes.
 
-Higher-priority gaps block; lower-priority gaps become follow-ups.
+Mapping to readiness:
+
+- **`blocked`** — hard floor unmet (a changed behaviour has no stable hardening test press can write), an unfixable level-1/2 gap inside cooked scope, or spinning wheels (three attempts at one gap without green).
+- **`follow-up recommended`** — hard floor met. Only level-4/5 gaps remain, plus out-of-scope findings and untouched-code coverage. Cooked contract is review-safe; follow-ups are documented for post-review attention.
+- **`ready for /age`** — hard floor met. Levels 1-3 closed on cooked scope.
+
+Spinning-wheels cap: count test-edit + run cycles per gap. On the third failed attempt without green, mark readiness `blocked` with reason `spinning: <gap-description>` and stop.
 
 ## When to fix vs follow-up
 

--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -122,7 +122,7 @@ For phases that already write rich reports (`/age`, `/press`, `/cure` once exten
 `/ultracook` stops and surfaces the report when:
 
 - A phase's slug file is missing after the sub-agent returns (the sub-agent did not write its handoff — print "phase did not write handoff — check sub-agent logs").
-- A phase writes `status: halt: <reason>` (a quality gate failed, press came back `blocked` or `follow-up recommended`, cure could not apply any finding).
+- A phase writes `status: halt: <reason>` (a quality gate failed, press came back `blocked`, cure could not apply any finding).
 - An age phase writes `next: done` because the diff is clean at the medium+ floor (early-stop). Note: this only fires from age spawns; cure always writes `next: age` and cap-enforcement does not flow through `next: done` (the chain length handles that — see `### Cap enforcement` above).
 
 In every early-stop case, surface the slug file path so the user can read the full report. The natural terminal case (chain table exhausted after spawn #7) does not need an explicit early-stop signal — the orchestrator simply runs out of entries to spawn.


### PR DESCRIPTION
## What changed

`/press --auto` now flows to `/age --auto` on both `ready for /age` and `follow-up recommended` (only `blocked` halts), but readiness now requires every changed behaviour to leave press with an executable hardening test that would fail on regression, with `blocked` triggered by false premise, unfixable level-1/2 gap, missing hardening test, or spinning wheels (three attempts on one gap without green).

## Why

`follow-up recommended` mostly covers gaps press is forbidden to touch (out-of-scope bugs, untouched-code coverage) — stopping `--auto` there halted the chain without anything constructive happening, while the new floor keeps user confidence by ensuring the cooked contract is genuinely test-locked before age sees it.

## How to verify

Re-read `skills/press/SKILL.md`, `skills/press/references/gap-analysis.md`, and the auto-mode cross-references in `skills/cook/SKILL.md`.

## Risk / rollout notes

Behavioural change to the `/cook --auto → /press → /age → /cure` chain — in-flight `--auto` runs will continue further than before once this lands. Markdown-only, no code or test changes.

## Checklist

- [x] Conventional Commits PR title (`docs(press):`)
- [x] Tests added or updated (N/A — markdown-only)
- [x] Documentation updated (this IS the documentation)
- [x] No secrets or credentials added