### PR TITLE
fix(install): tolerate per-skill install failures from release lag

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,7 +28,7 @@ EC_SKILL_REPO="paulnsorensen/easy-cheese"
 # new skills land — this list is only used when the API call is
 # unavailable (offline, rate-limited, repo temporarily private). Kept
 # loosely in sync with skills/ but not load-bearing for happy-path runs.
-EC_FALLBACK_SKILLS="age briesearch cheese cheez-read cheez-search cheez-write cook culture cure melt mold press ultracook"
+EC_FALLBACK_SKILLS="age briesearch cheese cheez-read cheez-search cheez-write cook culture cure hard-cheese melt mold press ultracook"
 
 # Default selections.
 EC_DEFAULT_TOOLS="$EC_KNOWN_TOOLS"
@@ -469,9 +469,12 @@ ec_discover_skills() {
 # live skill list via 'gh api ... contents/skills' and call gh once per
 # skill with --force for idempotent re-runs. If discovery fails we fall
 # back to EC_FALLBACK_SKILLS so the installer still does something useful
-# offline. Per-skill install failures are warned and tracked but do not
-# abort the rest of the loop. Dry-run skips discovery and uses the
-# embedded list for predictable, network-free output.
+# offline. Per-skill install failures warn but do not abort the script —
+# discovery reads from the default branch, so newly-added skills may not
+# yet exist at the latest release tag. We only return non-zero if every
+# skill failed (catastrophic, e.g. gh unauthenticated). Dry-run skips
+# discovery and uses the embedded list for predictable, network-free
+# output.
 ec_install_skills() {
     local harness="$1"
     local gh="${EC_GH:-gh}"
@@ -494,19 +497,24 @@ ec_install_skills() {
         fi
     fi
 
-    local skill rc=0
+    local skill installed=0 failed=0
     for skill in $skills; do
         if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
             ec_log "easy-cheese skills: would run '$gh skill install $EC_SKILL_REPO $skill --agent $harness --scope user --force'"
             continue
         fi
         ec_log "easy-cheese skills: installing $skill into $harness (user scope)"
-        if ! "$gh" skill install "$EC_SKILL_REPO" "$skill" --agent "$harness" --scope user --force; then
-            ec_warn "easy-cheese skills: failed to install $skill"
-            rc=1
+        if "$gh" skill install "$EC_SKILL_REPO" "$skill" --agent "$harness" --scope user --force; then
+            installed=$((installed + 1))
+        else
+            ec_warn "easy-cheese skills: failed to install $skill (not yet in latest release?)"
+            failed=$((failed + 1))
         fi
     done
-    return $rc
+    if (( installed == 0 && failed > 0 )); then
+        return 1
+    fi
+    return 0
 }
 
 # Parse argv into the EC_* config variables. Echoes nothing on success;

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -647,7 +647,7 @@ STUB
     grep -q "^gh skill install paulnsorensen/easy-cheese age --agent claude-code --scope user --force$" "$STUB_LOG"
     grep -q "^gh skill install paulnsorensen/easy-cheese press --agent claude-code --scope user --force$" "$STUB_LOG"
     grep -q "^gh skill install paulnsorensen/easy-cheese ultracook --agent claude-code --scope user --force$" "$STUB_LOG"
-    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 13 ]
+    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 14 ]
 }
 
 @test "ec_install_skills falls back to embedded list when gh api returns empty" {
@@ -657,17 +657,18 @@ STUB
     run ec_install_skills claude-code
     [ "$status" -eq 0 ]
     [[ "$output" == *"using embedded fallback list"* ]]
-    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 13 ]
+    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 14 ]
 }
 
