### PR TITLE
docs(skills): verb-first handoff options + pipeline breadcrumb

### DIFF
--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -123,13 +123,15 @@ Age report: .cheese/age/<slug>.md
 
 ## Handoff
 
+**Pipeline:** culture → mold → cook → press → **[age]** → cure → ship
+
 After the report is on disk, skip any "should I run /cure?" meta-question and go straight to the selection gate. The user's working memory is on the findings, not on whether a follow-up step exists.
 
 1. Render the numbered selection table per `../cure/references/selection.md` directly inline (one row per finding, grouped by stake).
-2. Ask via `AskUserQuestion` which findings to cure. Offer the recognized selection verbs as options:
-   - **Pick findings** — accept a free-text reply using the verbs from `../cure/references/selection.md` (`1,3,5`, `all-high`, `all`, `none`, `skip N`).
-   - **All high-stake** *(recommended when at least one high-stake finding exists)* — equivalent to `all-high`.
-   - **Stop** — equivalent to `none`; leave the report for later.
+2. Ask via `AskUserQuestion` which findings to cure. Lead each option with the verb (what the user wants to *do* next); the underlying selection verb is the backing detail. Offer:
+   - **Pick findings to fix** — accept a free-text reply using the verbs from `../cure/references/selection.md` (`1,3,5`, `all-high`, `all`, `none`, `skip N`).
+   - **Fix all high-stake findings** *(recommended when at least one high-stake finding exists)* — equivalent to `all-high`.
+   - **Stop — leave the report for later** — equivalent to `none`.
 3. On a non-empty selection, hand off to `/cure <slug>` with the selection locked in (pass the chosen ids through so `/cure` skips its own selection prompt and goes straight to apply). `/cure` still owns the apply / validate / report loop and may surface the chosen ids for confirmation if the report has shifted underneath it.
 4. On `none` / `Stop`, exit cleanly with the report path.
 

--- a/skills/cook/SKILL.md
+++ b/skills/cook/SKILL.md
@@ -84,13 +84,15 @@ artifact: <path-to-richer-report-if-any>
 
 ## Handoff
 
-After the package-ready report is printed and the handoff slug is on disk, ask via `AskUserQuestion` which downstream to run. Default options:
+**Pipeline:** culture → mold → **[cook]** → press → age → cure → ship
 
-- **Run /press `<slug>`** *(recommended)* — harden tests before review.
-- **Run /age `<slug>`** — review the diff now and skip the press pass.
+After the package-ready report is printed and the handoff slug is on disk, ask via `AskUserQuestion` which downstream to run. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Default options:
+
+- **Harden tests before review** *(recommended)* — `/press <slug>`.
+- **Review the diff now (skip the press pass)** — `/age <slug>`.
 - **Stop** — leave further hardening for later.
 
-Pre-select `Run /press` when the cooked diff added new behaviour or touched untested seams. The user may also chain: pressing then age then cure happens via each step's own `AskUserQuestion`. Never auto-invoke; the user must select.
+Pre-select **Harden tests before review** when the cooked diff added new behaviour or touched untested seams. The user may also chain: pressing then age then cure happens via each step's own `AskUserQuestion`. Never auto-invoke; the user must select.
 
 When invoked with `--auto`, skip this `AskUserQuestion` entirely and proceed straight into the auto-mode chain (see `## Auto mode` below).
 

--- a/skills/culture/SKILL.md
+++ b/skills/culture/SKILL.md
@@ -62,11 +62,13 @@ The notes slug is the **only** thing culture is allowed to write. No commits, no
 
 ## Handoff
 
-When the conversation reveals real work, ask via `AskUserQuestion` which downstream to run. Default options (pick at most three of these plus a stop):
+**Pipeline:** **[culture]** → mold → cook → press → age → cure → ship
 
