### PR TITLE
fix(ci): pin smoke-test skill installs to the commit under test

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -77,6 +77,11 @@ jobs:
       - name: Real install smoke test (--skip-mcp)
         env:
           GH_TOKEN: ${{ github.token }}
+          # Pin every skill install to the commit under test so the smoke
+          # test exercises the script against this PR / push, not against
+          # the latest released tag (which can lag behind main when new
+          # skills are added).
+          EC_SKILL_REF: ${{ github.event.pull_request.head.sha || github.sha }}
         run: bash scripts/install.sh --skip-mcp
 
       # Real install of the code-review-graph CLI with the [embeddings]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,7 +28,7 @@ EC_SKILL_REPO="paulnsorensen/easy-cheese"
 # new skills land — this list is only used when the API call is
 # unavailable (offline, rate-limited, repo temporarily private). Kept
 # loosely in sync with skills/ but not load-bearing for happy-path runs.
-EC_FALLBACK_SKILLS="age briesearch cheese cheez-read cheez-search cheez-write cook culture cure melt mold press ultracook"
+EC_FALLBACK_SKILLS="age briesearch cheese cheez-read cheez-search cheez-write cook culture cure hard-cheese melt mold press ultracook"
 
 # Default selections.
 EC_DEFAULT_TOOLS="$EC_KNOWN_TOOLS"
@@ -88,6 +88,9 @@ Environment:
   EC_NPX               Override npx (used to launch context7 / tavily MCP).
   EC_UV     EC_PIPX    Override uv / pipx for code-review-graph install.
   EC_PIP    EC_CRG     Override pip / code-review-graph binaries.
+  EC_SKILL_REF         Pin skill installs to a git tag or commit SHA
+                       (passes --pin to 'gh skill install'). Used by CI
+                       to test against the commit under review.
 USAGE
 }
 
@@ -472,6 +475,12 @@ ec_discover_skills() {
 # offline. Per-skill install failures are warned and tracked but do not
 # abort the rest of the loop. Dry-run skips discovery and uses the
 # embedded list for predictable, network-free output.
+#
+# Set EC_SKILL_REF=<tag-or-sha> to pin every install to a specific git
+# ref (passes --pin to gh skill install). Used by CI so the smoke test
+# exercises the install script against the commit being tested rather
+# than the latest released tag. End users leave it unset to get the
+# latest release.
 ec_install_skills() {
     local harness="$1"
     local gh="${EC_GH:-gh}"
@@ -494,14 +503,18 @@ ec_install_skills() {
         fi
     fi
 
-    local skill rc=0
+    local skill rc=0 ref="${EC_SKILL_REF:-}" pin_log=""
+    [[ -n "$ref" ]] && pin_log=" --pin $ref"
     for skill in $skills; do
+        local cmd=("$gh" skill install "$EC_SKILL_REPO" "$skill")
+        [[ -n "$ref" ]] && cmd+=(--pin "$ref")
+        cmd+=(--agent "$harness" --scope user --force)
         if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-            ec_log "easy-cheese skills: would run '$gh skill install $EC_SKILL_REPO $skill --agent $harness --scope user --force'"
+            ec_log "easy-cheese skills: would run '$gh skill install $EC_SKILL_REPO $skill$pin_log --agent $harness --scope user --force'"
             continue
         fi
         ec_log "easy-cheese skills: installing $skill into $harness (user scope)"
-        if ! "$gh" skill install "$EC_SKILL_REPO" "$skill" --agent "$harness" --scope user --force; then
+        if ! "${cmd[@]}"; then
             ec_warn "easy-cheese skills: failed to install $skill"
             rc=1
         fi

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -647,7 +647,7 @@ STUB
     grep -q "^gh skill install paulnsorensen/easy-cheese age --agent claude-code --scope user --force$" "$STUB_LOG"
     grep -q "^gh skill install paulnsorensen/easy-cheese press --agent claude-code --scope user --force$" "$STUB_LOG"
     grep -q "^gh skill install paulnsorensen/easy-cheese ultracook --agent claude-code --scope user --force$" "$STUB_LOG"
-    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 13 ]
+    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 14 ]
 }
 
 @test "ec_install_skills falls back to embedded list when gh api returns empty" {
@@ -657,7 +657,31 @@ STUB
     run ec_install_skills claude-code
     [ "$status" -eq 0 ]
     [[ "$output" == *"using embedded fallback list"* ]]
-    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 13 ]
+    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 14 ]
+}
+
+@test "ec_install_skills passes --pin when EC_SKILL_REF is set" {
+    cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "gh $*" >> "$STUB_LOG"
+case "$1" in
+    api) printf 'alpha\nbeta\n'; exit 0 ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUB_BIN/gh"
+    EC_GH="$STUB_BIN/gh" EC_SKILL_REF="abc123def" run ec_install_skills claude-code
+    [ "$status" -eq 0 ]
+    # --pin should be threaded into every install call, slotted before --agent.
+    grep -q "^gh skill install paulnsorensen/easy-cheese alpha --pin abc123def --agent claude-code --scope user --force$" "$STUB_LOG"
+    grep -q "^gh skill install paulnsorensen/easy-cheese beta --pin abc123def --agent claude-code --scope user --force$" "$STUB_LOG"
+}
+
+@test "ec_install_skills dry-run echoes --pin in the would-run line when EC_SKILL_REF is set" {
+    make_stub gh
+    EC_GH="$STUB_BIN/gh" EC_SKILL_REF="v1.2.3" EC_DRY_RUN=1 run ec_install_skills claude-code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--pin v1.2.3"* ]]
 }
 
 @test "ec_install_skills returns non-zero when any skill install fails" {
@@ -807,8 +831,8 @@ STUB
     grep -q "^tilth install claude-code --edit$" "$STUB_LOG"
     grep -q "^gh skill install paulnsorensen/easy-cheese age --agent claude-code --scope user --force$" "$STUB_LOG"
     grep -q "^gh skill install paulnsorensen/easy-cheese press --agent claude-code --scope user --force$" "$STUB_LOG"
-    # 13 skill installs total, no broken --all flag.
-    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 13 ]
+    # 14 skill installs total, no broken --all flag.
+    [ "$(grep -c '^gh skill install ' "$STUB_LOG")" -eq 14 ]
     # No brew calls should have happened.
     ! grep -q "^brew" "$STUB_LOG" || false
 }


