### PR TITLE
feat(melt): detect squash-merge residue and add batch-resolve --debug

### DIFF
--- a/skills/melt/SKILL.md
+++ b/skills/melt/SKILL.md
@@ -46,7 +46,7 @@ If the verdict is `SQUASH-MERGED`, surface the printed remedy to the user verbat
 
 Verdict semantics:
 
-- `SQUASH-MERGED` (via `gh-api`) — PR found; cherry-pick list from PR commits (prints a warn if no SHAs matched — verify before running remedy).
+- `SQUASH-MERGED` (via `gh-api`) — PR found and at least one local commit's SHA matched the PR; cherry-pick list derived from the unmatched (post-squash) commits.
 - `SQUASH-MERGED` (via `local-synth`) — detected offline; cherry-pick list must be reviewed by hand.
 - `not-detected` — proceed to the cascade.
 - `not-applicable` — on the base branch.

--- a/skills/melt/SKILL.md
+++ b/skills/melt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: melt
-description: This skill should be used when a git merge, rebase, or cherry-pick has produced conflicts and the user wants them resolved — phrases like "melt the conflicts", "fix the merge conflicts", "resolve the rebase conflicts", "what's conflicting after the merge", "/melt", "fix the cherry-pick", or any prompt that surfaces `<<<<<<<` markers, `CONFLICT (...)` git output, or a half-finished merge state. Runs the structural-merge cascade — mergiraf (AST-aware auto-resolve) → git rerere (replay remembered fixes) → kdiff3 (manual fallback) — with helper scripts for batch resolution, ours/theirs picks, and lockfile regeneration. Use even when only one file is conflicting if the user wants the structural pass attempted before manual editing. Do NOT use for general git operations without conflicts. After `/cook` or `/cure` if a merge step blocked them; before retrying the gate that surfaced the conflict.
+description: This skill should be used when a git merge, rebase, or cherry-pick has produced conflicts and the user wants them resolved — phrases like "melt the conflicts", "fix the merge conflicts", "resolve the rebase conflicts", "what's conflicting after the merge", "/melt", "fix the cherry-pick", or any prompt that surfaces `<<<<<<<` markers, `CONFLICT (...)` git output, or a half-finished merge state. First checks for squash-merge residue (rebase doomed by a squash-merged PR — abort and re-cherry-pick), then runs the structural-merge cascade — mergiraf (AST-aware auto-resolve) → git rerere (replay remembered fixes) → kdiff3 (manual fallback) — with helper scripts for batch resolution, ours/theirs picks, and lockfile regeneration. Use even when only one file is conflicting if the user wants the structural pass attempted before manual editing. Do NOT use for general git operations without conflicts. After `/cook` or `/cure` if a merge step blocked them; before retrying the gate that surfaced the conflict.
 license: MIT
 ---
 
@@ -30,9 +30,30 @@ The bash-driven flows below cover the bulk of resolution. Drop into the cheez-* 
 
 ## Protocol
 
+### 0. Squash-residue check
+
+Run this before the conflict summary. If the branch was squash-merged into base, mergiraf cannot help — the right answer is to abort and re-cherry-pick the unique commits.
+
+```bash
+python3 skills/melt/scripts/detect-squash-residue.py
+```
+
+If the verdict is `SQUASH-MERGED`, surface the printed remedy to the user verbatim and stop the cascade. The remedy is destructive (`git reset --hard`) and must be copy-pasted by the user, not auto-applied. Flags:
+
+- `--base` — base ref to compare against (default: `origin/main`).
+- `--branch` — branch to check (default: current).
+- `--json` — structured output for scripting.
+
+Verdict semantics:
+
+- `SQUASH-MERGED` (via `gh-api`) — PR found; cherry-pick list is exact.
+- `SQUASH-MERGED` (via `local-synth`) — detected offline; cherry-pick list must be reviewed by hand.
+- `not-detected` — proceed to the cascade.
+- `not-applicable` — on the base branch.
+
 ### 1. Diagnose
 
-Run the summary script first; it replaces ad-hoc `grep -n '<<<<<<<'` parsers and is shaped for low-token output.
+Run the summary script next; it replaces ad-hoc `grep -n '<<<<<<<'` parsers and is shaped for low-token output.
 
 ```bash
 python3 skills/melt/scripts/conflict-summary.py
@@ -66,20 +87,16 @@ python3 skills/melt/scripts/batch-resolve.py --apply
 python3 skills/melt/scripts/batch-resolve.py --verbose
 ```
 
-To inspect what mergiraf would produce for a single file without touching the working copy:
+To inspect what mergiraf would produce for a single file without touching the working copy, use `--debug`:
 
 ```bash
-git show :1:<path> > /tmp/base
-git show :2:<path> > /tmp/ours
-git show :3:<path> > /tmp/theirs
-mergiraf merge /tmp/base /tmp/ours /tmp/theirs -o /tmp/merged -p <path>
-grep -c '<<<<<<' /tmp/merged    # 0 = clean
+python3 skills/melt/scripts/batch-resolve.py --debug <path>
 ```
 
-If the merged output is clean, apply it:
+The script extracts the three stages, runs mergiraf with `RUST_LOG=mergiraf=debug`, keeps the tempdir, and prints paths to the merged output, the log, and the conflict-marker count. Inspect with `cat`/`diff` against the printed paths. If the merged output is clean, apply it:
 
 ```bash
-cp /tmp/merged <path>
+cp <merged_path> <path>
 git add <path>
 ```
 
@@ -142,11 +159,10 @@ Supports `Cargo.lock`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `poet
 
 ### 6. Debug mergiraf
 
-When mergiraf is not resolving something it should:
+When mergiraf is not resolving something it should, use `--debug` for a single-file inspection (keeps the tempdir, captures `RUST_LOG=mergiraf=debug`):
 
 ```bash
-RUST_LOG=mergiraf=debug mergiraf merge /tmp/base /tmp/ours /tmp/theirs \
-    -o /tmp/merged -p <path> 2>&1
+python3 skills/melt/scripts/batch-resolve.py --debug <path>
 
 mergiraf languages | grep <extension>   # is the type registered?
 git check-attr merge -- <path>          # should show: merge: mergiraf
@@ -174,7 +190,8 @@ ls .git/rr-cache/              # browse the resolution database
 
 | Script | Purpose | When |
 | --- | --- | --- |
-| `conflict-summary.py` | Structured summary with line numbers and context | **Run first** |
+| `detect-squash-residue.py` | Detect that the branch was squash-merged and emit the abort+cherry-pick remedy | **Run first** — short-circuits the cascade |
+| `conflict-summary.py` | Structured summary with line numbers and context | After residue check |
 | `batch-resolve.py` | Run `mergiraf merge` over every conflicted file | Supported languages |
 | `conflict-pick.py` | Choose ours / theirs per hunk | Shell, SQL, formats mergiraf does not parse |
 | `lockfile-resolve.py` | Take one side and regenerate the lockfile | `Cargo.lock`, `package-lock.json`, etc. |
@@ -225,7 +242,9 @@ After resolution finishes, prompt the next step via `AskUserQuestion`. Default o
 
 ## Rules
 
+- Always run `detect-squash-residue.py` first; if positive, surface the remedy and stop the cascade.
 - Always run `conflict-summary.py` before deciding the cascade order.
 - Prefer structural resolution over manual edits when mergiraf supports the file type.
 - Never weaken or hand-edit a lockfile in place — regenerate from the manifest.
 - Surface unresolved files explicitly; do not claim a clean tree until `git status` agrees.
+- Never auto-apply the squash-residue remedy — it is destructive (`git reset --hard`); the user copy-pastes it.

--- a/skills/melt/SKILL.md
+++ b/skills/melt/SKILL.md
@@ -46,7 +46,7 @@ If the verdict is `SQUASH-MERGED`, surface the printed remedy to the user verbat
 
 Verdict semantics:
 
