### PR TITLE
chore: align infrastructure with skillz-that-grillz baseline

### DIFF
--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,55 @@
+---
+applyTo: ".github/scripts/**/*.py,tests/python/**/*.py"
+---
+
+# Python review checklist (skill validators + melt script tests)
+
+Two Python surfaces live in this repo:
+
+- `.github/scripts/` — CI validators (`validate_skills.py` + `test_validate_skills.py`).
+  These run on `python3` from the GitHub Actions runner with `pyyaml` as
+  the only third-party dependency. No virtualenv, no `uv`.
+- `tests/python/` — pytest suite covering the `melt` skill's helper
+  scripts (`conflict_pick`, `conflict_summary`, `batch_resolve`, etc.).
+  Runs under `pytest` with stdlib-style fixtures via `conftest.py`.
+
+## Hard rules
+
+- **Dependencies are pinned in `validate.yml`.** The only allowed
+  third-party imports are `pyyaml` (validators) and `pytest` (tests). Push
+  back on PRs that pull in `requests`, `pydantic`, `pandas`, etc. — every
+  new dep means a bootstrap step in CI and another supply-chain edge.
+- **Python 3.12 baseline.** CI pins `python-version: "3.12"`. Don't reach
+  for 3.13+ features without updating `validate.yml` first; don't write
+  3.8-compatible code "to be safe" either — the runner is fixed.
+- **No filesystem writes from validators.** `.github/scripts/` files read
+  and report; they never mutate the tree. A PR that adds autofix logic
+  belongs in a separate skill or script, not in `validate_skills.py`.
+- **Exit-code propagation is load-bearing.** Validators and pytest must
+  exit non-zero on failure, or CI silently passes. `except Exception:`
+  without re-raising or `sys.exit(1)` is a bug, not a style issue.
+
+## What to flag
+
+- New top-level functions over 40 lines — decompose.
+- Bare `except:` or `except Exception:` that swallows errors in either
+  surface. Validators must fail loud; tests must surface failures cleanly.
+- Tests in `tests/python/*.py` or `test_validate_skills.py` that don't
+  actually assert on observable behavior — `assert True` after a
+  `try/except` block is not a test.
+- pytest tests that depend on filesystem state outside `tmp_path` or
+  network access. Both make CI flaky.
+- Hard-coded paths that escape the repo root (e.g. `/Users/...`,
+  `os.path.expanduser("~/Dev/...")`). Use `Path(__file__).resolve()` or
+  pytest's `tmp_path` / `monkeypatch.chdir`.
+
+## What not to flag
+
+- Missing type hints on internal helpers. Annotate function boundaries; let
+  inference handle the rest.
+- Missing docstrings on private functions with clear names.
+- f-string vs `.format()` style preferences.
+- Anything `ruff` or `mypy` would catch — this repo doesn't run them, and
+  introducing them is a separate decision.
+- pytest fixtures defined in `conftest.py` instead of inline. That's the
+  conventional location and reviewers shouldn't relitigate it.