### PR DESCRIPTION
## Summary

CI \`validate\` has been red on main since #37 — \`test install.sh (macOS)\` fails because \`scripts/install.sh\` discovers skills from main but installs from the latest release tag (\`v0.0.6\`, pre-\`hard-cheese\`). One missing skill flips \`rc=1\`, and the smoke test paints red even though the install script itself is correct.

Replaces #41 (closed) — that PR's approach silently tolerated install failures for all users, which would mask real bugs in production installs.

## What changed

- **\`install.sh\`** — new \`EC_SKILL_REF\` env var. When set, threads \`--pin <ref>\` into every \`gh skill install\` call. \`gh skill install\`'s \`--pin\` accepts a git tag or commit SHA (per its \`--help\`).
- **\`validate.yml\`** — the smoke-test step now sets \`EC_SKILL_REF: \${{ github.event.pull_request.head.sha || github.sha }}\`, so CI installs the actual code under test for both PR and push events.
- **\`EC_FALLBACK_SKILLS\`** — added \`hard-cheese\` so the offline fallback path doesn't silently miss it.
- **Tests** — bumped three \`-eq 13\` count assertions to \`14\`; added a test that asserts \`--pin\` is threaded in when \`EC_SKILL_REF\` is set; added a dry-run test that the \`would-run\` log line includes \`--pin\`.

End users running \`curl … | bash\` leave \`EC_SKILL_REF\` unset and continue to get the latest release with the original loud-failure semantics — no behavior change for them. The change is scoped to CI.

## Test plan

- [x] \`bats tests/bash/test_install.bats\` — all 81 tests pass locally
- [x] \`shellcheck scripts/install.sh\` clean
- [x] \`yamllint .github/workflows/validate.yml\` clean
- [ ] CI \`validate\` on this PR goes green (the smoke test will install from this PR's head sha)
- [ ] After merge, CI on main goes green without needing a new release

🤖 Generated with [Claude Code](https://claude.com/claude-code)