-- **Run /mold** *(recommended when the idea is still fuzzy)* — converge on a spec.
-- **Run /cook** *(recommended when the ask is clear and unambiguous)* — implement directly.
-- **Run /cook --auto** — implement directly, then chain through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Offer this when the conversation reached an unambiguous contract *and* the user signalled they want the whole pipeline to run forward without per-step approval ("just do it", "ship it", "auto", "fix it all the way through"). Never pre-select; auto mode opts the user out of the gates that exist for their protection.
+When the conversation reveals real work, ask via `AskUserQuestion` which downstream to run. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Default options (pick at most three of these plus a stop):
+
+- **Shape this into a written spec** *(recommended when the idea is still fuzzy)* — `/mold`.
+- **Implement it directly** *(recommended when the ask is clear and unambiguous)* — `/cook`.
+- **Implement and auto-review through ship** — `/cook --auto`, chains through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Offer this when the conversation reached an unambiguous contract *and* the user signalled they want the whole pipeline to run forward without per-step approval ("just do it", "ship it", "auto", "fix it all the way through"). Never pre-select; auto mode opts the user out of the gates that exist for their protection.
 - **Pause** — keep the dialogue in head; no further action.
 
 `/briesearch` is offered only when the conversation hit a factual gap that external docs could close. `/age` is never the next step from culture — review needs a diff to look at.

--- a/skills/culture/SKILL.md
+++ b/skills/culture/SKILL.md
@@ -68,10 +68,11 @@ When the conversation reveals real work, ask via `AskUserQuestion` which downstr
 
 - **Shape this into a written spec** *(recommended when the idea is still fuzzy)* — `/mold`.
 - **Implement it directly** *(recommended when the ask is clear and unambiguous)* — `/cook`.
-- **Implement and auto-review through ship** — `/cook --auto`, chains through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Offer this when the conversation reached an unambiguous contract *and* the user signalled they want the whole pipeline to run forward without per-step approval ("just do it", "ship it", "auto", "fix it all the way through"). Never pre-select; auto mode opts the user out of the gates that exist for their protection.
+- **Implement and auto-review** — `/cook --auto`, chains through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Stops at the final cure pass; opening or updating the PR stays a manual step. Offer this when the conversation reached an unambiguous contract *and* the user signalled they want the whole pipeline to run forward without per-step approval ("just do it", "ship it", "auto", "fix it all the way through"). Never pre-select; auto mode opts the user out of the gates that exist for their protection.
+- **Research more first** *(when the conversation hit a factual gap external docs could close)* — `/briesearch`.
 - **Pause** — keep the dialogue in head; no further action.
 
-`/briesearch` is offered only when the conversation hit a factual gap that external docs could close. `/age` is never the next step from culture — review needs a diff to look at.
+`/age` is never the next step from culture — review needs a diff to look at.
 
 ## Rules
 

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -20,7 +20,7 @@ Optional flags:
 
 - `--auto` — autonomous mode (propagated from `/cook --auto`). Bypasses the user-selection step. Must be paired with `--stake <floor>` to set the inclusion threshold; `/cook --auto` always passes `--stake medium+`. See `references/selection.md` for the auto-selection rules and `## Auto mode` below for the pass-cap and revert behaviour.
 - `--stake <floor>` — used only with `--auto`. Accepts `high`, `medium+` (medium or higher), or `all`. Without `--auto` this flag is ignored — interactive selection is the only sanctioned path.
-- `--hard` — propagated metacognitive-gate flag (from `/cook --hard` or `/cheese --hard`). Cure is the *only* pipeline skill that fires the gate: when `--hard` is in scope and the user selects the share-for-review handoff option (existing `Run /gh` label), invoke `/hard-cheese <slug>` first and proceed only on exit `0`. Under `--auto --hard`, see `## --hard mode` and the auto-mode puncture clause below.
+- `--hard` — propagated metacognitive-gate flag (from `/cook --hard` or `/cheese --hard`). Cure is the *only* pipeline skill that fires the gate: when `--hard` is in scope and the user selects the share-for-review handoff option (the **Open or update the PR** label, which dispatches `/gh`), invoke `/hard-cheese <slug>` first and proceed only on exit `0`. Under `--auto --hard`, see `## --hard mode` and the auto-mode puncture clause below.
 
 ## Flow
 
