### PR TITLE
docs(skills): route handoffs through shared Codex-safe gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,15 @@ skills/
 
 Each `SKILL.md` is self-contained markdown with YAML frontmatter. There are no nested sub-skills; deeper material lives in `references/<topic>.md` so the harness can load it progressively.
 
+Content shared _across_ skills lives at top-level `shared/` (e.g. `shared/handoff-gate.md`), sibling to `skills/` rather than inside any one skill's `references/`. Skills reference it by relative path (`../../shared/<file>.md`). The top-level location keeps it out of skill auto-discovery and signals that it's a cross-cutting contract, not a private detail of any single skill.
+
 ## Skills
 
 ### Workflow skills
 
 | Skill path | Command | Purpose |
 | --- | --- | --- |
-| `skills/cheese/SKILL.md` | `/cheese` | Unified entry point. Classifies any input (idea, spec path, PR, stack trace, file path), announces the routing decision, and gates dispatch behind `AskUserQuestion`. Never auto-invokes. |
+| `skills/cheese/SKILL.md` | `/cheese` | Unified entry point. Classifies any input (idea, spec path, PR, stack trace, file path), announces the routing decision, gates dispatch behind explicit user selection, then immediately runs the selected non-stop target with its dispatch packet. |
 | `skills/briesearch/SKILL.md` | `/briesearch` | Research technical questions across docs, web, codebase, and GitHub examples with confidence-capped synthesis. |
 | `skills/mold/SKILL.md` | `/mold` | Shape fuzzy ideas into grounded specs through dialogue, validate cycles, and a two-key handshake. |
 | `skills/culture/SKILL.md` | `/culture` | No-write rubber-ducking and architecture exploration. Hard invariant: writes only the opt-in `.cheese/notes/<slug>.md` handoff at session end, and only when the user asks for notes. |
@@ -129,7 +131,7 @@ If those tools don't show up after install, the cheez-* skills will hard-fail wi
    └─ review only                     ──►  /age         ──►  /cure
 ```
 
-`/cheese` is the front door. It inspects whatever you drop in (idea, spec path, PR ref, stack trace, file path), announces its routing decision, and waits for explicit confirmation before any downstream skill runs. Use it directly, or skip it when you already know the destination — a clear bug can go straight to `/cook`, a no-write design discussion stays in `/culture`. `/melt` cuts in whenever a merge step blocks `/cook` or `/cure`. Append `--hard` to any pipeline step to insert `/hard-cheese` as a metacognitive vibecheck gate before review.
+`/cheese` is the front door. It inspects whatever you drop in (idea, spec path, PR ref, stack trace, file path), announces its routing decision, and waits for explicit confirmation before any downstream skill runs; after a non-stop selection, it immediately dispatches the selected target. Use it directly, or skip it when you already know the destination — a clear bug can go straight to `/cook`, a no-write design discussion stays in `/culture`. `/melt` cuts in whenever a merge step blocks `/cook` or `/cure`. Append `--hard` to any pipeline step to insert `/hard-cheese` as a metacognitive vibecheck gate before review.
 
 ## Scope
 

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -12,6 +12,8 @@ Also emits:
   - docs/SUMMARY.md — literate-nav for the whole site.
   - docs/install.md — sliced out of README.md's Install / Installing MCP servers
     / Installing CLI tools sections so install instructions stay single-sourced.
+  - docs/shared/*.md — cross-skill contracts (e.g. handoff-gate.md) mirrored
+    from the repo's top-level shared/ directory so skills can link to them.
   - docs/contributing.md, docs/security.md, docs/code-of-conduct.md — slurped
     from the repo root so they stay single-sourced.
 """
@@ -26,6 +28,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILLS_DIR = REPO_ROOT / "skills"
+SHARED_DIR = REPO_ROOT / "shared"
 REPO_URL = "https://github.com/paulnsorensen/easy-cheese"
 
 LINK_RE = re.compile(r"(?<!\!)\[([^\]]+)\]\(([^)\s]+)(\s+\"[^\"]*\")?\)")
@@ -87,6 +90,13 @@ def rewrite_skill_link(url: str, skill_name: str) -> str:
     m = re.match(r"^\.\./\.\./([A-Z_]+\.md)$", path)
     if m and m.group(1) in ROOT_DOC_MAP:
         return f"../{ROOT_DOC_MAP[m.group(1)]}{anchor}"
+
+    # Cross-cutting contracts in top-level shared/ (e.g. ../../shared/handoff-gate.md).
+    # The source path climbs through repo_root; after flattening SKILL.md to
+    # docs/skills/<name>.md it only needs one `..` to reach docs/shared/.
+    m = re.match(r"^\.\./\.\./shared/(.+\.md)$", path)
+    if m:
+        return f"../shared/{m.group(1)}{anchor}"
 
     if path == "../../LICENSE":
         return f"{REPO_URL}/blob/main/LICENSE"
@@ -320,7 +330,48 @@ def emit_root_passthrough(filename: str, dest: str, title: str) -> bool:
     return True
 
 
-def emit_nav(skills: list[dict], extras: list[tuple[str, str]]) -> None:
+def emit_shared_pages() -> list[tuple[str, str]]:
+    """Emit shared/<file>.md into docs/shared/<file>.md.
+
+    The shared/ directory holds cross-skill contracts (e.g. handoff-gate.md)
+    that skill SKILL.md bodies reference via ``../../shared/<file>.md``. That
+    relative path already resolves correctly from docs/skills/<name>.md to
+    docs/shared/<file>.md, so no link rewriting is needed — but the target
+    file has to exist in the docs tree, and mkdocs --strict requires it to
+    be in the nav.
+
+    Returns ``(title, docs_path)`` pairs for ``emit_nav`` to render under a
+    "Shared contracts" section.
+    """
+    if not SHARED_DIR.is_dir():
+        return []
+
+    entries: list[tuple[str, str]] = []
+    for src in sorted(p for p in SHARED_DIR.iterdir() if p.is_file() and p.suffix == ".md"):
+        src_rel = src.relative_to(REPO_ROOT).as_posix()
+        out = f"shared/{src.name}"
+        text = src.read_text(encoding="utf-8")
+        with mkdocs_gen_files.open(out, "w") as fh:
+            fh.write(text)
+        mkdocs_gen_files.set_edit_path(out, src_rel)
+
+        title = _first_h1(text) or src.stem.replace("-", " ").capitalize()
+        entries.append((title, out))
+    return entries
+
+
+def _first_h1(text: str) -> str:
+    for line in text.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return ""
+
+
+def emit_nav(
+    skills: list[dict],
+    shared: list[tuple[str, str]],
+    extras: list[tuple[str, str]],
+) -> None:
     lines = [
         "* [Home](index.md)",
         "* [Install](install.md)",
@@ -331,6 +382,10 @@ def emit_nav(skills: list[dict], extras: list[tuple[str, str]]) -> None:
         lines.append(f"    * [/{s['name']}](skills/{s['name']}.md)")
         for ref_name, ref_path in s["refs"]:
             lines.append(f"        * [{ref_name}]({ref_path})")
+    if shared:
+        lines.append("* Shared contracts")
+        for title, path in shared:
+            lines.append(f"    * [{title}]({path})")
     if extras:
         lines.append("* Project")
         for title, path in extras:
@@ -348,6 +403,7 @@ def main() -> None:
 
     emit_skills_index(skills)
     emit_install_page()
+    shared = emit_shared_pages()
 
     extras: list[tuple[str, str]] = []
     if emit_root_passthrough("README.md", "readme.md", "README"):
@@ -359,7 +415,7 @@ def main() -> None:
     if emit_root_passthrough("CODE_OF_CONDUCT.md", "code-of-conduct.md", "Code of conduct"):
         extras.append(("Code of conduct", "code-of-conduct.md"))
 
-    emit_nav(skills, extras)
+    emit_nav(skills, shared, extras)
 
 
 main()

--- a/shared/handoff-gate.md
+++ b/shared/handoff-gate.md
@@ -1,0 +1,89 @@
+# Handoff gate
+
+Use this reference whenever a workflow skill asks the user to choose the next step after a gate.
+
+## Contract
+
+A handoff gate prevents silent dispatch. It does not mean the agent stops after the user selects an option. Once the user chooses a non-stop option, the current assistant turn immediately starts the selected action — either dispatching a downstream skill (skill transition) or continuing internal work in the current skill (in-skill continuation).
+
+"Never auto-invoke" means no downstream skill starts before an explicit user selection. It is not permission to answer only with "next: /some-skill" after the user has already selected that option.
+
+## Vocabulary
+
+- **Dispatch** — start a *new* skill with a concrete command. Reserved for skill transitions.
+- **Continue / proceed** — keep working inside the *current* skill (e.g. write a manifest, ask one targeted follow-up, re-run an internal phase). Never write `dispatch:` for in-skill continuation; use `continue:` instead.
+- **Stop / pause** — return a final status with no further action.
+
+## Gate shape
+
+Before asking, render each option as a structured record. The host UI may show this as buttons, a structured question, or a numbered list, but the semantics must be stable. The top-level key is `handoff_gate:` to distinguish it from per-option context payloads (`handoff_context:` — see below):
+
+```yaml
+handoff_gate:
+  source_skill: /<current-skill>
+  recommended: <label-or-none>
+  options:
+    - label: Run /press <slug>
+      dispatch: /press <slug>
+      context:
+        slug: <slug>
+        source_report: .cheese/cook/<slug>.md
+        flags: []
+    - label: Modify decomposition
+      continue: ask-for-decomposition-change
+      context:
+        scope: current-skill
+    - label: Stop
+      dispatch: none
+      context:
+        reason: leave pipeline paused
+```
+
+Every option must include:
+
+- **Label** — the user-facing choice.
+- Exactly one of:
+  - **Dispatch** — the exact command for a skill transition (`/press <slug>`, `/age <slug> --hard`, …), including slug/path/scope and propagated flags such as `--hard`.
+  - **Continue** — a short identifier for an in-skill action the current skill knows how to execute (e.g. `ask-for-decomposition-change`, `re-run-decomposer`, `write-manifest-then-seed`).
+  - `dispatch: none` — terminal options (Stop, Pause, Compact) that return a final status and do not start another skill.
+- **Context** — any prose or structured payload the action needs but that is not part of the command line.
+- **On select** — execute the dispatch or continue action immediately after the user selects it.
+
+`dispatch: none` is for *terminal* options only. Options that keep the current skill running must use `continue:`, not `dispatch: none`, so the gate reader can tell "stop" apart from "do something else in this skill".
+
+## Codex-compatible asking
+
+Prefer the host's structured question primitive when it is callable (`AskUserQuestion`, Codex `request_user_input`, or the host equivalent). If no structured primitive is available, ask a plain numbered question and wait for the next user reply.
+
+After the answer arrives:
+
+1. Normalize the answer to one option label or recognized free-text verb.
+2. If the answer is ambiguous, ask one clarifying question; do not guess.
+3. If the selected option has `dispatch: none`, stop with the relevant artifact path or pause status.
+4. If the selected option has a `continue:` identifier, execute that in-skill action immediately.
+5. If the selected option has a `dispatch:` command, immediately enter that skill with the exact command and context packet.
+6. Do not re-run `/cheese` classification unless the selected option explicitly says to do so.
+
+## Context payloads
+
+Use context payloads when command-line flags would create an unstable mini-language. Payloads ride alongside the gate under the key `handoff_context:` so the downstream skill can tell them apart from the gate shape itself:
+
+```yaml
+handoff_context:
+  source_skill: /age
+  source_report: .cheese/age/<slug>.md
+  selection: "1,3,5"
+  resolved_ids: [1, 3, 5]
+```
+
+Examples of when to attach a `handoff_context:` block:
+
+- `/age -> /cure` selection ids travel as context, not as a `--select` flag.
+- `/culture -> /cook` carries the compact contract that emerged from discussion.
+- `/melt -> upstream skill` carries the interrupted operation and original skill invocation.
+
+Keep payloads short and factual. If a payload would exceed a compact screenful, write or reference a `.cheese/.../<slug>.md` handoff artifact and pass the path instead.
+
+## Flag propagation
+
+Propagate `--hard` through every runnable downstream option while the flag is in scope. Propagate `--auto` only inside documented auto-mode chains. Interactive gates must not add `--auto` unless the option explicitly says `--auto` and the user selected it.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -48,7 +48,7 @@ Per-dimension rubrics and recommendation shapes in `references/dimensions.md`. T
 3. Review every dimension; dimensions with no findings simply omit themselves.
 4. Group findings by stake (high → medium) and by file.
 5. Write the report to `.cheese/age/<slug>.md` and print the path.
-6. Hand off via `AskUserQuestion` (see `## Handoff` below). Age owns the selection gate: it asks the user *which findings to cure*, never *whether to run /cure*. `/cure` still owns the actual fix application — age never auto-applies fixes.
+6. Hand off via the shared handoff gate (see `## Handoff` below). Age owns the selection gate: it asks the user *which findings to cure*, never *whether to run /cure*. `/cure` still owns the actual fix application — age never auto-applies fixes.
 
 ## Preferred tools and fallbacks
 