--- a/.github/instructions/shell.instructions.md
+++ b/.github/instructions/shell.instructions.md
@@ -1,0 +1,58 @@
+---
+applyTo: "scripts/**/*.sh,tests/bash/**/*.bats"
+---
+
+# Shell review checklist (install script and bats tests)
+
+`scripts/install.sh` is the only entry point most users see. `tests/bash/`
+exercises it under bats. ShellCheck runs in CI (`just lint-sh`), so don't
+spend review budget on lint nits — focus on behavior.
+
+## Hard rules
+
+- `set -euo pipefail` at the top of any new shell script. Missing it is a
+  blocker, not a nit.
+- Quote every expansion: `"$var"`, `"${arr[@]}"`. Unquoted `$var` in a
+  filename or path is a security finding, not a style one.
+- `[[ ... ]]` over `[ ... ]`. Bash-only repo, no POSIX-sh constraint.
+- Use `printf` for any output that contains user-supplied data or escape
+  sequences. Reserve `echo` for literal static strings.
+- New external commands (`curl`, `jq`, `bats`, `brew`, etc.) need a preflight
+  check with a clear error message — don't let the script die three lines
+  later on `command not found`.
+
+## What to flag
+
+- Functions over ~30 lines or scripts over ~500 lines without decomposition.
+- Network calls without timeout flags (`curl --max-time`, `--connect-timeout`).
+- `eval` or `bash -c "$var"` — almost always avoidable, almost always a
+  vulnerability when `$var` touches user input.
+- `rm -rf "$var"` without guarding against empty `$var`. Use
+  `rm -rf -- "${var:?}"` or check first.
+- Silent failures in `install.sh` — every failed step should print what
+  failed and exit non-zero. This is the user's first impression of the
+  repo; a half-installed state is worse than a clean abort.
+- bats tests that exercise the happy path only. Each new flag or branch in
+  `install.sh` should have a failure-mode test in `test_install.bats`.
+
+## What not to flag
+
+- Anything ShellCheck already catches (SC2086, SC2046, etc.) — CI runs it.
+- `local` placement, alignment, double-vs-single quote on static strings.
+- Cheese / Dune / Mad Max / LOTR / Princess Bride flavor in user-facing
+  `echo` lines. Intentional repo voice.
+- Bashism vs POSIX-sh portability — this is a Bash repo.
+
+## bats specifics
+
+- Each `@test` does one thing. Name the test after the behavior, not the
+  function: `@test "install fails fast when curl missing"`, not
+  `@test "test_check_deps"`.
+- Use `run` for the command under test, then assert on `$status` and
+  `$output` — don't assert before `run` returns.
+- Stub external commands (`curl`, `brew`, `claude`, `gh`) via `PATH`
+  injection or helper wrappers. A bats test that actually hits the network
+  or shells out to real `brew` is a flake waiting to happen.
+- The real-install smoke test in `validate.yml` (the `--skip-mcp` job)
+  intentionally bypasses stubs to catch breakage in upstream package
+  resolution. Don't add stubbing there; do add it to `test_install.bats`.

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,36 @@
+name: Request Copilot review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-copilot-review:
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.user.type != 'Bot' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request Copilot review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          if gh pr edit "$PR_NUMBER" --repo "$REPO" --add-reviewer Copilot 2>/dev/null; then
+            echo "Copilot review requested via gh CLI"
+            exit 0
+          fi
+
+          echo "gh CLI path failed; trying REST API fallback"
+          if gh api "repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
+              -X POST \
+              -f "reviewers[]=copilot-pull-request-reviewer" 2>/dev/null; then
+            echo "Copilot review requested via REST API"
+            exit 0
+          fi
+
+          echo "::warning::Could not request Copilot review — ensure Copilot is enabled for this repo (Settings → Code & automation → Code review)"

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,8 @@
+formatter:
+  type: basic
+  retain_line_breaks_single: true
+  scan_folded_as_literal: true
+  trim_trailing_whitespace: true
+  eof_newline: true
+  indent: 2
+  include_document_start: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Agent Instructions for easy-cheese
+
+This document is for LLMs, agents, and automation tools working in this repository.
+
+## Single Quality Gate: `just check`
+
+**Before shipping any work (commit, PR, or merge), run `just check` and verify 0 errors/failures.**
+
+`just check` autofixes lint and runs tests. CI runs `just ci` (same checks, no autofixes).
+
+```bash
+just check
+```
+
+Do NOT commit or push when `just check` fails. If CI fails, pull the branch locally, run `just check`, commit the autofixes, and push.
+
+## Skills in this repo
+
+This is a skills-only collection following the [Agent Skills spec](https://agentskills.io/specification). Every change either adds, edits, or supports a skill under `skills/<name>/`.
+
+### Workflow skills (the cheese pipeline)
+
+| Skill | Purpose |
+|---|---|
+| `/cheese` | Unified entry — classifies input and routes to the right downstream skill |
+| `/mold` | Iterative dialogue to converge a fuzzy idea into an approved spec |
+| `/culture` | Deep no-write exploration of a codebase or topic |
+| `/cook` | TDD-disciplined implementation of an approved spec |
+| `/press` | Adversarial test hardening after `/cook` |
+| `/age` | Eight-dimension code review producing a stake-grouped findings report |
+| `/cure` | Applies selected `/age` findings as focused fixes |
+| `/melt` | Resolves merge / rebase / cherry-pick conflicts via the structural-merge cascade |
+| `/briesearch` | External research router (Context7, Tavily, gh, local code) |
+
+### Tool skills (lower-level primitives)
+
+| Skill | Purpose |
+|---|---|
+| `/cheez-search` | AST-aware search via tilth MCP — replaces grep / rg / ripgrep |
+| `/cheez-read` | Smart-outlining file reader via tilth MCP — replaces cat / head / tail |
+| `/cheez-write` | Batched edit writer via tilth MCP — replaces inline Edit / Write |
+| `/ultracook` | Composite workflow chaining `/cook` → `/press` → `/age` → `/cure` |
+
+See `README.md` for the full workflow and the suggested skill ordering.
+
+## Development notes
+
+- Python validators in `.github/scripts/` allow only `pyyaml` and `pytest` as third-party deps — see `.github/instructions/python.instructions.md`.
+- Shell scripts and bats tests follow the rules in `.github/instructions/shell.instructions.md`.
+- `cheez-*` skills require [tilth MCP](https://github.com/paulnsorensen/tilth) and hard-fail without it. Every other skill stays portable and degrades to host-native tools.
+- SKILL.md files must pass `validate_skills.py` (YAML frontmatter validation).
+- Conventional Commits format for all commits and PR titles (enforced by `validate.yml` for PRs).
+- Cheese / Dune / Mad Max / LOTR / Princess Bride flavor is welcome in user-facing docs and `SKILL.md` files. Keep commit messages and YAML frontmatter neutral.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,38 @@
+set dotenv-load := true
+
+# List all available commands
+@default:
+    just --list
+
+# Run all tests (skill validators + melt pytest suite + bash install tests)
+test:
+    python3 .github/scripts/test_validate_skills.py -v
+    python3 .github/scripts/validate_skills.py
+    python3 -m pytest tests/python -q
+    bats tests/bash/test_install.bats
+
+# Lint shell scripts
+lint-sh:
+    shellcheck scripts/install.sh
+
+# Fix markdown formatting issues
+lint-md-fix:
+    markdownlint-cli2 --fix "skills/**/*.md" "*.md"
+
+# Verify markdown (no autofix)
+lint-md:
+    markdownlint-cli2 "skills/**/*.md" "*.md"
+
+# Fix YAML formatting issues
+lint-yaml-fix:
+    yamlfmt .
+
+# Verify YAML formatting
+lint-yaml:
+    yamllint -c .yamllint.yml .
+
+# Full local check with autofixes
+check: lint-md-fix lint-yaml-fix lint-yaml lint-sh test
+
+# CI-mode verification (no autofixes)
+ci: lint-md lint-yaml lint-sh test


### PR DESCRIPTION
## Summary

Align easy-cheese infrastructure with skillz-that-grillz (just pulled):

- **Path-scoped Copilot review instructions** (`.github/instructions/*.md`) for Python validators and shell scripts — Copilot now gives context-aware review guidance per file pattern
- **Unified quality gate** (`justfile`) — `just check` (autofix) and `just ci` (verify) wrap all linters + tests
- **AGENTS.md** — Quality-gate reference for non-Claude agents (Codex, Gemini, custom)
- **YAML formatter config** (`.yamlfmt`) — pairs with justfile for autofix support
- **Copilot auto-review workflow** — GitHub Actions auto-requests Copilot as reviewer on every PR open/reopen

## What changed

- Added `.github/instructions/python.instructions.md` (2.7 KB) — rules for `.github/scripts/` + `tests/python/`
- Added `.github/instructions/shell.instructions.md` (2.7 KB) — rules for `scripts/` + `tests/bash/`
- Added `.github/workflows/copilot-review.yml` — requests Copilot review via gh CLI + REST API fallback
- Added `justfile` (886 B) — runs validators + pytest + bats + linters
- Added `AGENTS.md` (2.7 KB) — references the workflow (mold → cook → age → cure) for agent onboarding
- Added `.yamlfmt` (187 B) — YAML autoformatter config

## Test plan

✅ All files lint clean (yamllint, markdownlint via CI)
✅ Justfile recipes parse and callable
✅ Test recipe runs: validators + pytest + bats
✅ `just check` with autofixes, `just ci` verify-only
✅ Copilot workflow: skips drafts, requests review on open/reopen
✅ Path-scoped Copilot instructions ready for agent-assisted reviews

## Next

- Merge to activate `just check` as the pre-ship quality gate
- PR reviews will include Copilot's automated pass
- Developers use `just check` locally before push

🧀 Generated with [Claude Code](https://claude.com/claude-code)