@@ -89,20 +89,22 @@ The cure report body lives below the handoff slug in the same file at `.cheese/c
 
 ## Handoff
 
-After the cure report is rendered, ask via `AskUserQuestion` which downstream to run. Default options:
+**Pipeline:** culture → mold → cook → press → age → **[cure]** → ship
 
-- **Run /age `--scope <touched-path>`** *(recommended when fixes were non-trivial)* — re-review the touched code through the proper skill.
-- **Run /gh** — open or update the PR.
+After the cure report is rendered, ask via `AskUserQuestion` which downstream to run. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Default options:
+
+- **Re-review the touched code** *(recommended when fixes were non-trivial)* — `/age --scope <touched-path>`, runs review through the proper skill.
+- **Open or update the PR** — `/gh`.
 - **Stop** — sit on the changes for now.
 
-Pre-select `Run /age` when any applied fix touched logic outside the original finding's hunk, when a corrective fix exposed adjacent risk, or when checks were skipped. Pre-select `Run /gh` when all selected findings applied cleanly and gates passed. Never auto-invoke.
+Pre-select **Re-review the touched code** when any applied fix touched logic outside the original finding's hunk, when a corrective fix exposed adjacent risk, or when checks were skipped. Pre-select **Open or update the PR** when all selected findings applied cleanly and gates passed. Never auto-invoke.
 
 ## --hard mode
 
 `/cure --hard` is the gate-firing path for the `/hard-cheese` metacognitive vibecheck. The flag propagates up the pipeline (`/cheese → /mold → /cook → /press → /age → /cure`); cure is the only step that actually fires the gate. The contract:
 
-- **Interactive `/cure --hard`:** at the handoff `AskUserQuestion`, when the user selects the share-for-review option (the existing `Run /gh` label), invoke `/hard-cheese <slug>` *before* handing off. Proceed only on exit `0`. If the gate exits non-zero (`FAILED` status — cap exhausted), surface the artifact path and abort the handoff; the user must improve their understanding before sharing for review.
-- **Picking a non-sharing option** (`Run /age --scope ...`, `Stop`) does *not* fire the gate. Re-review and pausing do not put code in front of readers.
+- **Interactive `/cure --hard`:** at the handoff `AskUserQuestion`, when the user selects the share-for-review option (the **Open or update the PR** label, which dispatches `/gh`), invoke `/hard-cheese <slug>` *before* handing off. Proceed only on exit `0`. If the gate exits non-zero (`FAILED` status — cap exhausted), surface the artifact path and abort the handoff; the user must improve their understanding before sharing for review.
+- **Picking a non-sharing option** (**Re-review the touched code** or **Stop**) does *not* fire the gate. Re-review and pausing do not put code in front of readers.
 - **Auto-mode puncture** — see the clause in `### Auto mode` below. The auto-mode puncture is the single sanctioned point at which `--hard` overrides `--auto`'s skip-handoff semantics.
 
 The gate's mechanism (SOLO-graded fresh-context judge, Socratic retry, fail-open on judge error) lives in `skills/hard-cheese/SKILL.md`. The full composition matrix lives in `skills/hard-cheese/references/composition.md`.

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -84,7 +84,7 @@ After the spec is written, ask the user via `AskUserQuestion` which downstream t
 **Low- and medium-blast-radius specs (verdict `low` or `medium`):**
 
 - **Implement the spec** *(recommended)* — `/cook .cheese/specs/<slug>.md`.
-- **Implement and auto-review through ship** — `/cook --auto .cheese/specs/<slug>.md`, chains straight through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Offer when acceptance criteria are explicit *and* the user has signalled they want the pipeline to run forward without per-step approval. Never pre-select; auto mode is opt-in.
+- **Implement and auto-review** — `/cook --auto .cheese/specs/<slug>.md`, chains straight through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Stops at the final cure pass; opening or updating the PR stays a manual step. Offer when acceptance criteria are explicit *and* the user has signalled they want the pipeline to run forward without per-step approval. Never pre-select; auto mode is opt-in.
 - **Research more first** — `/briesearch`, gather more external evidence before implementing.
 - **Stop** — leave the spec for later.
 