-- `SQUASH-MERGED` (via `gh-api`) — PR found; cherry-pick list is exact.
+- `SQUASH-MERGED` (via `gh-api`) — PR found; cherry-pick list from PR commits (prints a warn if no SHAs matched — verify before running remedy).
 - `SQUASH-MERGED` (via `local-synth`) — detected offline; cherry-pick list must be reviewed by hand.
 - `not-detected` — proceed to the cascade.
 - `not-applicable` — on the base branch.

--- a/skills/melt/scripts/batch-resolve.py
+++ b/skills/melt/scripts/batch-resolve.py
@@ -110,6 +110,94 @@ def resolve_file(path: str, dry_run: bool = True, verbose: bool = False) -> dict
     return result
 
 
+def debug_file(path: str, keep_dir: str | None = None) -> dict:
+    """Run mergiraf on a single file with debug logging; keep the tempdir for inspection.
+
+    Returns a dict describing where the artifacts live. Never modifies the working
+    tree — the caller inspects the merged output manually.
+    """
+    result = {
+        "path": path,
+        "supported": is_mergiraf_supported(path),
+        "tempdir": None,
+        "merged_path": None,
+        "log_path": None,
+        "conflict_markers": None,
+        "exit_code": None,
+        "message": "",
+    }
+
+    if not result["supported"]:
+        result["message"] = "unsupported file type"
+        return result
+
+    base, ours, theirs = extract_stages(path)
+    if base is None or ours is None or theirs is None:
+        result["message"] = "could not extract all three stages"
+        return result
+
+    tmpdir = keep_dir or tempfile.mkdtemp(prefix="melt-debug-")
+    base_path = os.path.join(tmpdir, "base")
+    ours_path = os.path.join(tmpdir, "ours")
+    theirs_path = os.path.join(tmpdir, "theirs")
+    merged_path = os.path.join(tmpdir, "merged")
+    log_path = os.path.join(tmpdir, "mergiraf.log")
+
+    Path(base_path).write_text(base)
+    Path(ours_path).write_text(ours)
+    Path(theirs_path).write_text(theirs)
+
+    cmd = [
+        "mergiraf", "merge",
+        base_path, ours_path, theirs_path,
+        "-o", merged_path,
+        "-p", path,
+    ]
+    env = os.environ.copy()
+    env["RUST_LOG"] = "mergiraf=debug"
+    merge_result = subprocess.run(cmd, capture_output=True, text=True, env=env)
+
+    Path(log_path).write_text(merge_result.stderr or "")
+
+    result["tempdir"] = tmpdir
+    result["log_path"] = log_path
+    result["exit_code"] = merge_result.returncode
+
+    try:
+        merged_content = Path(merged_path).read_text()
+        result["merged_path"] = merged_path
+        result["conflict_markers"] = merged_content.count("<<<<<<<")
+        if result["conflict_markers"] == 0:
+            result["message"] = "clean merge"
+        else:
+            result["message"] = f"{result['conflict_markers']} conflict marker(s) remain"
+    except FileNotFoundError:
+        result["message"] = f"mergiraf produced no merged file (exit {merge_result.returncode})"
+
+    return result
+
+
+def format_debug(d: dict) -> str:
+    lines = [f"path: {d['path']}"]
+    if not d["supported"]:
+        lines.append(f"result: {d['message']}")
+        return "\n".join(lines)
+    lines.extend([
+        f"tempdir: {d['tempdir']}",
+        f"merged:  {d['merged_path']}",
+        f"log:     {d['log_path']}",
+        f"exit:    {d['exit_code']}",
+        f"markers: {d['conflict_markers']}",
+        f"result:  {d['message']}",
+        "",
+        "inspect:",
+        f"  cat {d['merged_path']}",
+        f"  cat {d['log_path']}",
+        f"  diff {d['tempdir']}/ours {d['merged_path']}",
+    ])
+    return "\n".join(lines)
+
+
 def format_terse(results: list, dry_run: bool) -> str:
     if not results:
         return "no conflicts"
@@ -162,6 +250,14 @@ def main():
     parser.add_argument(
         "--verbose", action="store_true", help="Markdown-formatted output and mergiraf debug logs."
     )
+    parser.add_argument(
+        "--debug",
+        metavar="PATH",
+        help=(
+            "Inspect mergiraf on a single file: keeps the tempdir, captures "
+            "RUST_LOG=mergiraf=debug, prints artifact paths. No working tree changes."
+        ),
+    )
     parser.add_argument("files", nargs="*", help="Specific files (default: all conflicted files).")
 
     args = parser.parse_args()
@@ -169,6 +265,11 @@ def main():
     if not check_mergiraf_available():
         print("mergiraf not found — install with: cargo install mergiraf", file=sys.stderr)
         return 1
+
+    if args.debug:
+        result = debug_file(args.debug)
+        print(format_debug(result))
+        return 0 if result["supported"] and result["conflict_markers"] == 0 else 1
 
     dry_run = not args.apply
     files = args.files if args.files else get_conflicted_files()

--- a/skills/melt/scripts/batch-resolve.py
+++ b/skills/melt/scripts/batch-resolve.py
@@ -179,22 +179,26 @@ def debug_file(path: str, keep_dir: str | None = None) -> dict:
 
 def format_debug(d: dict) -> str:
     lines = [f"path: {d['path']}"]
-    if not d["supported"]:
+    if not d["supported"] or d["tempdir"] is None:
         lines.append(f"result: {d['message']}")
         return "\n".join(lines)
+    markers = d["conflict_markers"] if d["conflict_markers"] is not None else "(none)"
     lines.extend([
         f"tempdir: {d['tempdir']}",
-        f"merged:  {d['merged_path']}",
+        f"merged:  {d['merged_path'] or '(none)'}",
         f"log:     {d['log_path']}",
         f"exit:    {d['exit_code']}",
-        f"markers: {d['conflict_markers']}",
+        f"markers: {markers}",
         f"result:  {d['message']}",
         "",
         "inspect:",
-        f"  cat {d['merged_path']}",
         f"  cat {d['log_path']}",
-        f"  diff {d['tempdir']}/ours {d['merged_path']}",
     ])
+    if d["merged_path"]:
+        lines.extend([
+            f"  cat {d['merged_path']}",
+            f"  diff {d['tempdir']}/ours {d['merged_path']}",
+        ])
     return "\n".join(lines)
 
 