@@ -125,14 +125,24 @@ Age report: .cheese/age/<slug>.md
 
 **Pipeline:** culture → mold → cook → press → **[age]** → cure → ship
 
-After the report is on disk, skip any "should I run /cure?" meta-question and go straight to the selection gate. The user's working memory is on the findings, not on whether a follow-up step exists.
+After the report is on disk, skip any "should I run /cure?" meta-question and go straight to the selection gate. The user's working memory is on the findings, not on whether a follow-up step exists. Use the shared handoff gate in `../../shared/handoff-gate.md` for post-selection dispatch.
 
 1. Render the numbered selection table per `../cure/references/selection.md` directly inline (one row per finding, grouped by stake).
-2. Ask via `AskUserQuestion` which findings to cure. Lead each option with the verb (what the user wants to *do* next); the underlying selection verb is the backing detail. Offer:
+2. Ask via the handoff gate which findings to cure. Lead each option with the verb (what the user wants to *do* next); the underlying selection verb is the backing detail. Offer:
    - **Pick findings to fix** — accept a free-text reply using the verbs from `../cure/references/selection.md` (`1,3,5`, `all-high`, `all`, `none`, `skip N`).
    - **Fix all high-stake findings** *(recommended when at least one high-stake finding exists)* — equivalent to `all-high`.
    - **Stop — leave the report for later** — equivalent to `none`.
-3. On a non-empty selection, hand off to `/cure <slug>` with the selection locked in (pass the chosen ids through so `/cure` skips its own selection prompt and goes straight to apply). `/cure` still owns the apply / validate / report loop and may surface the chosen ids for confirmation if the report has shifted underneath it.
+3. On a non-empty selection, immediately dispatch `/cure <slug> [--hard]` with the selection locked in via context, not a CLI flag:
+
+```yaml
+handoff_context:
+  source_skill: /age
+  source_report: .cheese/age/<slug>.md
+  selection: "<recognized verb or explicit ids>"
+  resolved_ids: [<expanded ids>]
+```
+
+`/cure` skips its own selection prompt when this context is present, re-confirms the cited ids still exist, then owns the apply / validate / report loop. `/age` never auto-applies fixes. Always emit `resolved_ids` alongside `selection` — expand the verb yourself rather than leaving the field empty; `/cure` re-confirms against the report regardless.
 4. On `none` / `Stop`, exit cleanly with the report path.
 
 Outside `--auto`, never auto-apply fixes and never invoke `/cure` without an explicit non-empty selection. The default selection remains empty. `--auto` substitutes a stake-floor selection — see `### Auto mode` below.
@@ -141,7 +151,7 @@ Outside `--auto`, never auto-apply fixes and never invoke `/cure` without an exp
 
 When invoked with `--auto`:
 
-- Skip the `AskUserQuestion`.
+- Skip the handoff gate.
 - If two cure passes have already completed (cap reached), stop and surface the final report — do not invoke `/cure` again even if findings remain.
 - Otherwise, if any medium-or-above finding exists, invoke `/cure <slug> --auto --stake medium+` and increment the cure-pass count when it returns.
 - If no medium-or-above findings remain, stop the chain with a one-line "auto chain clean" note and the report path.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -125,7 +125,7 @@ Age report: .cheese/age/<slug>.md
 
 **Pipeline:** culture → mold → cook → press → **[age]** → cure → ship
 
-After the report is on disk, skip any "should I run /cure?" meta-question and go straight to the selection gate. The user's working memory is on the findings, not on whether a follow-up step exists. Use the shared handoff gate in `../../shared/handoff-gate.md` for post-selection dispatch.
+After the report is on disk, skip any "should I run /cure?" meta-question and go straight to the selection gate. The user's working memory is on the findings, not on whether a follow-up step exists. Use the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md) for post-selection dispatch.
 
 1. Render the numbered selection table per `../cure/references/selection.md` directly inline (one row per finding, grouped by stake).
 2. Ask via the handoff gate which findings to cure. Lead each option with the verb (what the user wants to *do* next); the underlying selection verb is the backing detail. Offer:

