### PR TITLE
fix: replace custom FUNDING URL with canonical buy_me_a_coffee key

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ["https://buymeacoffee.com/paulnsorensen"]
+buy_me_a_coffee: paulnsorensen


### PR DESCRIPTION
## Summary
Replace the generic `custom:` URL in `.github/FUNDING.yml` with GitHub's canonical `buy_me_a_coffee: paulnsorensen` key. This ensures the Sponsor dropdown renders the official Buy Me a Coffee entry with proper icon and label, rather than a generic link.

## Changes
- Commit: 5c5c016
- File: `.github/FUNDING.yml`
- Swaps custom URL for native BMC support

## Test plan
- Verify the Sponsor dropdown on the repo home now shows the official Buy Me a Coffee entry with correct icon/label