-@test "ec_install_skills returns non-zero when any skill install fails" {
+@test "ec_install_skills warns but returns 0 when some skill installs fail" {
     cat > "$STUB_BIN/gh" <<'STUB'
 #!/usr/bin/env bash
 echo "gh $*" >> "$STUB_LOG"
 case "$1" in
     api) printf 'alpha\nbeta\ngamma\n'; exit 0 ;;
 esac
-# Auth ok, but fail when installing the 'beta' skill.
+# Auth ok, but fail when installing the 'beta' skill — simulates a
+# newly-added skill that isn't yet in the latest release tag.
 if [[ "$1" == "skill" && "$2" == "install" && "$4" == "beta" ]]; then
     exit 1
 fi
@@ -676,10 +677,30 @@ STUB
     chmod +x "$STUB_BIN/gh"
     export EC_GH="$STUB_BIN/gh"
     run ec_install_skills claude-code
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 0 ]
     [[ "$output" == *"failed to install beta"* ]]
     # Loop kept going past the failure — every other skill was still attempted.
     [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 3 ]
+}
+
+@test "ec_install_skills returns 1 when every skill install fails" {
+    cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "$STUB_LOG"
+case "$1" in
+    api) printf 'alpha\nbeta\ngamma\n'; exit 0 ;;
+    auth) exit 0 ;;
+esac
+# Every skill install fails — catastrophic (gh broken, repo gone, etc.)
+exit 1
+STUB
+    chmod +x "$STUB_BIN/gh"
+    export EC_GH="$STUB_BIN/gh"
+    run ec_install_skills claude-code
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"failed to install alpha"* ]]
+    [[ "$output" == *"failed to install beta"* ]]
+    [[ "$output" == *"failed to install gamma"* ]]
 }
 
 # -- ec_install_mcp -----------------------------------------------------------
@@ -807,8 +828,8 @@ STUB
     grep -q "^tilth install claude-code --edit$" "$STUB_LOG"
     grep -q "^gh skill install paulnsorensen/easy-cheese age --agent claude-code --scope user --force$" "$STUB_LOG"
     grep -q "^gh skill install paulnsorensen/easy-cheese press --agent claude-code --scope user --force$" "$STUB_LOG"
-    # 13 skill installs total, no broken --all flag.
-    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 13 ]
+    # 14 skill installs total, no broken --all flag.
+    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 14 ]
     # No brew calls should have happened.
     ! grep -q "^brew" "$STUB_LOG" || false
 }


### PR DESCRIPTION
## Summary

The CI \`validate\` workflow has been red on main since \`hard-cheese\` merged via #37 — the \`test install.sh (macOS)\` smoke test fails because \`scripts/install.sh\` discovers skills from main's contents but installs from the latest release tag (\`v0.0.6\`, pre-\`hard-cheese\`). Every per-skill install failure used to set \`rc=1\` and propagate up through \`set -e\`, failing the whole script even when every released skill installed cleanly.

## What changed

- **\`ec_install_skills\` semantics**: track \`installed\` and \`failed\` counts separately. Return non-zero only when every attempted install fails (catastrophic — gh broken, repo missing). Partial failures warn but exit 0.
- **Warning text**: \"failed to install \$skill\" → \"failed to install \$skill (not yet in latest release?)\" — surfaces the likely cause inline.
- **\`EC_FALLBACK_SKILLS\`**: added \`hard-cheese\` so the offline fallback path doesn't silently miss it.
- **Tests**: renamed the partial-failure test to assert exit 0; added a new test for the catastrophic-failure case (every install fails → exit 1); bumped the three \`-eq 13\` count assertions to \`14\` for the new fallback list size.

Now this matches the docstring's stated intent: \"Per-skill install failures warn but do not abort the script — discovery reads from the default branch, so newly-added skills may not yet exist at the latest release tag.\"

## Test plan

- [x] \`bats tests/bash/test_install.bats\` — all 80 tests pass locally
- [x] \`shellcheck scripts/install.sh\` clean
- [ ] CI \`validate\` workflow goes green on this PR
- [ ] Once merged, CI on main goes green without needing to cut a new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)