### PR TITLE
feat: add documentation site with auto-generated skill pages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,8 @@
 # Dependabot configuration — version updates only.
 # See: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# No top-level Python manifest; the only Python is in .github/scripts/
-# (CI helpers) with versions pinned inline in workflows. No pip ecosystem
-# entry — Dependabot can't track inline `pip install foo==x.y.z` lines.
+# Python in .github/scripts/ (CI helpers) is pinned inline in workflows and
+# is not tracked here. The docs/ pip manifest is tracked below.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -13,4 +12,13 @@ updates:
     open-pull-requests-limit: 5
     groups:
       actions-minor-and-patch:
+        update-types: [minor, patch]
+
+  - package-ecosystem: pip
+    directory: /docs
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      docs-minor-and-patch:
         update-types: [minor, patch]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,88 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - "docs/**"
+      - "mkdocs.yml"
+      - "scripts/gen_docs.py"
+      - ".github/workflows/docs.yml"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "SECURITY.md"
+      - "CODE_OF_CONDUCT.md"
+  pull_request:
+    paths:
+      - "skills/**"
+      - "docs/**"
+      - "mkdocs.yml"
+      - "scripts/gen_docs.py"
+      - ".github/workflows/docs.yml"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "SECURITY.md"
+      - "CODE_OF_CONDUCT.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install docs dependencies
+        run: pip install --no-cache-dir -r docs/requirements.txt
+
+      - name: Build docs (strict)
+        run: mkdocs build --strict
+
+  deploy:
+    name: deploy to gh-pages
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Install docs dependencies
+        run: pip install --no-cache-dir -r docs/requirements.txt
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy to gh-pages
+        run: mkdocs gh-deploy --force --no-history

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,14 @@
 # Python
 __pycache__/
 *.pyc
+.venv/
 
 # OS / editor
 .DS_Store
 *.swp
 .idea/
 .vscode/
+
+# MkDocs build output
+site/
+.cache/

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -14,3 +14,5 @@ rules:
 ignore: |-
   .cheese/
   .context/
+  mkdocs.yml
+  site/

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ gh skill install paulnsorensen/easy-cheese --agent claude-code --scope user
 gh skill install paulnsorensen/easy-cheese --agent claude-code --scope project
 ```
 
-Supported `--agent` values include `copilot`, `claude-code`, `cursor`, `codex`, `gemini`, and others. Omit `--agent` to use the harness auto-detected from your environment.
+Supported `--agent` values include `github-copilot`, `claude-code`, `cursor`, `codex`, `gemini-cli`, and others. Omit `--agent` to use the harness auto-detected from your environment.
 
 Preview a skill's content before committing to an install:
 

--- a/README.md
+++ b/README.md
@@ -219,14 +219,6 @@ Keep installed skills up to date:
 gh skill update --all
 ```
 
-### Claude Code (plugin)
-
-Once a `.claude-plugin/plugin.json` is added to this repo, install with:
-
-```sh
-/plugin install paulnsorensen/easy-cheese
-```
-
 ### Claude Code (manual)
 
 Copy the skills you want into your skills directory:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,61 @@