--- a/skills/melt/scripts/detect-squash-residue.py
+++ b/skills/melt/scripts/detect-squash-residue.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Detect squash-merge residue before running the conflict cascade.
+
+When a PR is squash-merged into the base branch, the local branch retains the
+pre-squash commits. Rebasing then re-applies commits whose content is already
+in base, producing useless conflicts that mergiraf cannot resolve — the right
+answer is to abort and re-cherry-pick the commits that postdate the squash.
+
+Detection path:
+  1. gh API — `gh pr list --state merged --head <branch>` returns both the
+     verdict (PR exists) and the cherry-pick list (PR commit SHAs).
+  2. Local fallback — synthesize a would-be squash commit via `commit-tree`,
+     then ask `git cherry` whether base already contains an equivalent. Works
+     offline but cannot enumerate which commits were squashed.
+
+No auto-fix. Prints the remedy as a copy-paste block; the user runs it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Safe git ref name characters: alphanumeric, slash, dot, dash, underscore.
+# Used to prevent shell metacharacters from being interpolated into the printed
+# remedy block (which the user copy-pastes).
+_SAFE_REF = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from git_utils import run_git
+
+
+def _current_branch() -> str | None:
+    r = run_git(["branch", "--show-current"])
+    if r.returncode != 0:
+        return None
+    return r.stdout.strip() or None
+
+
+def _merge_base(base: str, head: str = "HEAD") -> str | None:
+    r = run_git(["merge-base", base, head])
+    return r.stdout.strip() if r.returncode == 0 else None
+
+
+def _commits_since(base: str, head: str = "HEAD") -> list[dict]:
+    r = run_git(["log", "--reverse", "--format=%H%x09%s", f"{base}..{head}"])
+    if r.returncode != 0:
+        return []
+    commits = []
+    for line in r.stdout.strip().split("\n"):
+        if "\t" in line:
+            sha, subject = line.split("\t", 1)
+            commits.append({"sha": sha, "short": sha[:8], "subject": subject})
+    return commits
+
+
+def _gh_available() -> bool:
+    return shutil.which("gh") is not None
+
+
+def _base_branch_name(base_ref: str) -> str:
+    """Strip the remote prefix from a base ref so it matches gh's --base flag.
+
+    `origin/main` → `main`. `main` → `main`. A user passing a ref with multiple
+    slashes (e.g. `upstream/release/1.0`) keeps everything after the first slash.
+    """
+    if "/" in base_ref:
+        _, _, rest = base_ref.partition("/")
+        return rest
+    return base_ref
+
+
+def _check_via_gh(branch: str, base_ref: str) -> dict | None:
+    if not _gh_available():
+        return None
+    cmd = [
+        "gh", "pr", "list",
+        "--state", "merged",
+        "--head", branch,
+        "--base", _base_branch_name(base_ref),
+        "--json", "number,url,mergeCommit,commits,mergedAt",
+        "-L", "5",
+    ]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        return None
+    try:
+        prs = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not prs:
+        return None
+    prs.sort(key=lambda p: p.get("mergedAt", ""), reverse=True)
+    pr = prs[0]
+    return {
+        "number": pr["number"],
+        "url": pr["url"],
+        "merge_commit": (pr.get("mergeCommit") or {}).get("oid"),
+        "merged_at": pr["mergedAt"],
+        "pr_commits": [c["oid"] for c in pr.get("commits", [])],
+        "multiple_prs": len(prs) > 1,
+    }
+
+
+def _check_via_synthesis(base_ref: str, head: str = "HEAD") -> bool | None:
+    """Build a would-be squash commit from head's tree, then ask `git cherry`
+    whether base_ref already contains an equivalent. Returns True if yes.
+    """
+    mb = _merge_base(base_ref, head)
+    if not mb:
+        return None
+    tree = run_git(["rev-parse", f"{head}^{{tree}}"])
+    if tree.returncode != 0:
+        return None
+    synth = run_git(
+        ["commit-tree", tree.stdout.strip(), "-p", mb, "-m", "_squash-probe"]
+    )
+    if synth.returncode != 0:
+        return None
+    cherry = run_git(["cherry", base_ref, synth.stdout.strip()])
+    if cherry.returncode != 0:
+        return None
+    first = cherry.stdout.strip().split("\n")[0] if cherry.stdout.strip() else ""
+    return first.startswith("-")
+
+
+def _in_progress_abort() -> str | None:
+    r = run_git(["rev-parse", "--git-dir"])
+    if r.returncode != 0:
+        return None
+    gd = Path(r.stdout.strip())
+    if (gd / "rebase-merge").exists() or (gd / "rebase-apply").exists():
+        return "git rebase --abort"
+    if (gd / "MERGE_HEAD").exists():
+        return "git merge --abort"
+    if (gd / "CHERRY_PICK_HEAD").exists():
+        return "git cherry-pick --abort"
+    return None
+
+
+def _resolve_head(branch: str) -> str:
+    """Return a ref usable as HEAD for diff/log: prefer local branch tip, fall
+    back to remote-tracking ref, else literal 'HEAD'."""
+    for candidate in (branch, f"refs/heads/{branch}", f"origin/{branch}"):
+        r = run_git(["rev-parse", "--verify", "--quiet", candidate])
+        if r.returncode == 0 and r.stdout.strip():
+            return candidate
+    return "HEAD"
+
+
+def detect(branch: str, base_ref: str) -> dict:
+    head_ref = _resolve_head(branch)
+    result = {
+        "verdict": "not-detected",
+        "method": None,
+        "branch": branch,
+        "base": base_ref,
+        "head_ref": head_ref,
+        "pr": None,
+        "branch_commits": _commits_since(base_ref, head_ref),
+        "squashed_shas": [],
+        "unique_commits": [],
+        "remedy": [],
+        "warnings": [],
+    }
+
+    if not result["branch_commits"]:
+        result["warnings"].append(f"no commits between {base_ref} and {head_ref}")
+        return result
+
+    gh = _check_via_gh(branch, base_ref)
+    if gh:
+        result["verdict"] = "squash-merged"
+        result["method"] = "gh-api"
+        result["pr"] = {
+            "number": gh["number"],
+            "url": gh["url"],
+            "merged_at": gh["merged_at"],
+            "merge_commit": gh["merge_commit"],
+        }
+        result["squashed_shas"] = gh["pr_commits"]
+        if gh["multiple_prs"]:
+            result["warnings"].append(
+                "multiple merged PRs from this branch — using most recent"
+            )
+        squashed = set(gh["pr_commits"])
+        result["unique_commits"] = [
+            c for c in result["branch_commits"] if c["sha"] not in squashed
+        ]
+        matched = len(result["branch_commits"]) - len(result["unique_commits"])
+        if matched == 0:
+            result["warnings"].append(
+                "no local commits matched PR commits by SHA — "
+                "branch may have been rebased after the squash merge; "
+                "verify the cherry-pick list manually before running the remedy"
+            )
+
+    if result["verdict"] == "not-detected":
+        synth = _check_via_synthesis(base_ref, head_ref)
+        if synth:
+            result["verdict"] = "squash-merged"
+            result["method"] = "local-synth"
+            result["warnings"].append(
+                "detected via local synthesis; cannot enumerate which commits "
+                "were squashed vs unique — review branch commits manually"
+            )
+
+    if result["verdict"] == "squash-merged":
+        remedy = []
+        abort = _in_progress_abort()
+        if abort:
+            remedy.append(abort)
+        remedy.append(f"git reset --hard {base_ref}")
+        if result["unique_commits"]:
+            shas = " ".join(c["sha"] for c in result["unique_commits"])
+            remedy.append(f"git cherry-pick {shas}")
+        elif result["method"] == "local-synth":
+            # No PR data available — list branch commits so the user has a
+            # recovery path before running `reset --hard`.
+            remedy.append("# review and cherry-pick unique commits manually:")
+            for c in result["branch_commits"]:
+                remedy.append(f"#   {c['short']} {c['subject']}")
+        result["remedy"] = remedy
+
+    return result
+
+
+def format_terse(d: dict) -> str:
+    if d["verdict"] == "not-detected":
+        lines = [f"verdict: not-detected branch={d['branch']} base={d['base']}"]
+        for w in d["warnings"]:
+            lines.append(f"warn: {w}")
+        return "\n".join(lines)
+
+    lines = []
+    pr = d["pr"]
+    if pr:
+        lines.append(
+            f"verdict: SQUASH-MERGED via PR #{pr['number']} "
+            f"merged={pr['merged_at']} method={d['method']}"
+        )
+        lines.append(f"  url: {pr['url']}")
+    else:
+        lines.append(f"verdict: SQUASH-MERGED method={d['method']}")
+
+    for w in d["warnings"]:
+        lines.append(f"warn: {w}")
+
+    if d["unique_commits"]:
+        lines.append(f"unique commits ({len(d['unique_commits'])}):")
+        for c in d["unique_commits"]:
+            lines.append(f"  {c['short']} {c['subject']}")
+    elif d["method"] == "local-synth":
+        lines.append(f"branch commits ({len(d['branch_commits'])}):")
+        for c in d["branch_commits"]:
+            lines.append(f"  {c['short']} {c['subject']}")
+
+    lines.append("remedy (copy-paste — destructive, review first):")
+    for r in d["remedy"]:
+        lines.append(f"  {r}")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Detect squash-merge residue and emit the remedy."
+    )
+    parser.add_argument(
+        "--base",
+        default="origin/main",
+        help="Base ref to compare against (default: origin/main).",
+    )
+    parser.add_argument("--branch", help="Branch to check (default: current).")
+    parser.add_argument("--json", action="store_true", help="Output as JSON.")
+    args = parser.parse_args()
+
+    if not _SAFE_REF.match(args.base):
+        msg = f"error: --base {args.base!r} contains unsafe characters"
+        if args.json:
+            print(json.dumps({"verdict": "error", "error": msg}))
+        else:
+            print(msg, file=sys.stderr)
+        return 1
+
+    branch = args.branch or _current_branch()
+    if not branch:
+        msg = "error: not on a branch (detached HEAD?)"
+        if args.json:
+            print(json.dumps({"verdict": "error", "error": msg}))
+        else:
+            print(msg, file=sys.stderr)
+        return 1
+
+    if not _SAFE_REF.match(branch):
+        msg = f"error: branch {branch!r} contains unsafe characters"
+        if args.json:
+            print(json.dumps({"verdict": "error", "error": msg}))
+        else:
+            print(msg, file=sys.stderr)
+        return 1
+
+    base_short = args.base.split("/")[-1]
+    if branch == base_short or branch in ("main", "master", "develop"):
+        msg = f"not-applicable: on base branch {branch}"
+        if args.json:
+            print(json.dumps({"verdict": "not-applicable", "reason": msg}))
+        else:
+            print(msg)
+        return 0
+
+    result = detect(branch, args.base)
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(format_terse(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/melt/scripts/detect-squash-residue.py
+++ b/skills/melt/scripts/detect-squash-residue.py
@@ -205,30 +205,33 @@ def detect(branch: str, base_ref: str) -> dict:
 
     gh = _check_via_gh(branch, base_ref)
     if gh:
-        result["verdict"] = "squash-merged"
-        result["method"] = "gh-api"
-        result["pr"] = {
-            "number": gh["number"],
-            "url": gh["url"],
-            "merged_at": gh["merged_at"],
-            "merge_commit": gh["merge_commit"],
-        }
-        result["squashed_shas"] = gh["pr_commits"]
-        if gh["multiple_prs"]:
-            result["warnings"].append(
-                "multiple merged PRs from this branch — using most recent"
-            )
         squashed = set(gh["pr_commits"])
-        result["unique_commits"] = [
-            c for c in result["branch_commits"] if c["sha"] not in squashed
-        ]
-        matched = len(result["branch_commits"]) - len(result["unique_commits"])
+        unique = [c for c in result["branch_commits"] if c["sha"] not in squashed]
+        matched = len(result["branch_commits"]) - len(unique)
         if matched == 0:
+            # PR name matched but zero SHAs overlap — too weak to trust as
+            # squash residue. Could be a reused branch name or a fully
+            # rebased branch. Fall through to local-synth (tree equivalence)
+            # for a stronger signal.
             result["warnings"].append(
-                "no local commits matched PR commits by SHA — "
-                "branch may have been rebased after the squash merge; "
-                "verify the cherry-pick list manually before running the remedy"
+                f"gh found PR #{gh['number']} ({gh['url']}) for this branch but "
+                "no local commits matched its SHAs — treating as inconclusive"
             )
+        else:
+            result["verdict"] = "squash-merged"
+            result["method"] = "gh-api"
+            result["pr"] = {
+                "number": gh["number"],
+                "url": gh["url"],
+                "merged_at": gh["merged_at"],
+                "merge_commit": gh["merge_commit"],
+            }
+            result["squashed_shas"] = gh["pr_commits"]
+            result["unique_commits"] = unique
+            if gh["multiple_prs"]:
+                result["warnings"].append(
+                    "multiple merged PRs from this branch — using most recent"
+                )
 
     if result["verdict"] == "not-detected":
         synth = _check_via_synthesis(base_ref, head_ref)

--- a/skills/melt/scripts/detect-squash-residue.py
+++ b/skills/melt/scripts/detect-squash-residue.py
@@ -48,10 +48,11 @@ def _merge_base(base: str, head: str = "HEAD") -> str | None:
     return r.stdout.strip() if r.returncode == 0 else None
 
 
-def _commits_since(base: str, head: str = "HEAD") -> list[dict]:
+def _commits_since(base: str, head: str = "HEAD") -> list[dict] | None:
+    """Returns commits on success (possibly empty), None on git failure."""
     r = run_git(["log", "--reverse", "--format=%H%x09%s", f"{base}..{head}"])
     if r.returncode != 0:
-        return []
+        return None
     commits = []
     for line in r.stdout.strip().split("\n"):
         if "\t" in line:
@@ -67,11 +68,15 @@ def _gh_available() -> bool:
 def _base_branch_name(base_ref: str) -> str:
     """Strip the remote prefix from a base ref so it matches gh's --base flag.
 
-    `origin/main` → `main`. `main` → `main`. A user passing a ref with multiple
-    slashes (e.g. `upstream/release/1.0`) keeps everything after the first slash.
+    Only strips the leading segment when it matches a registered remote, so
+    slash-named local branches like `release/1.0` are preserved as-is.
+    `origin/main` → `main`. `upstream/release/1.0` → `release/1.0`. `main` → `main`.
     """
-    if "/" in base_ref:
-        _, _, rest = base_ref.partition("/")
+    if "/" not in base_ref:
+        return base_ref
+    prefix, _, rest = base_ref.partition("/")
+    r = run_git(["remote"])
+    if r.returncode == 0 and prefix in r.stdout.splitlines():
         return rest
     return base_ref
 
@@ -130,6 +135,22 @@ def _check_via_synthesis(base_ref: str, head: str = "HEAD") -> bool | None:
     return first.startswith("-")
 
 
+def _branch_during_rebase() -> str | None:
+    """Read the pre-rebase branch name from git rebase metadata.
+
+    During a rebase HEAD is detached, so `git branch --show-current` returns
+    empty. The rebase state directory records the original branch in head-name.
+    """
+    r = run_git(["rev-parse", "--git-dir"])
+    if r.returncode != 0:
+        return None
+    gd = Path(r.stdout.strip())
+    for head_name_path in (gd / "rebase-merge" / "head-name", gd / "rebase-apply" / "head-name"):
+        if head_name_path.exists():
+            return head_name_path.read_text().strip().removeprefix("refs/heads/")
+    return None
+
+
 def _in_progress_abort() -> str | None:
     r = run_git(["rev-parse", "--git-dir"])
     if r.returncode != 0:
@@ -163,12 +184,20 @@ def detect(branch: str, base_ref: str) -> dict:
         "base": base_ref,
         "head_ref": head_ref,
         "pr": None,
-        "branch_commits": _commits_since(base_ref, head_ref),
+        "branch_commits": [],
         "squashed_shas": [],
         "unique_commits": [],
         "remedy": [],
         "warnings": [],
     }
+
+    branch_commits = _commits_since(base_ref, head_ref)
+    if branch_commits is None:
+        result["warnings"].append(
+            f"git log failed for {base_ref}..{head_ref} — is {base_ref} fetched?"
+        )
+        return result
+    result["branch_commits"] = branch_commits
 
     if not result["branch_commits"]:
         result["warnings"].append(f"no commits between {base_ref} and {head_ref}")
@@ -288,9 +317,9 @@ def main():
             print(msg, file=sys.stderr)
         return 1
 
-    branch = args.branch or _current_branch()
+    branch = args.branch or _current_branch() or _branch_during_rebase()
     if not branch:
-        msg = "error: not on a branch (detached HEAD?)"
+        msg = "error: cannot determine current branch — pass --branch <name>"
         if args.json:
             print(json.dumps({"verdict": "error", "error": msg}))
         else:

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -48,3 +48,8 @@ def batch_resolve() -> ModuleType:
 @pytest.fixture(scope="session")
 def git_utils() -> ModuleType:
     return _load("git_utils", SCRIPTS_DIR / "git_utils.py")
+
+
+@pytest.fixture(scope="session")
+def detect_squash_residue() -> ModuleType:
+    return _load("detect_squash_residue", SCRIPTS_DIR / "detect-squash-residue.py")

--- a/tests/python/test_batch_resolve.py
+++ b/tests/python/test_batch_resolve.py
@@ -138,6 +138,118 @@ class TestResolveFile:
         assert "mergiraf failed" not in result["message"]
 
 
+class TestDebugFile:
+    def test_unsupported_extension_returns_message(self, batch_resolve: ModuleType) -> None:
+        result = batch_resolve.debug_file("Cargo.lock")
+        assert result["supported"] is False
+        assert result["tempdir"] is None
+        assert "unsupported" in result["message"]
+
+    def test_missing_stages_returns_message(self, batch_resolve: ModuleType) -> None:
+        with patch.object(batch_resolve, "extract_stages", return_value=(None, None, None)):
+            result = batch_resolve.debug_file("foo.py")
+        assert result["tempdir"] is None
+        assert "stages" in result["message"]
+
+    def test_clean_merge_captures_artifacts_and_passes_debug_env(
+        self, batch_resolve: ModuleType, tmp_path: Path
+    ) -> None:
+        seen = {}
+
+        def fake_run(cmd, **kwargs):  # noqa: ANN001
+            seen["env"] = kwargs.get("env") or {}
+            Path(_merged_path(cmd)).write_text("clean\n")
+            return make_completed(stderr="debug log line\n")
+
+        with (
+            patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")),
+            patch.object(batch_resolve.subprocess, "run", side_effect=fake_run),
+            patch.object(
+                batch_resolve.tempfile, "mkdtemp", return_value=str(tmp_path / "dbg")
+            ),
+        ):
+            (tmp_path / "dbg").mkdir()
+            result = batch_resolve.debug_file("foo.py")
+
+        assert seen["env"].get("RUST_LOG") == "mergiraf=debug"
+        assert result["supported"] is True
+        assert result["conflict_markers"] == 0
+        assert result["message"] == "clean merge"
+        assert Path(result["log_path"]).read_text() == "debug log line\n"
+        assert Path(result["merged_path"]).read_text() == "clean\n"
+        # Tempdir is NOT cleaned up — caller can inspect.
+        assert Path(result["tempdir"]).exists()
+
+    def test_conflicts_remain_reports_marker_count(
+        self, batch_resolve: ModuleType, tmp_path: Path
+    ) -> None:
+        body = "<<<<<<< a\nx\n=======\ny\n>>>>>>> b\n<<<<<<< c\np\n=======\nq\n>>>>>>> d\n"
+
+        def fake_run(cmd, **kwargs):  # noqa: ANN001
+            Path(_merged_path(cmd)).write_text(body)
+            return make_completed(returncode=1, stderr="")
+
+        with (
+            patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")),
+            patch.object(batch_resolve.subprocess, "run", side_effect=fake_run),
+            patch.object(
+                batch_resolve.tempfile, "mkdtemp", return_value=str(tmp_path / "dbg")
+            ),
+        ):
+            (tmp_path / "dbg").mkdir()
+            result = batch_resolve.debug_file("foo.py")
+
+        assert result["conflict_markers"] == 2
+        assert "2 conflict marker(s) remain" in result["message"]
+
+    def test_mergiraf_missing_output_file(
+        self, batch_resolve: ModuleType, tmp_path: Path
+    ) -> None:
+        # mergiraf fails hard and writes no output.
+        with (
+            patch.object(batch_resolve, "extract_stages", return_value=("B", "O", "T")),
+            patch.object(
+                batch_resolve.subprocess, "run", return_value=make_completed(returncode=2)
+            ),
+            patch.object(
+                batch_resolve.tempfile, "mkdtemp", return_value=str(tmp_path / "dbg")
+            ),
+        ):
+            (tmp_path / "dbg").mkdir()
+            result = batch_resolve.debug_file("foo.py")
+
+        assert result["merged_path"] is None
+        assert "no merged file" in result["message"]
+        assert result["exit_code"] == 2
+
+    def test_format_debug_includes_inspect_block(self, batch_resolve: ModuleType) -> None:
+        d = {
+            "path": "foo.py",
+            "supported": True,
+            "tempdir": "/tmp/dbg",
+            "merged_path": "/tmp/dbg/merged",
+            "log_path": "/tmp/dbg/mergiraf.log",
+            "conflict_markers": 0,
+            "exit_code": 0,
+            "message": "clean merge",
+        }
+        out = batch_resolve.format_debug(d)
+        assert "tempdir: /tmp/dbg" in out
+        assert "merged:" in out
+        assert "log:" in out
+        assert "inspect:" in out
+        assert "cat /tmp/dbg/merged" in out
+
+    def test_format_debug_short_circuits_for_unsupported(
+        self, batch_resolve: ModuleType
+    ) -> None:
+        out = batch_resolve.format_debug(
+            {"path": "x.lock", "supported": False, "message": "unsupported file type"}
+        )
+        assert "result: unsupported file type" in out
+        assert "inspect:" not in out
+
+
 class TestFormatters:
     def test_terse_includes_status_and_summary(self, batch_resolve: ModuleType) -> None:
         results = [

--- a/tests/python/test_batch_resolve.py
+++ b/tests/python/test_batch_resolve.py
@@ -249,6 +249,43 @@ class TestDebugFile:
         assert "result: unsupported file type" in out
         assert "inspect:" not in out
 
+    def test_format_debug_short_circuits_when_tempdir_none(
+        self, batch_resolve: ModuleType
+    ) -> None:
+        d = {
+            "path": "foo.py",
+            "supported": True,
+            "tempdir": None,
+            "merged_path": None,
+            "log_path": None,
+            "conflict_markers": None,
+            "exit_code": None,
+            "message": "could not extract all three stages",
+        }
+        out = batch_resolve.format_debug(d)
+        assert "result: could not extract all three stages" in out
+        assert "inspect:" not in out
+        assert "cat None" not in out
+
+    def test_format_debug_shows_log_but_not_diff_when_merged_path_none(
+        self, batch_resolve: ModuleType
+    ) -> None:
+        d = {
+            "path": "foo.py",
+            "supported": True,
+            "tempdir": "/tmp/dbg",
+            "merged_path": None,
+            "log_path": "/tmp/dbg/mergiraf.log",
+            "conflict_markers": None,
+            "exit_code": 2,
+            "message": "mergiraf produced no merged file (exit 2)",
+        }
+        out = batch_resolve.format_debug(d)
+        assert "inspect:" in out
+        assert "cat /tmp/dbg/mergiraf.log" in out
+        assert "cat None" not in out
+        assert "diff" not in out
+
 
 class TestFormatters:
     def test_terse_includes_status_and_summary(self, batch_resolve: ModuleType) -> None:

--- a/tests/python/test_detect_squash_residue.py
+++ b/tests/python/test_detect_squash_residue.py
@@ -101,10 +101,12 @@ class TestDetectViaGhApi:
         assert cherry_pick_line is not None
         assert all(c["sha"] in cherry_pick_line for c in followups)
 
-    def test_force_pushed_branch_warns_on_sha_divergence(
+    def test_zero_sha_overlap_downgrades_to_not_detected_when_synth_negative(
         self, detect_squash_residue: ModuleType
     ) -> None:
-        # Local commits have completely different SHAs from PR commits (rebase after merge).
+        # PR name matched but SHAs don't overlap (reused branch name or fully
+        # rebased branch). With local-synth also negative, verdict is
+        # not-detected — too weak to emit a destructive remedy.
         local_commits = _commits("local-1", "local-2")
         gh = _gh_payload(
             number=99,
@@ -115,14 +117,44 @@ class TestDetectViaGhApi:
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=local_commits),
             patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_check_via_synthesis", return_value=False),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["verdict"] == "not-detected"
+        assert result["method"] is None
+        assert result["pr"] is None
+        assert result["remedy"] == []
+        assert any("no local commits matched its SHAs" in w for w in result["warnings"])
+        assert any("inconclusive" in w for w in result["warnings"])
+
+    def test_zero_sha_overlap_falls_through_to_local_synth(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # PR name matched but SHAs don't overlap; local-synth detects
+        # tree-equivalent residue → squash-merged via local-synth (not gh-api).
+        local_commits = _commits("rebased-1", "rebased-2")
+        gh = _gh_payload(
+            number=99,
+            commit_oids=["a" * 40, "b" * 40],
+            merged_at="2026-05-15T12:00:00Z",
+        )
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=local_commits),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_check_via_synthesis", return_value=True),
             patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
         ):
             result = detect_squash_residue.detect("feature", "origin/main")
 
         assert result["verdict"] == "squash-merged"
-        assert any("verify the cherry-pick list" in w for w in result["warnings"])
-        # All local commits treated as unique since none matched the PR.
-        assert len(result["unique_commits"]) == len(local_commits)
+        assert result["method"] == "local-synth"
+        assert result["pr"] is None  # gh-api result was discarded
+        assert any("no local commits matched its SHAs" in w for w in result["warnings"])
+        # Manual review block emitted since local-synth has no SHA list.
+        assert any(r.startswith("# review") for r in result["remedy"])
 
 
 class TestRemedyCompleteness:
@@ -130,11 +162,12 @@ class TestRemedyCompleteness:
     follow-up commits exist, and nothing extra when all branch commits were
     squashed (no follow-ups to recover)."""
 
-    def test_force_pushed_branch_still_gets_cherry_pick_remedy(
+    def test_force_pushed_branch_recovery_via_local_synth(
         self, detect_squash_residue: ModuleType
     ) -> None:
-        # SHAs diverged from PR (post-merge rebase). All local commits become
-        # unique → cherry-pick remedy lists every one of them.
+        # SHAs diverged from PR (post-merge rebase). gh-api downgrades to
+        # inconclusive; local-synth confirms via tree equivalence and the
+        # remedy is the manual-review block listing all local commits.
         local = _commits("rebased-local-1", "rebased-local-2")
         gh = _gh_payload(
             number=1,
@@ -145,14 +178,16 @@ class TestRemedyCompleteness:
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=local),
             patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_check_via_synthesis", return_value=True),
             patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
         ):
             result = detect_squash_residue.detect("feature", "origin/main")
 
-        cherry_pick_line = next((r for r in result["remedy"] if "cherry-pick" in r), None)
-        assert cherry_pick_line is not None
-        assert all(c["sha"] in cherry_pick_line for c in local)
-        assert any("verify the cherry-pick list" in w for w in result["warnings"])
+        assert result["method"] == "local-synth"
+        assert any(r.startswith("# review") for r in result["remedy"])
+        # Every branch commit appears in the manual-review block.
+        review_lines = [r for r in result["remedy"] if r.startswith("#   ")]
+        assert all(any(c["short"] in line for line in review_lines) for c in local)
 
     def test_full_sha_match_remedy_is_reset_only(
         self, detect_squash_residue: ModuleType

--- a/tests/python/test_detect_squash_residue.py
+++ b/tests/python/test_detect_squash_residue.py
@@ -1,0 +1,520 @@
+"""Tests for detect-squash-residue.
+
+Covers detect() across all paths:
+- gh-api positive: PR found, SHAs match → unique commits computed, no warning.
+- gh-api positive: PR found, SHAs diverged → warning about manual review.
+- gh-api positive: multiple PRs → most recent wins, warning emitted.
+- Local-synthesis fallback when gh returns None.
+- Negative path: neither detector fires.
+- In-progress operation detection → correct abort command in remedy.
+- Empty branch (no commits ahead of base) → not-detected with warning.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+
+def make_completed(
+    stdout: str = "", returncode: int = 0, stderr: str = ""
+) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["x"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _commits(*subjects: str) -> list[dict]:
+    """Build branch_commits list. SHA is derived from subject for deterministic matching."""
+    return [
+        {"sha": f"{i:040x}", "short": f"{i:040x}"[:8], "subject": s}
+        for i, s in enumerate(subjects, 1)
+    ]
+
+
+def _gh_payload(*, number: int, commit_oids: list[str], merged_at: str) -> dict:
+    return {
+        "number": number,
+        "url": f"https://example.com/pr/{number}",
+        "merge_commit": "f" * 40,
+        "merged_at": merged_at,
+        "pr_commits": commit_oids,
+        "multiple_prs": False,
+    }
+
+
+class TestDetectViaGhApi:
+    def test_pr_found_shas_match_yields_no_unique_commits(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        commits = _commits("first commit", "second commit")
+        gh = _gh_payload(
+            number=42,
+            commit_oids=[c["sha"] for c in commits],
+            merged_at="2026-05-15T12:00:00Z",
+        )
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["verdict"] == "squash-merged"
+        assert result["method"] == "gh-api"
+        assert result["pr"]["number"] == 42
+        assert result["unique_commits"] == []
+        assert not any("verify the cherry-pick list" in w for w in result["warnings"])
+        assert result["remedy"] == ["git reset --hard origin/main"]
+
+    def test_pr_found_with_unique_followups_lists_cherry_picks(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        squashed = _commits("squashed-1", "squashed-2")
+        followups = _commits("post-merge-fix", "another-post-merge")
+        # Offset followup SHAs so they don't collide with squashed.
+        for i, c in enumerate(followups, start=100):
+            c["sha"] = f"{i:040x}"
+            c["short"] = c["sha"][:8]
+        all_commits = squashed + followups
+        gh = _gh_payload(
+            number=7,
+            commit_oids=[c["sha"] for c in squashed],
+            merged_at="2026-05-15T12:00:00Z",
+        )
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=all_commits),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["verdict"] == "squash-merged"
+        unique_subjects = [c["subject"] for c in result["unique_commits"]]
+        assert unique_subjects == ["post-merge-fix", "another-post-merge"]
+        cherry_pick_line = next((r for r in result["remedy"] if "cherry-pick" in r), None)
+        assert cherry_pick_line is not None
+        assert all(c["sha"] in cherry_pick_line for c in followups)
+
+    def test_force_pushed_branch_warns_on_sha_divergence(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # Local commits have completely different SHAs from PR commits (rebase after merge).
+        local_commits = _commits("local-1", "local-2")
+        gh = _gh_payload(
+            number=99,
+            commit_oids=["a" * 40, "b" * 40],  # don't match local SHAs
+            merged_at="2026-05-15T12:00:00Z",
+        )
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=local_commits),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["verdict"] == "squash-merged"
+        assert any("verify the cherry-pick list" in w for w in result["warnings"])
+        # All local commits treated as unique since none matched the PR.
+        assert len(result["unique_commits"]) == len(local_commits)
+
+
+class TestRemedyCompleteness:
+    """The remedy must give the user a recovery path: a cherry-pick line when
+    follow-up commits exist, and nothing extra when all branch commits were
+    squashed (no follow-ups to recover)."""
+
+    def test_force_pushed_branch_still_gets_cherry_pick_remedy(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # SHAs diverged from PR (post-merge rebase). All local commits become
+        # unique → cherry-pick remedy lists every one of them.
+        local = _commits("rebased-local-1", "rebased-local-2")
+        gh = _gh_payload(
+            number=1,
+            commit_oids=["a" * 40],  # don't match local SHAs
+            merged_at="2026-05-15T12:00:00Z",
+        )
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=local),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        cherry_pick_line = next((r for r in result["remedy"] if "cherry-pick" in r), None)
+        assert cherry_pick_line is not None
+        assert all(c["sha"] in cherry_pick_line for c in local)
+        assert any("verify the cherry-pick list" in w for w in result["warnings"])
+
+    def test_full_sha_match_remedy_is_reset_only(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # All local commits matched PR commits → no follow-ups → `reset --hard`
+        # is the complete remedy. No cherry-pick, no manual review block.
+        commits = _commits("squashed-a", "squashed-b")
+        gh = _gh_payload(
+            number=2,
+            commit_oids=[c["sha"] for c in commits],
+            merged_at="2026-05-15T12:00:00Z",
+        )
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["remedy"] == ["git reset --hard origin/main"]
+
+    def test_multiple_prs_warns_and_uses_most_recent(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        commits = _commits("c1")
+        gh = _gh_payload(
+            number=10,
+            commit_oids=[c["sha"] for c in commits],
+            merged_at="2026-05-15T12:00:00Z",
+        )
+        gh["multiple_prs"] = True
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert any("multiple merged PRs" in w for w in result["warnings"])
+
+
+class TestDetectViaLocalSynthesis:
+    def test_synth_positive_when_gh_returns_none(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        commits = _commits("a", "b")
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=None),
+            patch.object(detect_squash_residue, "_check_via_synthesis", return_value=True),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["verdict"] == "squash-merged"
+        assert result["method"] == "local-synth"
+        assert result["unique_commits"] == []
+        assert any("review branch commits manually" in w for w in result["warnings"])
+        # Remedy must include the manual-review comment block.
+        assert any(r.startswith("# review") for r in result["remedy"])
+        assert any(c["short"] in r for c in commits for r in result["remedy"] if r.startswith("#"))
+
+    def test_synth_negative_yields_not_detected(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        commits = _commits("a")
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=None),
+            patch.object(detect_squash_residue, "_check_via_synthesis", return_value=False),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["verdict"] == "not-detected"
+        assert result["remedy"] == []
+
+
+class TestEdgeCases:
+    def test_no_commits_between_base_and_head(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=[]),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["verdict"] == "not-detected"
+        assert any("no commits between" in w for w in result["warnings"])
+
+    def test_in_progress_rebase_prepends_abort(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        commits = _commits("a")
+        gh = _gh_payload(
+            number=1, commit_oids=[c["sha"] for c in commits], merged_at="2026-05-15T12:00:00Z"
+        )
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(
+                detect_squash_residue, "_in_progress_abort", return_value="git rebase --abort"
+            ),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["remedy"][0] == "git rebase --abort"
+        assert result["remedy"][1] == "git reset --hard origin/main"
+
+    def test_in_progress_cherry_pick_prepends_correct_abort(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        commits = _commits("a")
+        gh = _gh_payload(
+            number=1, commit_oids=[c["sha"] for c in commits], merged_at="2026-05-15T12:00:00Z"
+        )
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(
+                detect_squash_residue,
+                "_in_progress_abort",
+                return_value="git cherry-pick --abort",
+            ),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["remedy"][0] == "git cherry-pick --abort"
+
+
+class TestInProgressAbort:
+    def test_detects_rebase_apply(
+        self, detect_squash_residue: ModuleType, tmp_path: Path
+    ) -> None:
+        gd = tmp_path / "git-dir"
+        (gd / "rebase-apply").mkdir(parents=True)
+        with patch.object(
+            detect_squash_residue,
+            "run_git",
+            return_value=make_completed(stdout=str(gd)),
+        ):
+            assert detect_squash_residue._in_progress_abort() == "git rebase --abort"
+
+    def test_detects_rebase_merge(
+        self, detect_squash_residue: ModuleType, tmp_path: Path
+    ) -> None:
+        gd = tmp_path / "git-dir"
+        (gd / "rebase-merge").mkdir(parents=True)
+        with patch.object(
+            detect_squash_residue, "run_git", return_value=make_completed(stdout=str(gd))
+        ):
+            assert detect_squash_residue._in_progress_abort() == "git rebase --abort"
+
+    def test_detects_merge(
+        self, detect_squash_residue: ModuleType, tmp_path: Path
+    ) -> None:
+        gd = tmp_path / "git-dir"
+        gd.mkdir()
+        (gd / "MERGE_HEAD").write_text("deadbeef")
+        with patch.object(
+            detect_squash_residue, "run_git", return_value=make_completed(stdout=str(gd))
+        ):
+            assert detect_squash_residue._in_progress_abort() == "git merge --abort"
+
+    def test_detects_cherry_pick(
+        self, detect_squash_residue: ModuleType, tmp_path: Path
+    ) -> None:
+        gd = tmp_path / "git-dir"
+        gd.mkdir()
+        (gd / "CHERRY_PICK_HEAD").write_text("deadbeef")
+        with patch.object(
+            detect_squash_residue, "run_git", return_value=make_completed(stdout=str(gd))
+        ):
+            assert detect_squash_residue._in_progress_abort() == "git cherry-pick --abort"
+
+    def test_no_in_progress_returns_none(
+        self, detect_squash_residue: ModuleType, tmp_path: Path
+    ) -> None:
+        gd = tmp_path / "git-dir"
+        gd.mkdir()
+        with patch.object(
+            detect_squash_residue, "run_git", return_value=make_completed(stdout=str(gd))
+        ):
+            assert detect_squash_residue._in_progress_abort() is None
+
+
+class TestGhApiCall:
+    def test_returns_none_when_gh_missing(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        with patch.object(detect_squash_residue, "_gh_available", return_value=False):
+            assert detect_squash_residue._check_via_gh("feature", "origin/main") is None
+
+    def test_returns_none_on_gh_failure(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        with (
+            patch.object(detect_squash_residue, "_gh_available", return_value=True),
+            patch.object(
+                detect_squash_residue.subprocess,
+                "run",
+                return_value=make_completed(returncode=1),
+            ),
+        ):
+            assert detect_squash_residue._check_via_gh("feature", "origin/main") is None
+
+    def test_returns_none_on_empty_pr_list(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        with (
+            patch.object(detect_squash_residue, "_gh_available", return_value=True),
+            patch.object(
+                detect_squash_residue.subprocess,
+                "run",
+                return_value=make_completed(stdout="[]"),
+            ),
+        ):
+            assert detect_squash_residue._check_via_gh("feature", "origin/main") is None
+
+    def test_picks_most_recent_when_multiple_prs(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        payload = json.dumps([
+            {
+                "number": 1,
+                "url": "https://example.com/pr/1",
+                "mergeCommit": {"oid": "a" * 40},
+                "mergedAt": "2026-01-01T00:00:00Z",
+                "commits": [{"oid": "1" * 40}],
+            },
+            {
+                "number": 2,
+                "url": "https://example.com/pr/2",
+                "mergeCommit": {"oid": "b" * 40},
+                "mergedAt": "2026-05-15T00:00:00Z",
+                "commits": [{"oid": "2" * 40}],
+            },
+        ])
+        with (
+            patch.object(detect_squash_residue, "_gh_available", return_value=True),
+            patch.object(
+                detect_squash_residue.subprocess,
+                "run",
+                return_value=make_completed(stdout=payload),
+            ),
+        ):
+            result = detect_squash_residue._check_via_gh("feature", "origin/main")
+
+        assert result is not None
+        assert result["number"] == 2
+        assert result["multiple_prs"] is True
+
+    def test_passes_base_filter_to_gh(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # Regression: PRs merged to a different base must not trigger a
+        # false-positive verdict against our base.
+        captured = {}
+
+        def fake_run(cmd, **kwargs):  # noqa: ANN001
+            captured["cmd"] = cmd
+            return make_completed(stdout="[]")
+
+        with (
+            patch.object(detect_squash_residue, "_gh_available", return_value=True),
+            patch.object(detect_squash_residue.subprocess, "run", side_effect=fake_run),
+        ):
+            detect_squash_residue._check_via_gh("feature", "origin/main")
+
+        assert "--base" in captured["cmd"]
+        base_idx = captured["cmd"].index("--base")
+        assert captured["cmd"][base_idx + 1] == "main"  # remote prefix stripped
+        # --head must still be present and use the raw branch name.
+        head_idx = captured["cmd"].index("--head")
+        assert captured["cmd"][head_idx + 1] == "feature"
+
+
+class TestBaseBranchName:
+    def test_strips_origin_prefix(self, detect_squash_residue: ModuleType) -> None:
+        assert detect_squash_residue._base_branch_name("origin/main") == "main"
+
+    def test_preserves_branch_without_remote(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        assert detect_squash_residue._base_branch_name("main") == "main"
+
+    def test_handles_multi_segment_branch(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # `upstream/release/1.0` should yield `release/1.0`.
+        assert (
+            detect_squash_residue._base_branch_name("upstream/release/1.0")
+            == "release/1.0"
+        )
+
+
+class TestRefValidation:
+    """Inputs flow into a printed copy-paste remedy. Reject shell metacharacters
+    so the printed remedy can't be made to mislead the user."""
+
+    def test_safe_ref_accepts_normal_refs(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        for ref in ("origin/main", "main", "release/1.0", "feature_x", "v1.2.3-rc1"):
+            assert detect_squash_residue._SAFE_REF.match(ref), ref
+
+    def test_safe_ref_rejects_shell_metacharacters(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        for ref in (
+            "origin/main; rm -rf ~",
+            "origin/main`whoami`",
+            "origin/main $(echo x)",
+            "origin/main | cat",
+            "origin/main\nrm -rf",
+        ):
+            assert not detect_squash_residue._SAFE_REF.match(ref), ref
+
+
+class TestFormatTerse:
+    def test_not_detected_prints_verdict(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        out = detect_squash_residue.format_terse({
+            "verdict": "not-detected",
+            "branch": "feature",
+            "base": "origin/main",
+            "warnings": [],
+        })
+        assert "verdict: not-detected" in out
+
+    def test_squash_merged_includes_pr_and_remedy(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        d = {
+            "verdict": "squash-merged",
+            "method": "gh-api",
+            "pr": {
+                "number": 42,
+                "url": "https://example.com/pr/42",
+                "merged_at": "2026-05-15T12:00:00Z",
+            },
+            "warnings": [],
+            "unique_commits": [
+                {"sha": "a" * 40, "short": "a" * 8, "subject": "follow-up"}
+            ],
+            "branch_commits": [],
+            "remedy": [
+                "git rebase --abort",
+                "git reset --hard origin/main",
+                "git cherry-pick aaaaaaaa",
+            ],
+        }
+        out = detect_squash_residue.format_terse(d)
+        assert "SQUASH-MERGED via PR #42" in out
+        assert "https://example.com/pr/42" in out
+        assert "follow-up" in out
+        assert "git rebase --abort" in out
+        assert "destructive, review first" in out

--- a/tests/python/test_detect_squash_residue.py
+++ b/tests/python/test_detect_squash_residue.py
@@ -234,6 +234,71 @@ class TestDetectViaLocalSynthesis:
         assert result["remedy"] == []
 
 
+class TestCommitsSince:
+    def test_returns_none_on_git_failure(self, detect_squash_residue: ModuleType) -> None:
+        with patch.object(
+            detect_squash_residue, "run_git", return_value=make_completed(returncode=128)
+        ):
+            assert detect_squash_residue._commits_since("origin/main") is None
+
+    def test_returns_empty_list_for_no_commits(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        with patch.object(
+            detect_squash_residue, "run_git", return_value=make_completed(stdout="")
+        ):
+            assert detect_squash_residue._commits_since("origin/main") == []
+
+
+class TestGitLogFailurePropagation:
+    def test_git_log_failure_warns_with_fetch_hint(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["verdict"] == "not-detected"
+        assert any("git log failed" in w for w in result["warnings"])
+        assert any("fetched" in w for w in result["warnings"])
+
+
+class TestBranchDuringRebase:
+    def test_reads_head_name_from_rebase_merge(
+        self, detect_squash_residue: ModuleType, tmp_path: Path
+    ) -> None:
+        gd = tmp_path / "git-dir"
+        (gd / "rebase-merge").mkdir(parents=True)
+        (gd / "rebase-merge" / "head-name").write_text("refs/heads/feature-branch\n")
+        with patch.object(
+            detect_squash_residue, "run_git", return_value=make_completed(stdout=str(gd))
+        ):
+            assert detect_squash_residue._branch_during_rebase() == "feature-branch"
+
+    def test_reads_head_name_from_rebase_apply(
+        self, detect_squash_residue: ModuleType, tmp_path: Path
+    ) -> None:
+        gd = tmp_path / "git-dir"
+        (gd / "rebase-apply").mkdir(parents=True)
+        (gd / "rebase-apply" / "head-name").write_text("refs/heads/fix/my-fix\n")
+        with patch.object(
+            detect_squash_residue, "run_git", return_value=make_completed(stdout=str(gd))
+        ):
+            assert detect_squash_residue._branch_during_rebase() == "fix/my-fix"
+
+    def test_returns_none_when_no_rebase_in_progress(
+        self, detect_squash_residue: ModuleType, tmp_path: Path
+    ) -> None:
+        gd = tmp_path / "git-dir"
+        gd.mkdir()
+        with patch.object(
+            detect_squash_residue, "run_git", return_value=make_completed(stdout=str(gd))
+        ):
+            assert detect_squash_residue._branch_during_rebase() is None
+
+
 class TestEdgeCases:
     def test_no_commits_between_base_and_head(
         self, detect_squash_residue: ModuleType
@@ -419,6 +484,9 @@ class TestGhApiCall:
         captured = {}
 
         def fake_run(cmd, **kwargs):  # noqa: ANN001
+            # _base_branch_name calls `git remote` to identify registered remotes.
+            if cmd[:2] == ["git", "remote"]:
+                return make_completed(stdout="origin\n")
             captured["cmd"] = cmd
             return make_completed(stdout="[]")
 
@@ -437,22 +505,40 @@ class TestGhApiCall:
 
 
 class TestBaseBranchName:
-    def test_strips_origin_prefix(self, detect_squash_residue: ModuleType) -> None:
-        assert detect_squash_residue._base_branch_name("origin/main") == "main"
+    def test_strips_registered_remote_prefix(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        with patch.object(
+            detect_squash_residue, "run_git", return_value=make_completed(stdout="origin\n")
+        ):
+            assert detect_squash_residue._base_branch_name("origin/main") == "main"
 
-    def test_preserves_branch_without_remote(
+    def test_preserves_branch_without_slash(
         self, detect_squash_residue: ModuleType
     ) -> None:
         assert detect_squash_residue._base_branch_name("main") == "main"
 
-    def test_handles_multi_segment_branch(
+    def test_preserves_slash_branch_not_matching_remote(
         self, detect_squash_residue: ModuleType
     ) -> None:
-        # `upstream/release/1.0` should yield `release/1.0`.
-        assert (
-            detect_squash_residue._base_branch_name("upstream/release/1.0")
-            == "release/1.0"
-        )
+        # `release/1.0` is a local slash-named branch; "release" is not a remote.
+        with patch.object(
+            detect_squash_residue, "run_git", return_value=make_completed(stdout="origin\n")
+        ):
+            assert detect_squash_residue._base_branch_name("release/1.0") == "release/1.0"
+
+    def test_strips_multi_segment_ref_with_registered_remote(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # `upstream/release/1.0` → strip "upstream/", keep "release/1.0".
+        with patch.object(
+            detect_squash_residue,
+            "run_git",
+            return_value=make_completed(stdout="origin\nupstream\n"),
+        ):
+            assert (
+                detect_squash_residue._base_branch_name("upstream/release/1.0") == "release/1.0"
+            )
 
 
 class TestRefValidation:


### PR DESCRIPTION
## What changed

Adds a Step 0 squash-merge residue detector to the `/melt` cascade and grows `batch-resolve.py` a `--debug PATH` mode that replaces the inline `/tmp/base` recipe in SKILL.md.

## Why

When a PR is squash-merged into base, the local branch still carries pre-squash commits and a naive rebase re-applies content that already landed — producing useless conflicts mergiraf cannot resolve. Detecting that up-front and printing an abort + re-cherry-pick remedy is faster (and correct) than chewing through the cascade. The `--debug` mode collapses a duplicated bash recipe and gives a single inspection entry point with `RUST_LOG=mergiraf=debug` and a kept tempdir.

## How to verify

- `python3 -m pytest tests/python/test_detect_squash_residue.py tests/python/test_batch_resolve.py -q` → 46 passed.
- `python3 skills/melt/scripts/detect-squash-residue.py --help` and `python3 skills/melt/scripts/batch-resolve.py --help` show the new flags.

## Risk / rollout notes

The squash-residue remedy is destructive (`git reset --hard`) and is **never auto-applied** — SKILL.md instructs the agent to surface the printed block verbatim and let the user copy-paste it. No behavior change to the existing cascade when residue is `not-detected`.

## Checklist

- [x] Conventional Commits PR title
- [x] Tests added or updated
- [x] Documentation updated (SKILL.md)
- [x] No secrets or credentials added