### PR TITLE
ci(docs): deploy via Pages Actions instead of gh-pages branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,9 @@ jobs:
   build:
     name: build docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -52,37 +55,32 @@ jobs:
 
       - name: Install docs dependencies
         run: pip install --no-cache-dir -r docs/requirements.txt
+
+      - name: Configure Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Build docs (strict)
         run: mkdocs build --strict
 
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: site
+
   deploy:
-    name: deploy to gh-pages
+    name: deploy to GitHub Pages
     needs: build
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-          cache: pip
-          cache-dependency-path: docs/requirements.txt
-
-      - name: Install docs dependencies
-        run: pip install --no-cache-dir -r docs/requirements.txt
-
-      - name: Configure git identity
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Deploy to gh-pages
-        run: mkdocs gh-deploy --force --no-history
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## What changed

Replace the `mkdocs gh-deploy --force --no-history` step with the official GitHub Pages Actions flow (`actions/configure-pages` + `actions/upload-pages-artifact` + `actions/deploy-pages`).

## Why

The repo's Pages source is `build_type: workflow` (Actions deploy), but the old workflow pushed to a `gh-pages` branch — which Pages was configured to ignore. Result: the workflow reported success, the `gh-pages` branch existed, but `https://paulnsorensen.github.io/easy-cheese/` 404'd because no Pages artifact was ever deployed.

## How to verify

After merge, the next `push` to `main` runs the `docs` workflow:

- `build` job → builds `site/` with `mkdocs build --strict`, then uploads the artifact (only on push-to-main).
- `deploy` job → `actions/deploy-pages` publishes the artifact; the run URL surfaces `page_url`.
- `https://paulnsorensen.github.io/easy-cheese/` should return 200 and serve the docs.

## Risk / rollout notes

- The dormant `gh-pages` branch can be deleted after the first successful Pages deployment (`git push origin --delete gh-pages`).
- No code changes — workflow-only.

## Checklist

- [x] Conventional Commits PR title
- [x] Tests added or updated (N/A — workflow change)
- [x] Documentation updated (N/A — workflow change)
- [x] No secrets or credentials added