+# 🧀 easy-cheese
+
+A skills plugin for [Claude Code](https://docs.claude.com/claude-code) — the cheese-making pipeline for code review, implementation, refactoring, and PR rescue.
+
+[![CI](https://img.shields.io/github/actions/workflow/status/paulnsorensen/easy-cheese/validate.yml?branch=main&label=CI&style=flat-square)](https://github.com/paulnsorensen/easy-cheese/actions/workflows/validate.yml)
+[![License: MIT](https://img.shields.io/github/license/paulnsorensen/easy-cheese?style=flat-square)](https://github.com/paulnsorensen/easy-cheese/blob/main/LICENSE)
+[![Latest release](https://img.shields.io/github/v/release/paulnsorensen/easy-cheese?style=flat-square)](https://github.com/paulnsorensen/easy-cheese/releases/latest)
+
+## Why cheese?
+
+Two reasons:
+
+1. **Cheese is a metaphor for the workflow.** Code starts as fresh milk (an idea), gets cultured (research), molded (spec'd), cooked (implemented), pressed (hardened with tests), aged (reviewed), and cured (fixed). Each phase has a skill.
+2. **Cheese is delicious.** And so is shipping software you trust.
+
+## The pipeline
+
+```mermaid
+flowchart LR
+    culture[/culture/] --> mold[/mold/]
+    mold --> cook[/cook/]
+    cook --> press[/press/]
+    press --> age[/age/]
+    age --> cure[/cure/]
+```
+
+Each skill is independently invocable — you don't have to run the full pipeline.
+
+## Quick start
+
+```bash
+# Install the plugin into Claude Code
+curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh | bash
+```
+
+See [Install](install.md) for per-user, per-project, and custom install layouts.
+
+## Skills at a glance
+
+| Skill                          | When to use                                                       |
+| ------------------------------ | ----------------------------------------------------------------- |
+| [`/cheese`](skills/cheese.md)  | Unified entry point — routes any input to the right skill         |
+| [`/culture`](skills/culture.md) | Deep codebase exploration, no writes                              |
+| [`/mold`](skills/mold.md)      | Shape a fuzzy idea into a written spec                            |
+| [`/cook`](skills/cook.md)      | Implement an approved spec via TDD                                |
+| [`/press`](skills/press.md)    | Harden tests after `/cook`                                        |
+| [`/age`](skills/age.md)        | Nine-dimension code review                                        |
+| [`/cure`](skills/cure.md)      | Apply selected fixes from an age report                           |
+| [`/ultracook`](skills/ultracook.md) | Full autonomous pipeline (cook → press → age → cure → …)     |
+| [`/melt`](skills/melt.md)      | Resolve merge / rebase / cherry-pick conflicts structurally        |
+| [`/hard-cheese`](skills/hard-cheese.md) | Metacognitive review gate before sharing code                       |
+
+Browse the full [Skills index](skills/index.md) for every skill, its triggers, and inputs/outputs.
+
+## Project links
+
+- [GitHub repository](https://github.com/paulnsorensen/easy-cheese)
+- [Contributing guide](contributing.md)
+- [Security policy](security.md)
+- [Code of conduct](code-of-conduct.md)
+- [Releases](https://github.com/paulnsorensen/easy-cheese/releases)

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,12 +28,20 @@ Each skill is independently invocable — you don't have to run the full pipelin
 
 ## Quick start
 
+The portable path that works on every OS is `gh skill`:
+
 ```bash
-# Install the plugin into Claude Code
+gh skill install paulnsorensen/easy-cheese
+```
+
+If you're on macOS and want the surrounding ecosystem (CLI tools + MCP servers) wired up in one shot:
+
+```bash
+# macOS only — relies on Homebrew
 curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh | bash
 ```
 
-See [Install](install.md) for per-user, per-project, and custom install layouts.
+See [Install](install.md) for per-user, per-project, manual, and platform-specific install paths.
 
 ## Skills at a glance
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,8 +1,8 @@
 # Install
 
-easy-cheese skills can be installed three ways. Pick the one that matches your harness.
+easy-cheese skills can be installed two ways. Pick the one that matches your harness and platform.
 
-## `gh skill` (recommended)
+## `gh skill` (recommended, all platforms)
 
 Requires [GitHub CLI](https://cli.github.com) v2.90.0+ with the `gh skill` command.
 
@@ -51,14 +51,6 @@ gh skill preview paulnsorensen/easy-cheese cook
 gh skill update --all
 ```
 
-## Claude Code plugin
-
-Once a `.claude-plugin/plugin.json` ships, install with:
-
-```bash
-/plugin install paulnsorensen/easy-cheese
-```
-
 ## Manual copy
 
 ```bash
@@ -71,9 +63,12 @@ mkdir -p .claude/skills
 cp -r skills/cook .claude/skills/
 ```
 
-## Bootstrap script (tools + MCP servers)
+## Bootstrap script (macOS only — tools + MCP servers)
 
 The repo ships an `install.sh` that handles the surrounding ecosystem — CLI tools (`ripgrep`, `jq`, `fd`, `ast-grep`, `mergiraf`, `tilth`, etc.) and MCP servers (`tilth`, `context7`, `tavily`, `code-review-graph`).
+
+!!! warning "macOS-only"
+    `install.sh` exits on non-macOS hosts and requires Homebrew. On Linux or Windows, use the `gh skill` path above and install CLI tools and MCP servers via your system package manager.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh | bash
@@ -86,7 +81,7 @@ Flags:
 | `--tools <list>` | Comma-separated CLI tools (`gh`, `ripgrep`, `fd`, `jq`, `ast-grep`, `git-delta`, `just`, `mergiraf`, `tilth`) |
 | `--mcp <list>` | MCP servers to register (`tilth`, `context7`, `tavily`, `code-review-graph`, `none`) |
 | `--skip-mcp` / `--skip-tools` | Run one half only |
-| `--harness <list>` | Harness to register MCP servers with (`auto`, `claude-code`, `cursor`, `codex`, `gemini`, `vscode`, `zed`, `copilot`) |
+| `--harness <list>` | Harness to register skills + MCP servers with. Passed through to `gh skill install --agent`, so values must match: `auto`, `claude-code`, `cursor`, `codex`, `github-copilot`, `gemini-cli` |
 | `--no-edit` | Register tilth without the `--edit` capability |
 | `--dry-run` | Print what would happen without changing anything |
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,93 @@
+# Install
+
+easy-cheese skills can be installed three ways. Pick the one that matches your harness.
+
+## `gh skill` (recommended)
+
+Requires [GitHub CLI](https://cli.github.com) v2.90.0+ with the `gh skill` command.
+
+```bash
+# Browse and pick
+gh skill install paulnsorensen/easy-cheese
+
+# Install one skill
+gh skill install paulnsorensen/easy-cheese cook
+
+# Install every skill in one shot
+for s in age briesearch cheese cheese-factory cheez-read cheez-search \
+         cheez-write cook culture cure hard-cheese melt mold press ultracook; do
+  gh skill install paulnsorensen/easy-cheese "$s"
+done
+```
+
+### Pin to a release or commit
+
+```bash
+gh skill install paulnsorensen/easy-cheese cook@v1.2.0
+gh skill install paulnsorensen/easy-cheese cook@abc123def
+```
+
+### Choose agent and scope
+
+```bash
+# User-wide (recommended for personal toolkits)
+gh skill install paulnsorensen/easy-cheese --agent claude-code --scope user
+
+# Committed into the current project repo
+gh skill install paulnsorensen/easy-cheese --agent claude-code --scope project
+```
+
+Supported `--agent` values include `claude-code`, `github-copilot`, `cursor`, `codex`, and `gemini-cli`. Omit `--agent` to auto-detect.
+
+### Preview before install
+
+```bash
+gh skill preview paulnsorensen/easy-cheese cook
+```
+
+### Keep up to date
+
+```bash
+gh skill update --all
+```
+
+## Claude Code plugin
+
+Once a `.claude-plugin/plugin.json` ships, install with:
+
+```bash
+/plugin install paulnsorensen/easy-cheese
+```
+
+## Manual copy
+
+```bash
+# Per-user
+mkdir -p ~/.claude/skills
+cp -r skills/age ~/.claude/skills/
+
+# Per-project
+mkdir -p .claude/skills
+cp -r skills/cook .claude/skills/
+```
+
+## Bootstrap script (tools + MCP servers)
+
+The repo ships an `install.sh` that handles the surrounding ecosystem — CLI tools (`ripgrep`, `jq`, `fd`, `ast-grep`, `mergiraf`, `tilth`, etc.) and MCP servers (`tilth`, `context7`, `tavily`, `code-review-graph`).
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh | bash
+```
+
+Flags:
+
+| Flag | Purpose |
+| --- | --- |
+| `--tools <list>` | Comma-separated CLI tools (`gh`, `ripgrep`, `fd`, `jq`, `ast-grep`, `git-delta`, `just`, `mergiraf`, `tilth`) |
+| `--mcp <list>` | MCP servers to register (`tilth`, `context7`, `tavily`, `code-review-graph`, `none`) |
+| `--skip-mcp` / `--skip-tools` | Run one half only |
+| `--harness <list>` | Harness to register MCP servers with (`auto`, `claude-code`, `cursor`, `codex`, `gemini`, `vscode`, `zed`, `copilot`) |
+| `--no-edit` | Register tilth without the `--edit` capability |
+| `--dry-run` | Print what would happen without changing anything |
+
+See `scripts/install.sh --help` for the full reference.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+mkdocs==1.6.1
+mkdocs-material==9.5.49
+mkdocs-gen-files==0.5.0
+mkdocs-literate-nav==0.6.1
+mkdocs-section-index==0.3.9
+pymdown-extensions==10.12
+pyyaml==6.0.2

--- a/justfile
+++ b/justfile
@@ -38,3 +38,16 @@ check: lint-md-fix lint-yaml-fix lint-yaml lint-sh test
 
 # CI-mode verification (no autofixes)
 ci: lint-md lint-yaml lint-sh test
+
+# Install docs build dependencies into a local venv
+docs-install:
+    python3 -m venv .venv
+    .venv/bin/python -m pip install -r docs/requirements.txt
+
+# Build the docs site (output: site/)
+docs-build: docs-install
+    .venv/bin/mkdocs build --strict
+
+# Serve docs locally on http://localhost:8000 with live reload
+docs-serve: docs-install
+    .venv/bin/mkdocs serve

--- a/justfile
+++ b/justfile
@@ -34,10 +34,10 @@ lint-yaml:
     yamllint -c .yamllint.yml .
 
 # Full local check with autofixes
-check: lint-md-fix lint-yaml-fix lint-yaml lint-sh test
+check: lint-md-fix lint-yaml-fix lint-yaml lint-sh test docs-build
 
 # CI-mode verification (no autofixes)
-ci: lint-md lint-yaml lint-sh test
+ci: lint-md lint-yaml lint-sh test docs-build
 
 # Install docs build dependencies into a local venv
 docs-install:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,96 @@
+site_name: easy-cheese
+site_description: A skills plugin for Claude Code — the cheese-making pipeline for code review, implementation, and refactoring.
+site_url: https://paulnsorensen.github.io/easy-cheese/
+site_author: Paul Sorensen
+
+repo_name: paulnsorensen/easy-cheese
+repo_url: https://github.com/paulnsorensen/easy-cheese
+edit_uri: edit/main/
+
+copyright: Copyright &copy; 2026 Paul Sorensen — MIT License
+
+docs_dir: docs
+
+theme:
+  name: material
+  language: en
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.indexes
+    - navigation.top
+    - navigation.footer
+    - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+    - content.action.view
+    - content.tabs.link
+    - search.suggest
+    - search.highlight
+    - search.share
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep orange
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep orange
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  icon:
+    repo: fontawesome/brands/github
+    edit: material/pencil
+    view: material/eye
+
+plugins:
+  - search
+  - gen-files:
+      scripts:
+        - scripts/gen_docs.py
+  - literate-nav:
+      nav_file: SUMMARY.md
+  - section-index
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - fenced_code
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.tasklist:
+      custom_checkbox: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/paulnsorensen/easy-cheese
+    - icon: fontawesome/solid/mug-hot
+      link: https://www.buymeacoffee.com/paulnsorensen

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -3,7 +3,8 @@
 Invoked by mkdocs-gen-files. For each skills/<name>/SKILL.md:
   - Emit docs/skills/<name>.md mirroring the SKILL.md body, with title from
     frontmatter and an "edit this page" link back to the source.
-  - Mirror references/* under docs/skills/<name>/references/*.
+  - Mirror references/* (Markdown + asset files like JSON schemas) under
+    docs/skills/<name>/references/*. Only Markdown refs land in the nav.
   - Rewrite internal Markdown links to match the flattened docs layout.
 
 Also emits:
@@ -157,12 +158,12 @@ def emit_skill_page(skill_dir: Path) -> dict | None:
     src_rel = skill_md.relative_to(REPO_ROOT).as_posix()
     page_path = f"skills/{name}.md"
 
-    front = (
-        f"---\n"
-        f"title: /{name}\n"
-        f"description: {first_sentence(description)}\n"
-        f"---\n\n"
-    )
+    front = "---\n" + yaml.safe_dump(
+        {"title": f"/{name}", "description": first_sentence(description)},
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    ) + "---\n\n"
 
     header = (
         f"# `/{name}`\n\n"
@@ -184,17 +185,23 @@ def emit_skill_page(skill_dir: Path) -> dict | None:
     refs_dir = skill_dir / "references"
     refs: list[tuple[str, str]] = []
     if refs_dir.is_dir():
-        for ref in sorted(refs_dir.glob("*.md")):
+        for ref in sorted(p for p in refs_dir.iterdir() if p.is_file()):
             ref_rel = ref.relative_to(REPO_ROOT).as_posix()
             out = f"skills/{name}/references/{ref.name}"
-            content = apply_link_rewrite(
-                ref.read_text(encoding="utf-8"),
-                lambda url: rewrite_ref_link(url, name),
-            )
-            with mkdocs_gen_files.open(out, "w") as fh:
-                fh.write(content)
-            mkdocs_gen_files.set_edit_path(out, ref_rel)
-            refs.append((ref.stem, out))
+            if ref.suffix.lower() == ".md":
+                content = apply_link_rewrite(
+                    ref.read_text(encoding="utf-8"),
+                    lambda url: rewrite_ref_link(url, name),
+                )
+                with mkdocs_gen_files.open(out, "w") as fh:
+                    fh.write(content)
+                mkdocs_gen_files.set_edit_path(out, ref_rel)
+                refs.append((ref.stem, out))
+            else:
+                # Non-Markdown reference (e.g. JSON schema) — copy as a static
+                # asset. set_edit_path() only applies to rendered pages.
+                with mkdocs_gen_files.open(out, "wb") as fh:
+                    fh.write(ref.read_bytes())
 
     return {"name": name, "description": description, "page": page_path, "refs": refs}
 
@@ -224,7 +231,12 @@ def emit_root_passthrough(filename: str, dest: str, title: str) -> bool:
     text = src.read_text(encoding="utf-8")
     text = re.sub(r"^#\s+.*\n", "", text, count=1)
     text = apply_link_rewrite(text, rewrite_root_passthrough_link)
-    front = f"---\ntitle: {title}\n---\n\n# {title}\n\n"
+    front = "---\n" + yaml.safe_dump(
+        {"title": title},
+        sort_keys=False,
+        allow_unicode=True,
+        default_flow_style=False,
+    ) + f"---\n\n# {title}\n\n"
     with mkdocs_gen_files.open(dest, "w") as fh:
         fh.write(front + text.lstrip())
     mkdocs_gen_files.set_edit_path(dest, filename)

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -1,0 +1,275 @@
+"""Generate MkDocs pages from skill sources at build time.
+
+Invoked by mkdocs-gen-files. For each skills/<name>/SKILL.md:
+  - Emit docs/skills/<name>.md mirroring the SKILL.md body, with title from
+    frontmatter and an "edit this page" link back to the source.
+  - Mirror references/* under docs/skills/<name>/references/*.
+  - Rewrite internal Markdown links to match the flattened docs layout.
+
+Also emits:
+  - docs/skills/index.md — table listing every skill + its one-line description.
+  - docs/SUMMARY.md — literate-nav for the whole site.
+  - docs/contributing.md, docs/security.md, docs/code-of-conduct.md — slurped
+    from the repo root so they stay single-sourced.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import mkdocs_gen_files
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+REPO_URL = "https://github.com/paulnsorensen/easy-cheese"
+
+LINK_RE = re.compile(r"(?<!\!)\[([^\]]+)\]\(([^)\s]+)(\s+\"[^\"]*\")?\)")
+NESTED_IMAGE_LINK_RE = re.compile(r"(\[!\[[^\]]*\]\([^)]+\)\]\()([^)\s]+)(\))")
+
+ROOT_DOC_MAP = {
+    "README.md": "readme.md",
+    "CONTRIBUTING.md": "contributing.md",
+    "SECURITY.md": "security.md",
+    "CODE_OF_CONDUCT.md": "code-of-conduct.md",
+}
+
+
+def parse_frontmatter(text: str) -> tuple[dict, str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return {}, text
+    raw = text[4:end]
+    body = text[end + 5 :]
+    try:
+        meta = yaml.safe_load(raw) or {}
+    except yaml.YAMLError:
+        meta = {}
+    return meta, body
+
+
+def first_sentence(desc: str) -> str:
+    desc = desc.replace("\n", " ").strip()
+    match = re.search(r"^(.*?[.!?])(\s|$)", desc)
+    return (match.group(1) if match else desc)[:240]
+
+
+def _split_anchor(path: str) -> tuple[str, str]:
+    if "#" in path:
+        body, anchor = path.split("#", 1)
+        return body, "#" + anchor
+    return path, ""
+
+
+def rewrite_skill_link(url: str, skill_name: str) -> str:
+    """Rewrite link from skills/<name>/SKILL.md space to docs/skills/<name>.md space."""
+    if url.startswith(("http://", "https://", "mailto:", "#")):
+        return url
+    path, anchor = _split_anchor(url)
+
+    if path.startswith("references/"):
+        return f"{skill_name}/{path}{anchor}"
+
+    m = re.match(r"^\.\./([^/]+)/SKILL\.md$", path)
+    if m:
+        return f"{m.group(1)}.md{anchor}"
+
+    m = re.match(r"^\.\./([^/]+)/references/(.+)$", path)
+    if m:
+        return f"{m.group(1)}/references/{m.group(2)}{anchor}"
+
+    m = re.match(r"^\.\./\.\./([A-Z_]+\.md)$", path)
+    if m and m.group(1) in ROOT_DOC_MAP:
+        return f"../{ROOT_DOC_MAP[m.group(1)]}{anchor}"
+
+    if path == "../../LICENSE":
+        return f"{REPO_URL}/blob/main/LICENSE"
+
+    return url
+
+
+def rewrite_ref_link(url: str, skill_name: str) -> str:
+    """Rewrite link from skills/<name>/references/<file>.md to docs/skills/<name>/references/<file>.md."""
+    if url.startswith(("http://", "https://", "mailto:", "#")):
+        return url
+    path, anchor = _split_anchor(url)
+
+    if path == "../SKILL.md":
+        return f"../../{skill_name}.md{anchor}"
+
+    m = re.match(r"^\.\./\.\./([^/]+)/SKILL\.md$", path)
+    if m:
+        return f"../../{m.group(1)}.md{anchor}"
+
+    m = re.match(r"^\.\./\.\./([^/]+)/references/(.+)$", path)
+    if m:
+        return f"../../{m.group(1)}/references/{m.group(2)}{anchor}"
+
+    m = re.match(r"^\.\./\.\./\.\./([A-Z_]+\.md)$", path)
+    if m and m.group(1) in ROOT_DOC_MAP:
+        return f"../../../{ROOT_DOC_MAP[m.group(1)]}{anchor}"
+
+    if path == "../../../LICENSE":
+        return f"{REPO_URL}/blob/main/LICENSE"
+
+    return url
+
+
+def rewrite_root_passthrough_link(url: str) -> str:
+    """Rewrite link inside CONTRIBUTING/SECURITY/CODE_OF_CONDUCT after they move into docs/."""
+    if url.startswith(("http://", "https://", "mailto:", "#")):
+        return url
+    path, anchor = _split_anchor(url)
+    stripped = path[2:] if path.startswith("./") else path
+
+    if stripped in ROOT_DOC_MAP:
+        return f"./{ROOT_DOC_MAP[stripped]}{anchor}"
+    if stripped == "LICENSE":
+        return f"{REPO_URL}/blob/main/LICENSE"
+    return url
+
+
+def apply_link_rewrite(text: str, rewriter) -> str:
+    def image_repl(match: re.Match) -> str:
+        prefix, url, suffix = match.group(1), match.group(2), match.group(3)
+        return f"{prefix}{rewriter(url)}{suffix}"
+
+    def repl(match: re.Match) -> str:
+        label, url, title = match.group(1), match.group(2), match.group(3) or ""
+        return f"[{label}]({rewriter(url)}{title})"
+
+    return LINK_RE.sub(repl, NESTED_IMAGE_LINK_RE.sub(image_repl, text))
+
+
+def emit_skill_page(skill_dir: Path) -> dict | None:
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        return None
+
+    meta, body = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+    name = meta.get("name") or skill_dir.name
+    description = meta.get("description", "").strip()
+    license_id = meta.get("license", "MIT")
+
+    src_rel = skill_md.relative_to(REPO_ROOT).as_posix()
+    page_path = f"skills/{name}.md"
+
+    front = (
+        f"---\n"
+        f"title: /{name}\n"
+        f"description: {first_sentence(description)}\n"
+        f"---\n\n"
+    )
+
+    header = (
+        f"# `/{name}`\n\n"
+        f"!!! info \"Skill metadata\"\n"
+        f"    - **License:** {license_id}\n"
+        f"    - **Source:** [`{src_rel}`]({REPO_URL}/blob/main/{src_rel})\n\n"
+        f"**When to invoke:** {description}\n\n"
+        f"---\n\n"
+    )
+
+    body = re.sub(r"^---\s*\n", "", body, count=1)
+    body = re.sub(r"^#\s+/?" + re.escape(name) + r"\s*\n", "", body, count=1, flags=re.MULTILINE)
+    body = apply_link_rewrite(body, lambda url: rewrite_skill_link(url, name))
+
+    with mkdocs_gen_files.open(page_path, "w") as fh:
+        fh.write(front + header + body.lstrip())
+    mkdocs_gen_files.set_edit_path(page_path, src_rel)
+
+    refs_dir = skill_dir / "references"
+    refs: list[tuple[str, str]] = []
+    if refs_dir.is_dir():
+        for ref in sorted(refs_dir.glob("*.md")):
+            ref_rel = ref.relative_to(REPO_ROOT).as_posix()
+            out = f"skills/{name}/references/{ref.name}"
+            content = apply_link_rewrite(
+                ref.read_text(encoding="utf-8"),
+                lambda url: rewrite_ref_link(url, name),
+            )
+            with mkdocs_gen_files.open(out, "w") as fh:
+                fh.write(content)
+            mkdocs_gen_files.set_edit_path(out, ref_rel)
+            refs.append((ref.stem, out))
+
+    return {"name": name, "description": description, "page": page_path, "refs": refs}
+
+
+def emit_skills_index(skills: list[dict]) -> None:
+    lines = [
+        "# Skills",
+        "",
+        "Every skill in easy-cheese. Each one is independently invocable — type `/<name>` or describe what you want in plain English and Claude Code will route to the right one.",
+        "",
+        "| Skill | When to use |",
+        "| --- | --- |",
+    ]
+    for s in skills:
+        summary = first_sentence(s["description"]).replace("|", "\\|")
+        lines.append(f"| [`/{s['name']}`]({s['name']}.md) | {summary} |")
+    lines.append("")
+
+    with mkdocs_gen_files.open("skills/index.md", "w") as fh:
+        fh.write("\n".join(lines))
+
+
+def emit_root_passthrough(filename: str, dest: str, title: str) -> bool:
+    src = REPO_ROOT / filename
+    if not src.exists():
+        return False
+    text = src.read_text(encoding="utf-8")
+    text = re.sub(r"^#\s+.*\n", "", text, count=1)
+    text = apply_link_rewrite(text, rewrite_root_passthrough_link)
+    front = f"---\ntitle: {title}\n---\n\n# {title}\n\n"
+    with mkdocs_gen_files.open(dest, "w") as fh:
+        fh.write(front + text.lstrip())
+    mkdocs_gen_files.set_edit_path(dest, filename)
+    return True
+
+
+def emit_nav(skills: list[dict], extras: list[tuple[str, str]]) -> None:
+    lines = [
+        "* [Home](index.md)",
+        "* [Install](install.md)",
+        "* Skills",
+        "    * [Overview](skills/index.md)",
+    ]
+    for s in skills:
+        lines.append(f"    * [/{s['name']}](skills/{s['name']}.md)")
+        for ref_name, ref_path in s["refs"]:
+            lines.append(f"        * [{ref_name}]({ref_path})")
+    if extras:
+        lines.append("* Project")
+        for title, path in extras:
+            lines.append(f"    * [{title}]({path})")
+    with mkdocs_gen_files.open("SUMMARY.md", "w") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+def main() -> None:
+    skills: list[dict] = []
+    for skill_dir in sorted(p for p in SKILLS_DIR.iterdir() if p.is_dir()):
+        page = emit_skill_page(skill_dir)
+        if page is not None:
+            skills.append(page)
+
+    emit_skills_index(skills)
+
+    extras: list[tuple[str, str]] = []
+    if emit_root_passthrough("README.md", "readme.md", "README"):
+        extras.append(("README", "readme.md"))
+    if emit_root_passthrough("CONTRIBUTING.md", "contributing.md", "Contributing"):
+        extras.append(("Contributing", "contributing.md"))
+    if emit_root_passthrough("SECURITY.md", "security.md", "Security policy"):
+        extras.append(("Security", "security.md"))
+    if emit_root_passthrough("CODE_OF_CONDUCT.md", "code-of-conduct.md", "Code of conduct"):
+        extras.append(("Code of conduct", "code-of-conduct.md"))
+
+    emit_nav(skills, extras)
+
+
+main()

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -75,7 +75,10 @@ Options:
   --harness <selection> Harness to register skills + MCP servers with.
                        Default: auto-detect claude-code, cursor, and codex.
                        Accepts a single harness, a comma-separated list, or
-                       'auto'. Other values include vscode, gemini, zed, copilot.
+                       'auto'. Values are passed through to
+                       'gh skill install --agent', so use the gh skill agent
+                       names: claude-code, cursor, codex, github-copilot,
+                       gemini-cli.
   --no-edit            Register tilth without the --edit capability.
   --dry-run            Print what would happen without changing anything.
   -h, --help           Show this help.

--- a/skills/briesearch/references/unavailable.md
+++ b/skills/briesearch/references/unavailable.md
@@ -9,7 +9,7 @@ Optional MCP servers (Context7, Tavily, code-review-graph, tilth) are not always
 | Context7 | Read repo docs, package README, vendor pages, then web search | Cap at `speculating` for version-specific questions |
 | Tavily | Host web search or user-provided links | Cap at `speculating` when freshness matters |
 | Codebase (cheez-*) | Fall back to Serena or LSP, `sg`, `ripgrep`, `find`, and targeted reads | Cap at `speculating` when local precedent is central |
-| code-review-graph (full tool list in [README → code-review-graph](../../../README.md#code-review-graph-review-impact-radius-architecture-semantic-search)) | Use `tilth_deps` + `cheez-search` callers (`tilth_search kind: "callers"`) for blast radius; skip cross-repo, semantic search, and architecture framing | Cap at `speculating` for cross-repo or large-architecture questions |
+| code-review-graph (full tool list in [README → Optional tools](../../../README.md#optional-tools)) | Use `tilth_deps` + `cheez-search` callers (`tilth_search kind: "callers"`) for blast radius; skip cross-repo, semantic search, and architecture framing | Cap at `speculating` for cross-repo or large-architecture questions |
 | GitHub (`gh`) | Note absence; user-supplied URLs are acceptable | Skip with a confidence note |
 
 ## Reporting an unavailable source

--- a/tests/python/test_gen_docs.py
+++ b/tests/python/test_gen_docs.py
@@ -1,0 +1,202 @@
+"""Tests for scripts/gen_docs.py link-rewrite rules.
+
+The generator's only non-trivial logic is link rewriting between three
+coordinate spaces (skill body, reference body, root passthrough). A regression
+here silently produces broken docs links, so each case gets a targeted test.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GEN_DOCS = REPO_ROOT / "scripts" / "gen_docs.py"
+
+
+@pytest.fixture(scope="module")
+def gen_docs() -> ModuleType:
+    """Import gen_docs.py without executing main() (mkdocs_gen_files isn't on PATH outside the docs venv)."""
+    sys.modules.setdefault("mkdocs_gen_files", _stub_mkdocs_gen_files())
+    spec = importlib.util.spec_from_file_location("gen_docs", GEN_DOCS)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Block main() from running on import — it would try to walk skills/ and write into the stub.
+    src = GEN_DOCS.read_text(encoding="utf-8").replace("\nmain()\n", "\n")
+    exec(compile(src, str(GEN_DOCS), "exec"), module.__dict__)
+    return module
+
+
+def _stub_mkdocs_gen_files() -> ModuleType:
+    import types
+
+    mod = types.ModuleType("mkdocs_gen_files")
+
+    class _Sink:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def write(self, _data):
+            return None
+
+    setattr(mod, "open", lambda *_a, **_kw: _Sink())
+    setattr(mod, "set_edit_path", lambda *_a, **_kw: None)
+    return mod
+
+
+class TestRewriteSkillLink:
+    def test_external_urls_pass_through(self, gen_docs):
+        for url in (
+            "https://example.com",
+            "http://example.com",
+            "mailto:x@y.z",
+            "#section",
+        ):
+            assert gen_docs.rewrite_skill_link(url, "cook") == url
+
+    def test_local_reference_resolves_under_skill(self, gen_docs):
+        assert gen_docs.rewrite_skill_link("references/foo.md", "cook") == "cook/references/foo.md"
+
+    def test_local_reference_keeps_anchor(self, gen_docs):
+        assert (
+            gen_docs.rewrite_skill_link("references/foo.md#part", "cook")
+            == "cook/references/foo.md#part"
+        )
+
+    def test_cross_skill_skill_md_flattens(self, gen_docs):
+        assert gen_docs.rewrite_skill_link("../press/SKILL.md", "cook") == "press.md"
+
+    def test_cross_skill_skill_md_with_anchor(self, gen_docs):
+        assert (
+            gen_docs.rewrite_skill_link("../press/SKILL.md#auto-mode", "cook")
+            == "press.md#auto-mode"
+        )
+
+    def test_cross_skill_reference(self, gen_docs):
+        assert (
+            gen_docs.rewrite_skill_link("../press/references/quality-gates.md", "cook")
+            == "press/references/quality-gates.md"
+        )
+
+    def test_root_doc_resolves_up_one_level(self, gen_docs):
+        assert gen_docs.rewrite_skill_link("../../CONTRIBUTING.md", "cook") == "../contributing.md"
+        assert gen_docs.rewrite_skill_link("../../SECURITY.md", "cook") == "../security.md"
+        assert gen_docs.rewrite_skill_link("../../README.md", "cook") == "../readme.md"
+
+    def test_license_becomes_absolute_repo_url(self, gen_docs):
+        assert gen_docs.rewrite_skill_link("../../LICENSE", "cook") == f"{gen_docs.REPO_URL}/blob/main/LICENSE"
+
+    def test_unknown_path_is_untouched(self, gen_docs):
+        assert gen_docs.rewrite_skill_link("../../some/other/file.md", "cook") == "../../some/other/file.md"
+
+
+class TestRewriteRefLink:
+    def test_external_urls_pass_through(self, gen_docs):
+        for url in ("https://example.com", "mailto:x@y.z", "#anchor"):
+            assert gen_docs.rewrite_ref_link(url, "press") == url
+
+    def test_sibling_skill_md(self, gen_docs):
+        assert gen_docs.rewrite_ref_link("../SKILL.md", "press") == "../../press.md"
+        assert gen_docs.rewrite_ref_link("../SKILL.md#auto", "press") == "../../press.md#auto"
+
+    def test_cross_skill_skill_md(self, gen_docs):
+        assert gen_docs.rewrite_ref_link("../../cook/SKILL.md", "press") == "../../cook.md"
+
+    def test_cross_skill_reference(self, gen_docs):
+        assert (
+            gen_docs.rewrite_ref_link("../../cook/references/foo.md", "press")
+            == "../../cook/references/foo.md"
+        )
+
+    def test_root_doc(self, gen_docs):
+        assert gen_docs.rewrite_ref_link("../../../CONTRIBUTING.md", "press") == "../../../contributing.md"
+        assert gen_docs.rewrite_ref_link("../../../README.md", "press") == "../../../readme.md"
+
+    def test_license(self, gen_docs):
+        assert (
+            gen_docs.rewrite_ref_link("../../../LICENSE", "press")
+            == f"{gen_docs.REPO_URL}/blob/main/LICENSE"
+        )
+
+
+class TestRewriteRootPassthroughLink:
+    def test_external_pass_through(self, gen_docs):
+        for url in ("https://example.com", "mailto:x@y.z", "#anchor"):
+            assert gen_docs.rewrite_root_passthrough_link(url) == url
+
+    def test_known_root_doc(self, gen_docs):
+        assert gen_docs.rewrite_root_passthrough_link("CONTRIBUTING.md") == "./contributing.md"
+        assert gen_docs.rewrite_root_passthrough_link("./SECURITY.md") == "./security.md"
+        assert gen_docs.rewrite_root_passthrough_link("CODE_OF_CONDUCT.md") == "./code-of-conduct.md"
+
+    def test_known_root_doc_with_anchor(self, gen_docs):
+        assert (
+            gen_docs.rewrite_root_passthrough_link("./CONTRIBUTING.md#pull-requests")
+            == "./contributing.md#pull-requests"
+        )
+
+    def test_license(self, gen_docs):
+        assert (
+            gen_docs.rewrite_root_passthrough_link("LICENSE")
+            == f"{gen_docs.REPO_URL}/blob/main/LICENSE"
+        )
+
+    def test_unknown_path_untouched(self, gen_docs):
+        assert gen_docs.rewrite_root_passthrough_link("skills/cook/SKILL.md") == "skills/cook/SKILL.md"
+
+
+class TestApplyLinkRewrite:
+    def test_rewrites_markdown_link(self, gen_docs):
+        text = "See [the press skill](../press/SKILL.md) for more."
+        out = gen_docs.apply_link_rewrite(text, lambda u: gen_docs.rewrite_skill_link(u, "cook"))
+        assert out == "See [the press skill](press.md) for more."
+
+    def test_rewrites_link_with_title(self, gen_docs):
+        text = '[link](../press/SKILL.md "Press skill")'
+        out = gen_docs.apply_link_rewrite(text, lambda u: gen_docs.rewrite_skill_link(u, "cook"))
+        assert out == '[link](press.md "Press skill")'
+
+    def test_leaves_inline_images_alone(self, gen_docs):
+        text = "![alt](references/diagram.png)"
+        out = gen_docs.apply_link_rewrite(text, lambda u: gen_docs.rewrite_skill_link(u, "cook"))
+        assert out == "![alt](references/diagram.png)"
+
+    def test_rewrites_nested_image_link(self, gen_docs):
+        text = "[![alt](logo.png)](../press/SKILL.md)"
+        out = gen_docs.apply_link_rewrite(text, lambda u: gen_docs.rewrite_skill_link(u, "cook"))
+        assert out == "[![alt](logo.png)](press.md)"
+
+
+class TestFirstSentence:
+    def test_grabs_first_sentence(self, gen_docs):
+        assert gen_docs.first_sentence("First sentence. Second.") == "First sentence."
+
+    def test_handles_newlines(self, gen_docs):
+        assert gen_docs.first_sentence("First\nsentence.\n\nSecond.") == "First sentence."
+
+    def test_caps_at_240_chars(self, gen_docs):
+        long = "x" * 300
+        assert len(gen_docs.first_sentence(long)) == 240
+
+
+class TestParseFrontmatter:
+    def test_extracts_metadata(self, gen_docs):
+        meta, body = gen_docs.parse_frontmatter("---\nname: foo\ndescription: bar\n---\nbody")
+        assert meta == {"name": "foo", "description": "bar"}
+        assert body == "body"
+
+    def test_no_frontmatter(self, gen_docs):
+        meta, body = gen_docs.parse_frontmatter("just body")
+        assert meta == {}
+        assert body == "just body"
+
+    def test_malformed_yaml_does_not_raise(self, gen_docs):
+        meta, _ = gen_docs.parse_frontmatter("---\nname: : foo\n---\nbody")
+        assert meta == {}


### PR DESCRIPTION
## What changed

Added a complete documentation site built with MkDocs that auto-generates skill pages from source files. Includes GitHub Actions deployment to gh-pages and local development targets.

## Why

The project needs public-facing documentation. Generating docs from skill sources keeps them in sync with the implementation and avoids duplication.

## How to verify

- Visit [the docs](https://paulnsorensen.github.io/easy-cheese/) after merge (deploys automatically to gh-pages)
- Or run `just docs-serve` locally to preview at http://localhost:8000
- Verify the skills index appears at /skills/ and each skill has a dedicated page

## Risk / rollout notes

None. Docs are read-only and deployment is automatic on push to main.