--- a/skills/cheese-factory/SKILL.md
+++ b/skills/cheese-factory/SKILL.md
@@ -148,9 +148,14 @@ C. Re-decompose — different boundaries
 D. Pause — hold off
 ```
 
-**Do NOT proceed without explicit approval.**
+Use the shared handoff gate in `../../shared/handoff-gate.md` for this approval step. All four options keep cheese-factory running internally (no skill transition) — they use `continue:` identifiers rather than `dispatch:` commands per the gate vocabulary:
 
-Write manifest to `.cheese/cheese-factory/<slug>/manifest.yaml`. Update: `phase: gate_approved`.
+- **Approve** — `continue: write-manifest-then-seed`: write `.cheese/cheese-factory/<slug>/manifest.yaml`, set `phase: gate_approved`, then proceed with Phase 1 (seed execution).
+- **Modify** — `continue: ask-for-decomposition-change`: ask one targeted question for the requested decomposition change, then re-render the plan.
+- **Re-decompose** — `continue: re-run-decomposer`: re-run the decomposer with the user's boundary instruction. Retry at most twice.
+- **Pause** — `dispatch: none`: leave the manifest draft and report its path.
+
+**Do NOT proceed without explicit approval.**
 
 #### Compaction seam C1
 

--- a/skills/cheese-factory/SKILL.md
+++ b/skills/cheese-factory/SKILL.md
@@ -148,7 +148,7 @@ C. Re-decompose — different boundaries
 D. Pause — hold off
 ```
 
-Use the shared handoff gate in `../../shared/handoff-gate.md` for this approval step. All four options keep cheese-factory running internally (no skill transition) — they use `continue:` identifiers rather than `dispatch:` commands per the gate vocabulary:
+Use the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md) for this approval step. All four options keep cheese-factory running internally (no skill transition) — they use `continue:` identifiers rather than `dispatch:` commands per the gate vocabulary:
 
 - **Approve** — `continue: write-manifest-then-seed`: write `.cheese/cheese-factory/<slug>/manifest.yaml`, set `phase: gate_approved`, then proceed with Phase 1 (seed execution).
 - **Modify** — `continue: ask-for-decomposition-change`: ask one targeted question for the requested decomposition change, then re-render the plan.

--- a/skills/cheese/SKILL.md
+++ b/skills/cheese/SKILL.md
@@ -34,7 +34,7 @@ If `$ARGUMENTS` is missing entirely and there is no recent context to lean on, a
 1. **Classify** — match `$ARGUMENTS` against the intent shapes in `references/classification.md`. Pick the highest-confidence shape; below the threshold, route to `clarify` (see step 4).
 2. **Announce** — print one short paragraph with: detected intent, chosen target skill (or pre-step), and the one-line reason for the decision. Cite the signal that drove it (e.g. "spec path under `.cheese/specs/`", "stack trace present", "PR URL").
 3. **Self-check** — run the coherence questions in `references/coherence-check.md` before dispatching. If any fails, downgrade to `clarify` or `research`.
-4. **Confirm** — issue a handoff gate per `../../shared/handoff-gate.md`: recommended target pre-selected, at least one alternative, and a `Stop` option. The user's selection is the only trigger for dispatch; never invoke a skill silently before the selection.
+4. **Confirm** — issue a handoff gate per [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md): recommended target pre-selected, at least one alternative, and a `Stop` option. The user's selection is the only trigger for dispatch; never invoke a skill silently before the selection.
 5. **Hand off** — once the user picks a non-stop option, immediately run the selected skill with the exact dispatch command and context packet. The downstream skill owns its own flow; `/cheese` does not narrate beyond the routing decision.
 
 `/cheese` is a router, not a worker. It never edits files, runs tests, opens PRs, or paraphrases the downstream skill's output.
@@ -64,7 +64,7 @@ Flow:
 1. Scan for the most recently modified handoff slug across `.cheese/{cook,press,age,cure,notes}/<slug>.md`.
 2. If none exist, offer to start the pipeline from scratch — `/mold` for fuzzy specs, `/cook` for clear asks, `/ultracook` for high-blast-radius specs — and stop.
 3. If at least one exists, read the latest one and use its `next:` field to decide the recommended action. Surface the orientation line so the user knows where they are.
-4. Confirm the resumption via the handoff gate in `../../shared/handoff-gate.md`. The recommended option depends on the slug's `next:` value:
+4. Confirm the resumption via the handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). The recommended option depends on the slug's `next:` value:
    - **When `next:` names a phase** (`mold | cook | press | age | cure | ultracook`):
      - **Run /\<next\> \<slug\>** *(recommended)* — continue the chain at the named phase.
      - **Run /ultracook \<slug\>** — re-enter the autonomous fresh-context chain.
@@ -112,7 +112,7 @@ If `clarify` is chosen, replace step 4 with the single clarifying question.
 
 ## Handoff
 