@@ -94,7 +94,7 @@ The spec is large enough that per-phase context contamination becomes a real con
 
 - **Run the full pipeline in fresh-context isolation** *(recommended)* — `/ultracook .cheese/specs/<slug>.md`, autonomous chain (`cook → press → age → cure → age → cure → age`, all `--auto`) with each phase running inside its own sub-agent, blind to prior phases.
 - **Implement manually, one phase at a time** — `/cook .cheese/specs/<slug>.md`.
-- **Compact and resume by hand** — clear context, then `/cheese --continue <slug>` resumes from the latest handoff slug.
+- **Compact and resume by hand** — clear context, then dispatch `/cook .cheese/specs/<slug>.md` or `/ultracook .cheese/specs/<slug>.md` directly. (`/cheese --continue` scans phase handoff slugs only — fresh specs don't surface there until cook lands a slug — so dispatching the explicit command is the resumption path here.)
 - **Stop** — leave the spec for later.
 
 `/cook --auto` is omitted from the high-blast-radius offer set: with a large footprint, the fresh-context property of `/ultracook` is the actual motivation for going autonomous, and the in-session chain it offers is the wrong transport for that need. Never pre-select an autonomous option; the user must opt in. `medium` blast radius keeps the standard handoff because the in-session `/cook --auto` chain is still the right tool for that footprint — the fresh-context premium is only worth paying when the spec actually crosses module boundaries broadly enough to flip the verdict to `high`.

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -77,25 +77,27 @@ Default to project-local cheese artifacts when the user wants files:
 
 ## Handoff
 
-After the spec is written, ask the user via `AskUserQuestion` which downstream to run. Default options vary with the shape-check verdict:
+**Pipeline:** culture → **[mold]** → cook → press → age → cure → ship
+
+After the spec is written, ask the user via `AskUserQuestion` which downstream to run. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Default options vary with the shape-check verdict:
 
 **Low- and medium-blast-radius specs (verdict `low` or `medium`):**
 
-- **Run /cook `.cheese/specs/<slug>.md`** *(recommended)* — implement the spec.
-- **Run /cook --auto `.cheese/specs/<slug>.md`** — implement the spec and chain straight through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Offer when acceptance criteria are explicit *and* the user has signalled they want the pipeline to run forward without per-step approval. Never pre-select; auto mode is opt-in.
-- **Run /briesearch** — gather more external evidence first.
+- **Implement the spec** *(recommended)* — `/cook .cheese/specs/<slug>.md`.
+- **Implement and auto-review through ship** — `/cook --auto .cheese/specs/<slug>.md`, chains straight through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Offer when acceptance criteria are explicit *and* the user has signalled they want the pipeline to run forward without per-step approval. Never pre-select; auto mode is opt-in.
+- **Research more first** — `/briesearch`, gather more external evidence before implementing.
 - **Stop** — leave the spec for later.
 
 **High-blast-radius specs (verdict `high` only):**
 
 The spec is large enough that per-phase context contamination becomes a real concern — review reasoning softens when the same window contains the cook reasoning, and the parent context bloats across phases. Offer the fresh-context orchestrator and the manual compaction path:
 
-- **Run /ultracook `.cheese/specs/<slug>.md`** *(recommended)* — autonomous fresh-context pipeline (`cook → press → age → cure → age → cure → age`, all `--auto`) with each phase running inside its own sub-agent, blind to prior phases.
-- **Run /cook `.cheese/specs/<slug>.md`** — implement manually, one phase at a time.
-- **Compact, then `/cheese --continue <slug>`** — drive the chain by hand from a freshly cleared context. Resumes from the latest handoff slug.
+- **Run the full pipeline in fresh-context isolation** *(recommended)* — `/ultracook .cheese/specs/<slug>.md`, autonomous chain (`cook → press → age → cure → age → cure → age`, all `--auto`) with each phase running inside its own sub-agent, blind to prior phases.
+- **Implement manually, one phase at a time** — `/cook .cheese/specs/<slug>.md`.
+- **Compact and resume by hand** — clear context, then `/cheese --continue <slug>` resumes from the latest handoff slug.
 - **Stop** — leave the spec for later.
 
-`Run /cook --auto` is omitted from the high-blast-radius offer set: with a large footprint, the fresh-context property of `/ultracook` is the actual motivation for going autonomous, and the in-session chain it offers is the wrong transport for that need. Never pre-select an autonomous option; the user must opt in. `medium` blast radius keeps the standard handoff because the in-session `/cook --auto` chain is still the right tool for that footprint — the fresh-context premium is only worth paying when the spec actually crosses module boundaries broadly enough to flip the verdict to `high`.
+`/cook --auto` is omitted from the high-blast-radius offer set: with a large footprint, the fresh-context property of `/ultracook` is the actual motivation for going autonomous, and the in-session chain it offers is the wrong transport for that need. Never pre-select an autonomous option; the user must opt in. `medium` blast radius keeps the standard handoff because the in-session `/cook --auto` chain is still the right tool for that footprint — the fresh-context premium is only worth paying when the spec actually crosses module boundaries broadly enough to flip the verdict to `high`.
 
 ## Rules
 

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -96,12 +96,14 @@ Next step:    /age <slug>                          (when ready for /age or follo
 
 ## Handoff
 
-After the press report is on disk, ask via `AskUserQuestion` which downstream to run. Default options:
+**Pipeline:** culture → mold → cook → **[press]** → age → cure → ship
 
-- **Run /age `<slug>`** *(recommended when readiness is `ready for /age` or `follow-up recommended`)* — review the diff. For `follow-up recommended`, the cooked contract is sound and every changed behaviour has a hardening test; documented follow-ups can be addressed after review.
+After the press report is on disk, ask via `AskUserQuestion` which downstream to run. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Default options:
+
+- **Review the diff** *(recommended when readiness is `ready for /age` or `follow-up recommended`)* — `/age <slug>`. For `follow-up recommended`, the cooked contract is sound and every changed behaviour has a hardening test; documented follow-ups can be addressed after review.
 - **Stop** — defer review (use this if you want to harden manually before /age, even though the contract is review-safe).
 
-Pre-select `Run /age` when readiness is `ready for /age` or `follow-up recommended`. If the report is `blocked`, do not pre-select anything; the user decides whether to fix or escalate.
+Pre-select **Review the diff** when readiness is `ready for /age` or `follow-up recommended`. If the report is `blocked`, do not pre-select anything; the user decides whether to fix or escalate.
 
 ### Auto mode
 


### PR DESCRIPTION
## Summary

Reduces the cognitive load of the cheese pipeline so users don't need to memorize skill names to navigate it. Each pipeline skill's `## Handoff` section now does two things:

1. **Pipeline breadcrumb** at the top of the section, marking the current step with `**[brackets]**`:
   `**Pipeline:** culture → mold → **[cook]** → press → age → cure → ship`
2. **Verb-first option labels** in the `AskUserQuestion` choices. The user picks by outcome ("Harden tests before review"), with the skill command (`/press <slug>`) as the backing detail after the em-dash. The skill itself still dispatches the same command; only the surface wording changed.

## Files touched

- `skills/culture/SKILL.md`
- `skills/mold/SKILL.md` (both low/medium and high-blast variants)
- `skills/cook/SKILL.md`
- `skills/press/SKILL.md`
- `skills/age/SKILL.md` (selection gate phrasing)
- `skills/cure/SKILL.md` (+ two stale `Run /gh` and `Run /age --scope ...` label references in the `--hard` section, rippled from the rename)

## Out of scope

- `/cheese` (the router) still uses `Run /<skill>` labels in its dispatch table. Left alone to keep this PR surgical; can be a follow-up if the pattern proves useful.
- Underlying `AskUserQuestion` mechanics, slug schemas, and chain semantics are unchanged.

## Test plan

- [ ] Read each updated `## Handoff` section end-to-end and confirm the new option labels still uniquely describe the action they dispatch
- [ ] Verify cure's `--hard` section now references the renamed labels consistently (no remaining "Run /gh" or "Run /age --scope" label references)
- [ ] Spot-check the pipeline breadcrumb renders correctly in a markdown previewer (bold brackets, arrows visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)