-Dispatch happens through `../../shared/handoff-gate.md`. Default option set per intent:
+Dispatch happens through [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Default option set per intent:
 
 - **clarify** — single targeted question; no skills offered until the answer arrives.
 - **research** — `Run /briesearch` (recommended), `Run /culture`, `Stop`.
@@ -140,4 +140,4 @@ Pre-select only the highest-confidence target. If two targets are viable, surfac
 
 - `references/classification.md` — intent shapes, signals, disambiguation rules.
 - `references/coherence-check.md` — pre-dispatch self-checks that downgrade misroutes.
-- `../../shared/handoff-gate.md` — Codex-safe post-selection dispatch contract (shared across workflow skills).
+- [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md) — Codex-safe post-selection dispatch contract (shared across workflow skills).

--- a/skills/cheese/SKILL.md
+++ b/skills/cheese/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cheese
-description: This skill should be used as the unified entry point when the user drops in any kind of input — a half-formed idea, a spec path, a file path, a PR or issue number, a stack trace, a bug report, or just `/cheese` — and wants the workflow to pick the right next step. Phrases like "/cheese", "what should I do with this", "help me get started", "route this", "figure out what skill I need", or any opening message that does not already name a downstream skill. Classifies the input into an intent shape (clarify, research, rubber-duck, mold, cook, debug-then-cook, age, age-then-cure), announces the detected intent + reason, and gates dispatch behind an explicit `AskUserQuestion` so nothing fires silently. Use even when the user seems to know what they want — confirming the routing decision is the value. Never auto-invokes downstream skills; always pauses for explicit confirmation. Before any other workflow skill.
+description: This skill should be used as the unified entry point when the user drops in any input — idea, spec path, file path, PR or issue, stack trace, bug report, or just `/cheese` — and wants the workflow routed. Phrases include "/cheese", "what should I do with this", "help me get started", "route this", "figure out what skill I need", or any opening message that does not already name a downstream skill. Classifies the input into an intent shape, announces the target and reason, and gates dispatch behind explicit user selection so nothing runs silently. After a non-stop selection, immediately dispatches the selected downstream skill with the exact command and context packet. Before any other workflow skill.
 license: MIT
 ---
 
@@ -34,8 +34,8 @@ If `$ARGUMENTS` is missing entirely and there is no recent context to lean on, a
 1. **Classify** — match `$ARGUMENTS` against the intent shapes in `references/classification.md`. Pick the highest-confidence shape; below the threshold, route to `clarify` (see step 4).
 2. **Announce** — print one short paragraph with: detected intent, chosen target skill (or pre-step), and the one-line reason for the decision. Cite the signal that drove it (e.g. "spec path under `.cheese/specs/`", "stack trace present", "PR URL").
 3. **Self-check** — run the coherence questions in `references/coherence-check.md` before dispatching. If any fails, downgrade to `clarify` or `research`.
-4. **Confirm** — issue an `AskUserQuestion` with the recommended target pre-selected and at least one alternative plus a `Stop` option. The user's selection is the only trigger for dispatch; never invoke a skill silently.
-5. **Hand off** — once the user picks, name the next skill and stop. The downstream skill owns its own flow; `/cheese` does not narrate beyond the routing decision.
+4. **Confirm** — issue a handoff gate per `../../shared/handoff-gate.md`: recommended target pre-selected, at least one alternative, and a `Stop` option. The user's selection is the only trigger for dispatch; never invoke a skill silently before the selection.
+5. **Hand off** — once the user picks a non-stop option, immediately run the selected skill with the exact dispatch command and context packet. The downstream skill owns its own flow; `/cheese` does not narrate beyond the routing decision.
 
 `/cheese` is a router, not a worker. It never edits files, runs tests, opens PRs, or paraphrases the downstream skill's output.
 
@@ -64,7 +64,7 @@ Flow:
 1. Scan for the most recently modified handoff slug across `.cheese/{cook,press,age,cure,notes}/<slug>.md`.
 2. If none exist, offer to start the pipeline from scratch — `/mold` for fuzzy specs, `/cook` for clear asks, `/ultracook` for high-blast-radius specs — and stop.
 3. If at least one exists, read the latest one and use its `next:` field to decide the recommended action. Surface the orientation line so the user knows where they are.
-4. Confirm the resumption via `AskUserQuestion`. The recommended option depends on the slug's `next:` value:
+4. Confirm the resumption via the handoff gate in `../../shared/handoff-gate.md`. The recommended option depends on the slug's `next:` value:
    - **When `next:` names a phase** (`mold | cook | press | age | cure | ultracook`):
      - **Run /\<next\> \<slug\>** *(recommended)* — continue the chain at the named phase.
      - **Run /ultracook \<slug\>** — re-enter the autonomous fresh-context chain.
@@ -74,7 +74,7 @@ Flow:
      - **Run /age \<slug\>** — re-review the diff in fresh context if you want another pass.
      - **Run /ultracook \<slug\>** — only if you want to redo the whole chain over the same slug. Refuses when phase handoffs already exist (per `/ultracook`'s existing-handoffs guard); requires removing the existing slugs first.
 
-`/cheese --continue` never auto-invokes, and it never builds `/done <slug>` or `/stop <slug>` from a terminal `next:` field — those values surface the terminal state to the user, not a runnable command. The slug files are the resumability contract: they tell the router where the pipeline is, and the user picks how to move it forward.
+`/cheese --continue` never dispatches before the user selects, and it never builds `/done <slug>` or `/stop <slug>` from a terminal `next:` field — those values surface the terminal state to the user, not a runnable command. After a non-stop selection, run the selected phase immediately with the slug. The slug files are the resumability contract: they tell the router where the pipeline is, and the user picks how to move it forward.
 
 ## Confidence and the clarify gate
 
@@ -95,7 +95,7 @@ Beyond cheez-* there are router-specific tools:
 | Need | Prefer | Fallback |
 | --- | --- | --- |
 | PR / issue context | `gh` | the URL or numbers the user provided |
-| Confirming routing target with the user | `AskUserQuestion` | a numbered list with explicit "no auto-invoke" wording |
+| Confirming routing target with the user | `AskUserQuestion` / host structured question (`request_user_input` in Codex when available) | a numbered list with explicit dispatch commands and "no auto-invoke before selection" wording |
 
 `/cheese` keeps tool use light. Treat anything heavier than a single-file read or one search call as a sign the work belongs in the downstream skill, not in the router.
 
@@ -106,13 +106,13 @@ Always emit, in order:
 1. **Detected intent** — one line, e.g. `Intent: cook (clear single-file fix)`.
 2. **Reason** — one line citing the signal (`reason: spec path .cheese/specs/foo.md`).
 3. **Target** — the recommended skill, e.g. `Target: /cook .cheese/specs/foo.md`.
-4. **Confirmation prompt** — `AskUserQuestion` with the recommended target pre-selected, one alternative, and `Stop`.
+4. **Confirmation prompt** — handoff gate with the recommended target pre-selected, one alternative, `Stop`, and exact dispatch records for every non-stop option.
 
 If `clarify` is chosen, replace step 4 with the single clarifying question.
 
 ## Handoff
 
-Dispatch happens through `AskUserQuestion`. Default option set per intent:
+Dispatch happens through `../../shared/handoff-gate.md`. Default option set per intent:
 
 - **clarify** — single targeted question; no skills offered until the answer arrives.
 - **research** — `Run /briesearch` (recommended), `Run /culture`, `Stop`.
@@ -126,11 +126,11 @@ Dispatch happens through `AskUserQuestion`. Default option set per intent:
 
 Pre-select only the highest-confidence target. If two targets are viable, surface both and let the user decide.
 
-`/cheese` never auto-invokes. The user picks, then the next skill runs.
+`/cheese` never auto-invokes before the user selects. After a non-stop selection, the selected skill runs immediately with the captured dispatch packet.
 
 ## Rules
 
-- Classification is the only output until the user confirms.
+- Classification is the only output until the user confirms; after a non-stop confirmation, dispatch instead of stopping at a recommendation.
 - One clarifying question, max, before re-entering classification.
 - Below `medium` confidence, route to `clarify`, not to a guess.
 - Never paraphrase or summarise downstream skill output — that is the downstream skill's job.
@@ -140,3 +140,4 @@ Pre-select only the highest-confidence target. If two targets are viable, surfac
 
 - `references/classification.md` — intent shapes, signals, disambiguation rules.
 - `references/coherence-check.md` — pre-dispatch self-checks that downgrade misroutes.
+- `../../shared/handoff-gate.md` — Codex-safe post-selection dispatch contract (shared across workflow skills).

--- a/skills/cook/SKILL.md
+++ b/skills/cook/SKILL.md
@@ -22,7 +22,7 @@ Accept one of:
 
 Optional flags:
 
-- `--auto` — autonomous mode. Skip every handoff `AskUserQuestion`, propagate the flag through `/press → /age → /cure`, and fix every medium-or-above finding across up to two cure passes. See `## Auto mode` below.
+- `--auto` — autonomous mode. Skip every handoff gate, propagate the flag through `/press → /age → /cure`, and fix every medium-or-above finding across up to two cure passes. See `## Auto mode` below.
 - `--hard` — propagate the `/hard-cheese` metacognitive gate flag through `/press → /age → /cure`. Cook does not fire the gate itself; it only passes the flag along. The gate fires at `/cure`'s share-for-review handoff or, under `--auto --hard`, at the end of cure's final auto pass. See `skills/hard-cheese/SKILL.md` and `skills/hard-cheese/references/composition.md`.
 
 ### Standalone fast-path
@@ -41,7 +41,7 @@ When the fast-path applies, derive a slug from the task (e.g. `tail-trailing-new
 2. **Cut** — write failing tests for the changed behaviour. See `references/tdd-loop.md`.
 3. **Implement** — make the cut tests pass with the smallest production change.
 4. **Taste-test** — check spec drift, readability, and scope creep. Two-round cap; details in `references/tdd-loop.md`.
-5. **Hand off** — produce the package-ready report (`references/package-report.md`), write the handoff slug (`## Handoff slug` below), and prompt the next step via `AskUserQuestion` (see `## Handoff` below). The default chain is `/press` → `/age` → `/cure`.
+5. **Hand off** — produce the package-ready report (`references/package-report.md`), write the handoff slug (`## Handoff slug` below), and prompt the next step via the shared handoff gate (see `## Handoff` below). The default chain is `/press` → `/age` → `/cure`.
 
 Code search, reading, and editing all go through the cheez-* skills (`/cheez-search`, `/cheez-read`, `/cheez-write`) — see those skills for tool selection rules and out-of-scope fallbacks.
 
@@ -86,15 +86,15 @@ artifact: <path-to-richer-report-if-any>
 
 **Pipeline:** culture → mold → **[cook]** → press → age → cure → ship
 
-After the package-ready report is printed and the handoff slug is on disk, ask via `AskUserQuestion` which downstream to run. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Default options:
+After the package-ready report is printed and the handoff slug is on disk, ask via the shared handoff gate in `../../shared/handoff-gate.md`. Lead each option with the verb (what the user wants to *do* next); the skill command (with any in-scope `--hard` propagation) is the backing detail. Default options:
 
 - **Harden tests before review** *(recommended)* — `/press <slug>`.
 - **Review the diff now (skip the press pass)** — `/age <slug>`.
-- **Stop** — leave further hardening for later.
+- **Stop** — dispatch none; leave further hardening for later.
 
-Pre-select **Harden tests before review** when the cooked diff added new behaviour or touched untested seams. The user may also chain: pressing then age then cure happens via each step's own `AskUserQuestion`. Never auto-invoke; the user must select.
+Pre-select **Harden tests before review** when the cooked diff added new behaviour or touched untested seams. The user may also chain: pressing then age then cure happens via each step's own handoff gate. Never dispatch before selection; after a non-stop selection, run the selected command immediately.
 
-When invoked with `--auto`, skip this `AskUserQuestion` entirely and proceed straight into the auto-mode chain (see `## Auto mode` below).
+When invoked with `--auto`, skip this gate entirely and proceed straight into the auto-mode chain (see `## Auto mode` below).
 
 ## Auto mode
 
@@ -139,7 +139,7 @@ Final age:      <path>
 Next step:      review the diff, then /gh when ready
 ```
 
-Auto mode is a propagated flag, not a separate skill — every downstream invocation passes `--auto` along so each step knows to skip its own handoff `AskUserQuestion`.
+Auto mode is a propagated flag, not a separate skill — every downstream invocation passes `--auto` along so each step knows to skip its own handoff gate.
 
 ## Rules
 

--- a/skills/cook/SKILL.md
+++ b/skills/cook/SKILL.md
@@ -86,7 +86,7 @@ artifact: <path-to-richer-report-if-any>
 
 **Pipeline:** culture → mold → **[cook]** → press → age → cure → ship
 
-After the package-ready report is printed and the handoff slug is on disk, ask via the shared handoff gate in `../../shared/handoff-gate.md`. Lead each option with the verb (what the user wants to *do* next); the skill command (with any in-scope `--hard` propagation) is the backing detail. Default options:
+After the package-ready report is printed and the handoff slug is on disk, ask via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Lead each option with the verb (what the user wants to *do* next); the skill command (with any in-scope `--hard` propagation) is the backing detail. Default options:
 
 - **Harden tests before review** *(recommended)* — `/press <slug>`.
 - **Review the diff now (skip the press pass)** — `/age <slug>`.

--- a/skills/culture/SKILL.md
+++ b/skills/culture/SKILL.md
@@ -64,15 +64,25 @@ The notes slug is the **only** thing culture is allowed to write. No commits, no
 
 **Pipeline:** **[culture]** → mold → cook → press → age → cure → ship
 
-When the conversation reveals real work, ask via `AskUserQuestion` which downstream to run. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Default options (pick at most three of these plus a stop):
+When the conversation reveals real work, ask via the shared handoff gate in `../../shared/handoff-gate.md`. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Before asking, render a compact context packet so the downstream skill can dispatch without losing the discussion:
 
-- **Shape this into a written spec** *(recommended when the idea is still fuzzy)* — `/mold`.
-- **Implement it directly** *(recommended when the ask is clear and unambiguous)* — `/cook`.
-- **Implement and auto-review** — `/cook --auto`, chains through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Stops at the final cure pass; opening or updating the PR stays a manual step. Offer this when the conversation reached an unambiguous contract *and* the user signalled they want the whole pipeline to run forward without per-step approval ("just do it", "ship it", "auto", "fix it all the way through"). Never pre-select; auto mode opts the user out of the gates that exist for their protection.
+```yaml
+handoff_context:
+  source_skill: /culture
+  summary: <one factual sentence>
+  open_questions: [<only blockers, if any>]
+  artifact: <.cheese/notes/<slug>.md if written, otherwise none>
+```
+
+Default options (pick at most three of these plus a stop):
+
+- **Shape this into a written spec** *(recommended when the idea is still fuzzy)* — `/mold` with the context packet, or `/mold .cheese/notes/<slug>.md` when a notes slug exists.
+- **Implement it directly** *(recommended when the ask is clear and unambiguous)* — `/cook` with the context packet as the accepted contract.
+- **Implement and auto-review** — `/cook --auto` with the context packet, chains through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Stops at the final cure pass; opening or updating the PR stays a manual step. Offer this when the conversation reached an unambiguous contract *and* the user signalled they want the whole pipeline to run forward without per-step approval ("just do it", "ship it", "auto", "fix it all the way through"). Never pre-select; auto mode opts the user out of the gates that exist for their protection.
 - **Research more first** *(when the conversation hit a factual gap external docs could close)* — `/briesearch`.
-- **Pause** — keep the dialogue in head; no further action.
+- **Pause** — dispatch none; keep the dialogue in head.
 
-`/age` is never the next step from culture — review needs a diff to look at.
+After a non-stop selection, run the selected downstream skill immediately with the context packet. `/age` is never the next step from culture — review needs a diff to look at.
 
 ## Rules
 

--- a/skills/culture/SKILL.md
+++ b/skills/culture/SKILL.md
@@ -64,7 +64,7 @@ The notes slug is the **only** thing culture is allowed to write. No commits, no
 
 **Pipeline:** **[culture]** → mold → cook → press → age → cure → ship
 
-When the conversation reveals real work, ask via the shared handoff gate in `../../shared/handoff-gate.md`. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Before asking, render a compact context packet so the downstream skill can dispatch without losing the discussion:
+When the conversation reveals real work, ask via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Before asking, render a compact context packet so the downstream skill can dispatch without losing the discussion:
 
 ```yaml
 handoff_context:

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -12,7 +12,7 @@ Do not use it to apply every suggestion automatically. The user chooses what to 
 
 ## Inputs
 
-Accept any of: a `/age` slug (`/cure <slug>` reads `.cheese/age/<slug>.md`), a pasted findings list, a CI failure summary, or a scoped instruction like "fix the high-stake age findings". `/age` may also hand off with a pre-locked selection by passing the chosen ids inline in the dispatch (see `references/selection.md#handoff-from-age` for the canonical format); when that happens, skip rendering the selection list and go straight to apply.
+Accept any of: a `/age` slug (`/cure <slug>` reads `.cheese/age/<slug>.md`), a pasted findings list, a CI failure summary, or a scoped instruction like "fix the high-stake age findings". `/age` may also hand off with a pre-locked selection by passing the chosen ids in a structured handoff context (see `references/selection.md#handoff-from-age` for the canonical format); when that context is present, skip rendering the selection list and go straight to apply.
 
 If selection is ambiguous *and* not pre-locked from `/age`, render a numbered selection list per `references/selection.md` and ask what to apply. The default selection is empty.
 
@@ -25,12 +25,12 @@ Optional flags:
 ## Flow
 
 1. **Load** — read the findings (markdown, not JSON sidecars).
-2. **Select** — if `/age` handed off a pre-locked selection, adopt it as-is (re-confirm the cited ids still exist in the report). Otherwise gate on explicit user selection. See `references/selection.md` for the recognized verbs.
+2. **Select** — if `/age` handed off a structured pre-locked selection, adopt it as-is after re-confirming the cited ids still exist in the report. Otherwise gate on explicit user selection. See `references/selection.md` for the recognized verbs.
 3. **Apply** — fix one logical group at a time via `cheez-read` (re-confirm anchor location) and `cheez-write` (apply).
 4. **Validate** — run the narrowest tests that prove each fix, then any relevant project-wide gates (lint, typecheck, build).
 5. **Re-review hand-off** — recommend `/age --scope <touched-path>` so review runs through the proper skill rather than reimplementing it inline. `/cure` does not re-grade its own work. If the user picks re-age, the resulting report can feed a fresh `/cure` invocation.
 6. **Ship report** — what changed, checks run, deferred items, residual risks. Write the handoff slug at the top of `.cheese/cure/<slug>.md` (see `## Handoff slug` below) so the chain (and `/ultracook`) can read the outcome without re-parsing the full report.
-7. **Hand off** — prompt the next step via `AskUserQuestion` (see `## Handoff` below). Never auto-invoke.
+7. **Hand off** — prompt the next step via the shared handoff gate (see `## Handoff` below). Never dispatch before the user selects; after a non-stop selection, run the selected command immediately.
 
 ## Preferred tools and fallbacks
 
@@ -91,19 +91,19 @@ The cure report body lives below the handoff slug in the same file at `.cheese/c
 
 **Pipeline:** culture → mold → cook → press → age → **[cure]** → ship
 
-After the cure report is rendered, ask via `AskUserQuestion` which downstream to run. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Default options:
+After the cure report is rendered, ask via the shared handoff gate in `../../shared/handoff-gate.md`. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Default options:
 
-- **Re-review the touched code** *(recommended when fixes were non-trivial)* — `/age --scope <touched-path>`, runs review through the proper skill.
-- **Open or update the PR** — `/gh`.
-- **Stop** — sit on the changes for now.
+- **Re-review the touched code** *(recommended when fixes were non-trivial)* — `/age --scope <touched-path>`, runs review through the proper skill. Propagates `--hard` when in scope.
+- **Open or update the PR** — `/gh`. When `--hard` is in scope, this option first dispatches `/hard-cheese <slug>` and proceeds to `/gh` only if the gate exits `0`.
+- **Stop** — dispatch none; sit on the changes for now.
 
-Pre-select **Re-review the touched code** when any applied fix touched logic outside the original finding's hunk, when a corrective fix exposed adjacent risk, or when checks were skipped. Pre-select **Open or update the PR** when all selected findings applied cleanly and gates passed. Never auto-invoke.
+Pre-select **Re-review the touched code** when any applied fix touched logic outside the original finding's hunk, when a corrective fix exposed adjacent risk, or when checks were skipped. Pre-select **Open or update the PR** when all selected findings applied cleanly and gates passed. Never dispatch before selection; after a non-stop selection, run the selected command immediately.
 
 ## --hard mode
 
 `/cure --hard` is the gate-firing path for the `/hard-cheese` metacognitive vibecheck. The flag propagates up the pipeline (`/cheese → /mold → /cook → /press → /age → /cure`); cure is the only step that actually fires the gate. The contract:
 
-- **Interactive `/cure --hard`:** at the handoff `AskUserQuestion`, when the user selects the share-for-review option (the **Open or update the PR** label, which dispatches `/gh`), invoke `/hard-cheese <slug>` *before* handing off. Proceed only on exit `0`. If the gate exits non-zero (`FAILED` status — cap exhausted), surface the artifact path and abort the handoff; the user must improve their understanding before sharing for review.
+- **Interactive `/cure --hard`:** at the handoff gate, when the user selects the share-for-review option (the **Open or update the PR** label, which dispatches `/gh`), invoke `/hard-cheese <slug>` *before* handing off. Proceed only on exit `0`. If the gate exits non-zero (`FAILED` status — cap exhausted), surface the artifact path and abort the handoff; the user must improve their understanding before sharing for review.
 - **Picking a non-sharing option** (**Re-review the touched code** or **Stop**) does *not* fire the gate. Re-review and pausing do not put code in front of readers.
 - **Auto-mode puncture** — see the clause in `### Auto mode` below. The auto-mode puncture is the single sanctioned point at which `--hard` overrides `--auto`'s skip-handoff semantics.
 
@@ -113,10 +113,10 @@ The gate's mechanism (SOLO-graded fresh-context judge, Socratic retry, fail-open
 
 When invoked with `--auto --stake <floor>`:
 
-- Skip the selection-list rendering and the `AskUserQuestion`.
+- Skip the selection-list rendering and the handoff gate.
 - Auto-select every finding whose stake meets the floor (`high` only, `medium+` for medium or higher, or `all`).
 - Apply findings one at a time. After each fix, run the narrowest test that proves it. If the fix breaks a previously-passing test or any project-wide gate, revert that single finding's edit and record it under `### Deferred` in the cure report with the test name and the failure summary. Continue with the remaining findings.
-- After all selected findings are processed, skip the handoff `AskUserQuestion` and invoke `/age --scope <touched-paths> --auto` so the chain can re-review.
+- After all selected findings are processed, skip the handoff gate and invoke `/age --scope <touched-paths> --auto` so the chain can re-review.
 - `/age --auto` enforces the two-pass cap. Cure does not need to track passes itself — it just keeps applying when invoked.
 - Never invoke `/gh` from auto mode. The chain ends with the final age report and the user opens a PR manually if they want.
 

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -91,7 +91,7 @@ The cure report body lives below the handoff slug in the same file at `.cheese/c
 
 **Pipeline:** culture → mold → cook → press → age → **[cure]** → ship
 
-After the cure report is rendered, ask via the shared handoff gate in `../../shared/handoff-gate.md`. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Default options:
+After the cure report is rendered, ask via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Default options:
 
 - **Re-review the touched code** *(recommended when fixes were non-trivial)* — `/age --scope <touched-path>`, runs review through the proper skill. Propagates `--hard` when in scope.
 - **Open or update the PR** — `/gh`. When `--hard` is in scope, this option first dispatches `/hard-cheese <slug>` and proceeds to `/gh` only if the gate exits `0`.

--- a/skills/cure/references/selection.md
+++ b/skills/cure/references/selection.md
@@ -8,9 +8,19 @@ The only sanctioned bypass of the selection rule is the `--auto --stake <floor>`
 
 ## Handoff from /age
 
-When `/age` completes the selection gate and the user picks a non-empty set, it dispatches `/cure` with the selection locked in by passing the chosen ids as plain text in the invocation context — the same verbs accepted at the prompt (`1,3,5`, `all-high`, etc.). `/cure` reads this from the dispatch context, skips rendering the selection table, and goes straight to apply.
+When `/age` completes the selection gate and the user picks a non-empty set, it dispatches `/cure <slug>` with the selection locked in by passing a structured context block alongside the invocation:
 
-There is no CLI flag (`--select` is not a supported syntax). The selection travels as prose context in the `AskUserQuestion` resolution, not as a parsed argument.
+```yaml
+handoff_context:
+  source_skill: /age
+  source_report: .cheese/age/<slug>.md
+  selection: "1,3,5 | all-high | all | skip N"
+  resolved_ids: [1, 3, 5]
+```
+
+Both `selection` (the verb) and `resolved_ids` (the expanded list) are required. `/age` expands the verb before dispatch so `/cure` never has to interpret it; `/cure` re-confirms the resolved ids against the report and goes straight to apply.
+
+There is no CLI flag (`--select` is not a supported syntax). The selection travels in the handoff context, not as a parsed argument.
 
 ## Rendering the selection list
 
@@ -67,6 +77,6 @@ When `/cure` is invoked with `--auto --stake <floor>`:
 - **Per-finding flow is the same as interactive:** `cheez-read` to re-confirm, `cheez-write` to apply, narrowest test to verify.
 - **On test breakage:** revert that single finding's edit, log it under the cure report's `### Deferred` section with the test name and one-line failure summary, and continue with the next finding. Do not stop the whole pass for one bad fix.
 - **On a finding that is no longer applicable** (file moved, code already fixed): record under `### Skipped` exactly as in interactive mode.
-- **After all selected findings are processed:** invoke `/age --scope <touched-paths> --auto` directly (no `AskUserQuestion`). The pass-cap is enforced inside `/age --auto`, not here — cure keeps applying when called.
+- **After all selected findings are processed:** invoke `/age --scope <touched-paths> --auto` directly (no handoff gate). The pass-cap is enforced inside `/age --auto`, not here — cure keeps applying when called.
 
 `--auto` is not a verb the user should type interactively. It exists to make the `/cook --auto` chain coherent. If a user types `/cure --auto` directly without `--stake`, error out with a one-line message pointing them at standard interactive `/cure <slug>` — `--stake` is the contract for auto mode, and without it `/cure --auto` has no inclusion threshold. Do not prompt for a floor; do not silently fall back to interactive selection.

--- a/skills/melt/SKILL.md
+++ b/skills/melt/SKILL.md
@@ -232,13 +232,13 @@ git cherry-pick --abort
 
 ## Handoff
 
-After resolution finishes, prompt the next step via `AskUserQuestion`. Default options:
+After resolution finishes, prompt the next step via the shared handoff gate in `../../shared/handoff-gate.md`. Include the detected interrupted operation and upstream invocation in the context packet before asking. Default options:
 
-- **Resume** — `git merge --continue` / `git rebase --continue` / `git cherry-pick --continue`, then return to whatever skill triggered the merge (`/cook`, `/cure`, etc.).
-- **Re-run gates** — re-enter the upstream skill so its quality gates run on the merged state.
-- **Stop** — leave the working tree staged for the user to inspect.
+- **Resume** — dispatch the exact continuation command for the current operation (`git merge --continue`, `git rebase --continue`, or `git cherry-pick --continue`). If the triggering skill invocation is known, return to that skill with the original context after the git operation succeeds; otherwise stop with the resumed git status.
+- **Re-run gates** — dispatch the upstream skill invocation that originally surfaced the conflict so its quality gates run on the merged state.
+- **Stop** — dispatch none; leave the working tree staged for the user to inspect.
 
-`/melt` never auto-resumes. The user picks.
+`/melt` never resumes before the user selects. After a non-stop selection, run the selected continuation immediately.
 
 ## Rules
 

--- a/skills/melt/SKILL.md
+++ b/skills/melt/SKILL.md
@@ -232,7 +232,7 @@ git cherry-pick --abort
 
 ## Handoff
 
-After resolution finishes, prompt the next step via the shared handoff gate in `../../shared/handoff-gate.md`. Include the detected interrupted operation and upstream invocation in the context packet before asking. Default options:
+After resolution finishes, prompt the next step via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Include the detected interrupted operation and upstream invocation in the context packet before asking. Default options:
 
 - **Resume** — dispatch the exact continuation command for the current operation (`git merge --continue`, `git rebase --continue`, or `git cherry-pick --continue`). If the triggering skill invocation is known, return to that skill with the original context after the git operation succeeds; otherwise stop with the resumed git status.
 - **Re-run gates** — dispatch the upstream skill invocation that originally surfaced the conflict so its quality gates run on the merged state.

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -17,7 +17,7 @@ Do not use it for free-form discussion with no artifact intent (`/culture`), dir
 3. **Sketch** — for any feature touching >1 module or a new public interface, run the shape check (`references/shape-check.md`) on the touched symbols, then lock seams in pseudocode signatures before talking spec content. Default to full signatures, not hand-waving.
 4. **Two-key handshake** — both the user (explicit verb) and the agent (coherence self-check) must agree before extraction. See `references/handshake.md`.
 5. **Curdle** — write the approved spec to `.cheese/specs/<slug>.md` (and optional `.cheese/issues/<slug>-NNN.md`). Format and slug rules in `references/curdle.md`.
-6. **Hand off** — once the spec is on disk, prompt the next step via the shared handoff gate in `../../shared/handoff-gate.md`. Never dispatch before the user selects; after a non-stop selection, run the selected downstream skill immediately.
+6. **Hand off** — once the spec is on disk, prompt the next step via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Never dispatch before the user selects; after a non-stop selection, run the selected downstream skill immediately.
 
 ## Modes
 
@@ -79,7 +79,7 @@ Default to project-local cheese artifacts when the user wants files:
 
 **Pipeline:** culture → **[mold]** → cook → press → age → cure → ship
 
-After the spec is written, ask the user via the shared handoff gate in `../../shared/handoff-gate.md`. Lead each option with the verb (what the user wants to *do* next); the skill command (with the spec path and any in-scope `--hard` propagation) is the backing detail. Default options vary with the shape-check verdict:
+After the spec is written, ask the user via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Lead each option with the verb (what the user wants to *do* next); the skill command (with the spec path and any in-scope `--hard` propagation) is the backing detail. Default options vary with the shape-check verdict:
 
 **Low- and medium-blast-radius specs (verdict `low` or `medium`):**
 

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -17,7 +17,7 @@ Do not use it for free-form discussion with no artifact intent (`/culture`), dir
 3. **Sketch** — for any feature touching >1 module or a new public interface, run the shape check (`references/shape-check.md`) on the touched symbols, then lock seams in pseudocode signatures before talking spec content. Default to full signatures, not hand-waving.
 4. **Two-key handshake** — both the user (explicit verb) and the agent (coherence self-check) must agree before extraction. See `references/handshake.md`.
 5. **Curdle** — write the approved spec to `.cheese/specs/<slug>.md` (and optional `.cheese/issues/<slug>-NNN.md`). Format and slug rules in `references/curdle.md`.
-6. **Hand off** — once the spec is on disk, prompt the next step via `AskUserQuestion` (see `## Handoff` below). Never auto-invoke.
+6. **Hand off** — once the spec is on disk, prompt the next step via the shared handoff gate in `../../shared/handoff-gate.md`. Never dispatch before the user selects; after a non-stop selection, run the selected downstream skill immediately.
 
 ## Modes
 
@@ -79,23 +79,23 @@ Default to project-local cheese artifacts when the user wants files:
 
 **Pipeline:** culture → **[mold]** → cook → press → age → cure → ship
 
-After the spec is written, ask the user via `AskUserQuestion` which downstream to run. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Default options vary with the shape-check verdict:
+After the spec is written, ask the user via the shared handoff gate in `../../shared/handoff-gate.md`. Lead each option with the verb (what the user wants to *do* next); the skill command (with the spec path and any in-scope `--hard` propagation) is the backing detail. Default options vary with the shape-check verdict:
 
 **Low- and medium-blast-radius specs (verdict `low` or `medium`):**
 
 - **Implement the spec** *(recommended)* — `/cook .cheese/specs/<slug>.md`.
 - **Implement and auto-review** — `/cook --auto .cheese/specs/<slug>.md`, chains straight through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Stops at the final cure pass; opening or updating the PR stays a manual step. Offer when acceptance criteria are explicit *and* the user has signalled they want the pipeline to run forward without per-step approval. Never pre-select; auto mode is opt-in.
 - **Research more first** — `/briesearch`, gather more external evidence before implementing.
-- **Stop** — leave the spec for later.
+- **Stop** — dispatch none; leave the spec for later.
 
 **High-blast-radius specs (verdict `high` only):**
 
-The spec is large enough that per-phase context contamination becomes a real concern — review reasoning softens when the same window contains the cook reasoning, and the parent context bloats across phases. Offer the fresh-context orchestrator and the manual compaction path:
+The spec is large enough that per-phase context contamination becomes a real concern: review reasoning softens when the same window contains the cook reasoning, and the parent context bloats across phases. Offer the fresh-context orchestrator and the manual compaction path:
 
 - **Run the full pipeline in fresh-context isolation** *(recommended)* — `/ultracook .cheese/specs/<slug>.md`, autonomous chain (`cook → press → age → cure → age → cure → age`, all `--auto`) with each phase running inside its own sub-agent, blind to prior phases.
 - **Implement manually, one phase at a time** — `/cook .cheese/specs/<slug>.md`.
-- **Compact and resume by hand** — clear context, then dispatch `/cook .cheese/specs/<slug>.md` or `/ultracook .cheese/specs/<slug>.md` directly. (`/cheese --continue` scans phase handoff slugs only — fresh specs don't surface there until cook lands a slug — so dispatching the explicit command is the resumption path here.)
-- **Stop** — leave the spec for later.
+- **Compact and resume by hand** — dispatch none; clear context, then dispatch `/cook .cheese/specs/<slug>.md` or `/ultracook .cheese/specs/<slug>.md` directly. (`/cheese --continue` scans phase handoff slugs only — fresh specs don't surface there until cook lands a slug — so dispatching the explicit command is the resumption path here.)
+- **Stop** — dispatch none; leave the spec for later.
 
 `/cook --auto` is omitted from the high-blast-radius offer set: with a large footprint, the fresh-context property of `/ultracook` is the actual motivation for going autonomous, and the in-session chain it offers is the wrong transport for that need. Never pre-select an autonomous option; the user must opt in. `medium` blast radius keeps the standard handoff because the in-session `/cook --auto` chain is still the right tool for that footprint — the fresh-context premium is only worth paying when the spec actually crosses module boundaries broadly enough to flip the verdict to `high`.
 

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -98,7 +98,7 @@ Next step:    /age <slug>                          (when ready for /age or follo
 
 **Pipeline:** culture → mold → cook → **[press]** → age → cure → ship
 
-After the press report is on disk, ask via the shared handoff gate in `../../shared/handoff-gate.md`. Lead each option with the verb (what the user wants to *do* next); the skill command (with any in-scope `--hard` propagation) is the backing detail. Default options:
+After the press report is on disk, ask via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Lead each option with the verb (what the user wants to *do* next); the skill command (with any in-scope `--hard` propagation) is the backing detail. Default options:
 
 - **Review the diff** *(recommended when readiness is `ready for /age` or `follow-up recommended`)* — `/age <slug>`. For `follow-up recommended`, the cooked contract is sound and every changed behaviour has a hardening test; documented follow-ups can be addressed after review.
 - **Stop** — dispatch none; defer review (use this if you want to harden manually before /age, even though the contract is review-safe).

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -23,7 +23,7 @@ Do not use it to implement broad new behavior. Press may add or strengthen tests
 5. **Corrective fixes** — only for defects the hardening tests expose. No new behaviour.
 6. **Run checks** — narrowest useful tests, then relevant wider gates already in the project.
 7. **Report** — write `.cheese/press/<slug>.md` (slug carried from `/cook`, or derived from branch/task) and print the path. Mark readiness: `ready for /age`, `follow-up recommended`, or `blocked`.
-8. **Hand off** — in manual mode, prompt the next step via `AskUserQuestion` (see `## Handoff` below); in `--auto` mode, chain forward per `### Auto mode`.
+8. **Hand off** — in manual mode, prompt the next step via the shared handoff gate (see `## Handoff` below); in `--auto` mode, chain forward per `### Auto mode`.
 
 ## Preferred tools and fallbacks
 
@@ -98,18 +98,18 @@ Next step:    /age <slug>                          (when ready for /age or follo
 
 **Pipeline:** culture → mold → cook → **[press]** → age → cure → ship
 
-After the press report is on disk, ask via `AskUserQuestion` which downstream to run. Lead each option with the verb (what the user wants to *do* next); the skill command is the backing detail. Default options:
+After the press report is on disk, ask via the shared handoff gate in `../../shared/handoff-gate.md`. Lead each option with the verb (what the user wants to *do* next); the skill command (with any in-scope `--hard` propagation) is the backing detail. Default options:
 
 - **Review the diff** *(recommended when readiness is `ready for /age` or `follow-up recommended`)* — `/age <slug>`. For `follow-up recommended`, the cooked contract is sound and every changed behaviour has a hardening test; documented follow-ups can be addressed after review.
-- **Stop** — defer review (use this if you want to harden manually before /age, even though the contract is review-safe).
+- **Stop** — dispatch none; defer review (use this if you want to harden manually before /age, even though the contract is review-safe).
 
-Pre-select **Review the diff** when readiness is `ready for /age` or `follow-up recommended`. If the report is `blocked`, do not pre-select anything; the user decides whether to fix or escalate.
+Pre-select **Review the diff** when readiness is `ready for /age` or `follow-up recommended`. If the report is `blocked`, do not pre-select anything; the user decides whether to fix or escalate. After a non-stop selection, run the selected command immediately.
 
 ### Auto mode
 
 When invoked with `--auto` (propagated from `/cook --auto`):
 
-- Skip the `AskUserQuestion` entirely.
+- Skip the handoff gate entirely.
 - If readiness is `ready for /age` or `follow-up recommended`, invoke `/age <slug> --auto` directly. Both states mean the cooked contract is sound and every changed behaviour has a hardening test; follow-ups are documented and review-safe.
 - If readiness is `blocked`, stop the auto chain and surface the press report to the user. `blocked` is reserved for cases where human judgement is genuinely required: a false premise on the cooked contract, an unfixable level-1/2 gap inside cooked scope, a changed behaviour press could not lock with a stable hardening test, or spinning wheels (three attempts at the same gap without green).
 

--- a/tests/python/test_gen_docs.py
+++ b/tests/python/test_gen_docs.py
@@ -96,6 +96,22 @@ class TestRewriteSkillLink:
     def test_unknown_path_is_untouched(self, gen_docs):
         assert gen_docs.rewrite_skill_link("../../some/other/file.md", "cook") == "../../some/other/file.md"
 
+    def test_shared_contract_link_climbs_one_level(self, gen_docs):
+        # Source skills/<name>/SKILL.md uses ../../shared/<file>.md (two ups:
+        # skills/<name>/ -> skills/ -> repo_root, then shared/). After
+        # flattening to docs/skills/<name>.md the `<name>/` directory is gone,
+        # so only one `..` is needed to reach docs/shared/<file>.md.
+        assert (
+            gen_docs.rewrite_skill_link("../../shared/handoff-gate.md", "age")
+            == "../shared/handoff-gate.md"
+        )
+
+    def test_shared_contract_link_preserves_anchor(self, gen_docs):
+        assert (
+            gen_docs.rewrite_skill_link("../../shared/handoff-gate.md#vocabulary", "age")
+            == "../shared/handoff-gate.md#vocabulary"
+        )
+
 
 class TestRewriteRefLink:
     def test_external_urls_pass_through(self, gen_docs):
@@ -278,3 +294,151 @@ class TestEmitInstallPage:
         self._write_full_readme(tmp_path / "README.md")
         monkeypatch.setattr(gen_docs, "REPO_ROOT", tmp_path)
         assert gen_docs.emit_install_page() is True
+
+
+class TestEmitSharedPages:
+    """emit_shared_pages mirrors shared/*.md into the docs tree.
+
+    The function is what makes the ``../../shared/<file>.md`` links from
+    skill SKILL.md bodies actually resolve under mkdocs --strict. We test
+    the contract end-to-end: an empty dir is a no-op, files get copied,
+    non-Markdown files are skipped, and titles fall back to the slug.
+    """
+
+    def _capture_writes(self, gen_docs, monkeypatch):
+        """Intercept mkdocs_gen_files.open() so we can assert on its writes."""
+        writes: dict[str, str] = {}
+
+        class _Capturing:
+            def __init__(self, key):
+                self.key = key
+                self.buf: list[str] = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                writes[self.key] = "".join(self.buf)
+                return False
+
+            def write(self, data):
+                self.buf.append(data)
+
+        import mkdocs_gen_files
+
+        monkeypatch.setattr(mkdocs_gen_files, "open", lambda key, *_a, **_kw: _Capturing(key))
+        monkeypatch.setattr(mkdocs_gen_files, "set_edit_path", lambda *_a, **_kw: None)
+        return writes
+
+    def test_missing_dir_returns_empty(self, gen_docs, tmp_path, monkeypatch):
+        monkeypatch.setattr(gen_docs, "SHARED_DIR", tmp_path / "nope")
+        assert gen_docs.emit_shared_pages() == []
+
+    def test_empty_dir_returns_empty(self, gen_docs, tmp_path, monkeypatch):
+        (tmp_path / "shared").mkdir()
+        monkeypatch.setattr(gen_docs, "SHARED_DIR", tmp_path / "shared")
+        monkeypatch.setattr(gen_docs, "REPO_ROOT", tmp_path)
+        assert gen_docs.emit_shared_pages() == []
+
+    def test_emits_markdown_and_uses_h1_as_title(self, gen_docs, tmp_path, monkeypatch):
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        (shared / "handoff-gate.md").write_text("# Handoff gate\n\nbody\n", encoding="utf-8")
+        monkeypatch.setattr(gen_docs, "SHARED_DIR", shared)
+        monkeypatch.setattr(gen_docs, "REPO_ROOT", tmp_path)
+        writes = self._capture_writes(gen_docs, monkeypatch)
+
+        entries = gen_docs.emit_shared_pages()
+
+        assert entries == [("Handoff gate", "shared/handoff-gate.md")]
+        assert writes["shared/handoff-gate.md"] == "# Handoff gate\n\nbody\n"
+
+    def test_falls_back_to_slug_when_no_h1(self, gen_docs, tmp_path, monkeypatch):
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        (shared / "no-h1.md").write_text("just body, no heading\n", encoding="utf-8")
+        monkeypatch.setattr(gen_docs, "SHARED_DIR", shared)
+        monkeypatch.setattr(gen_docs, "REPO_ROOT", tmp_path)
+        self._capture_writes(gen_docs, monkeypatch)
+
+        entries = gen_docs.emit_shared_pages()
+
+        assert entries == [("No h1", "shared/no-h1.md")]
+
+    def test_skips_non_markdown_files(self, gen_docs, tmp_path, monkeypatch):
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        (shared / "handoff-gate.md").write_text("# Gate\n", encoding="utf-8")
+        (shared / "schema.json").write_text("{}", encoding="utf-8")
+        (shared / "notes.txt").write_text("ignore me", encoding="utf-8")
+        monkeypatch.setattr(gen_docs, "SHARED_DIR", shared)
+        monkeypatch.setattr(gen_docs, "REPO_ROOT", tmp_path)
+        writes = self._capture_writes(gen_docs, monkeypatch)
+
+        entries = gen_docs.emit_shared_pages()
+
+        # Only the .md file lands in the docs tree (and the nav).
+        assert [path for _, path in entries] == ["shared/handoff-gate.md"]
+        assert set(writes) == {"shared/handoff-gate.md"}
+
+    def test_multiple_files_sorted(self, gen_docs, tmp_path, monkeypatch):
+        shared = tmp_path / "shared"
+        shared.mkdir()
+        (shared / "zebra.md").write_text("# Zebra\n", encoding="utf-8")
+        (shared / "alpha.md").write_text("# Alpha\n", encoding="utf-8")
+        monkeypatch.setattr(gen_docs, "SHARED_DIR", shared)
+        monkeypatch.setattr(gen_docs, "REPO_ROOT", tmp_path)
+        self._capture_writes(gen_docs, monkeypatch)
+
+        entries = gen_docs.emit_shared_pages()
+
+        # Sorted by source filename — keeps the generated nav stable across runs.
+        assert [path for _, path in entries] == ["shared/alpha.md", "shared/zebra.md"]
+
+
+class TestEmitNav:
+    """emit_nav renders the literate-nav SUMMARY.md.
+
+    The shared-contracts section is only added when at least one shared
+    page exists; otherwise mkdocs --strict would warn about an empty group.
+    """
+
+    def _captured_summary(self, gen_docs, monkeypatch):
+        buf: list[str] = []
+
+        class _Sink:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                return False
+
+            def write(self, data):
+                buf.append(data)
+
+        import mkdocs_gen_files
+
+        monkeypatch.setattr(mkdocs_gen_files, "open", lambda *_a, **_kw: _Sink())
+        monkeypatch.setattr(mkdocs_gen_files, "set_edit_path", lambda *_a, **_kw: None)
+        return buf
+
+    def test_includes_shared_section_when_present(self, gen_docs, monkeypatch):
+        buf = self._captured_summary(gen_docs, monkeypatch)
+        gen_docs.emit_nav(
+            skills=[{"name": "age", "refs": []}],
+            shared=[("Handoff gate", "shared/handoff-gate.md")],
+            extras=[],
+        )
+        out = "".join(buf)
+        assert "* Shared contracts" in out
+        assert "* [Handoff gate](shared/handoff-gate.md)" in out
+
+    def test_omits_shared_section_when_empty(self, gen_docs, monkeypatch):
+        buf = self._captured_summary(gen_docs, monkeypatch)
+        gen_docs.emit_nav(
+            skills=[{"name": "age", "refs": []}],
+            shared=[],
+            extras=[("README", "readme.md")],
+        )
+        out = "".join(buf)
+        assert "Shared contracts" not in out


### PR DESCRIPTION
## Summary

- Adds `shared/handoff-gate.md` as the cross-skill contract for post-gate dispatch (skill transitions via `dispatch:` vs in-skill continuation via `continue:`), so handoffs work on hosts that don't have `AskUserQuestion`.
- Each workflow skill (`/age`, `/cheese`, `/cheese-factory`, `/cook`, `/culture`, `/cure`, `/melt`, `/mold`, `/press`) now points at the shared gate instead of inline `AskUserQuestion` references at its handoff seam.
- Skills whose selections or contracts don't survive a CLI flag emit structured context packets: `/age → /cure` carries `selection` + `resolved_ids`, `/culture → /cook` carries the discussion summary as the accepted contract, `/melt` carries the interrupted git op + upstream skill.
- README documents the top-level `shared/` directory pattern: cross-cutting content lives sibling to `skills/` so it stays out of skill auto-discovery and reads as a contract rather than a private detail of any single skill.

## Why

`AskUserQuestion` is a Claude Code primitive; running these skills under Codex (or any other harness without it) silently fell back to "stop and recommend a next step", which broke the handoff contract — the user picked, then nothing happened. The shared gate names the primitive the host actually has (`AskUserQuestion`, Codex `request_user_input`, or a plain numbered question) and standardises what each option carries (`label`, exactly one of `dispatch:` / `continue:` / `dispatch: none`, plus a `context:` payload).

## Out of scope

- `/cheese`'s in-skill clarify path still calls `AskUserQuestion` directly (single in-skill question, not a dispatch). `coherence-check.md` mentions "the dispatch `AskUserQuestion`" — stale wording, left for a follow-up.
- No code changes outside skill markdown + the new `shared/handoff-gate.md`.

## Test plan

- [ ] Read `shared/handoff-gate.md` end-to-end and confirm the contract covers skill transition, in-skill continuation, and terminal stop without ambiguity.
- [ ] Spot-check each updated skill's `## Handoff` section: verb-first labels survive, the shared gate is referenced, context packets are present where promised.
- [ ] Confirm `mkdocs build --strict` still passes (no broken relative links from skill files into `../../shared/handoff-gate.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)