### PR TITLE
docs(site): cheese-theme the mkdocs site

### DIFF
--- a/docs/assets/favicon.svg
+++ b/docs/assets/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <title>easy-cheese</title>
+  <!-- wedge body -->
+  <path d="M6 46 L58 18 L58 46 Z"
+        fill="#fbbf24" stroke="#b45309" stroke-width="2" stroke-linejoin="round"/>
+  <!-- rind along the cut edge -->
+  <path d="M6 46 L58 46"
+        stroke="#b45309" stroke-width="3" stroke-linecap="round"/>
+  <!-- holes -->
+  <circle cx="22" cy="40" r="3" fill="#f59e0b"/>
+  <circle cx="34" cy="34" r="2.5" fill="#f59e0b"/>
+  <circle cx="44" cy="30" r="2" fill="#f59e0b"/>
+  <circle cx="28" cy="42" r="1.5" fill="#f59e0b"/>
+  <circle cx="40" cy="42" r="1.5" fill="#f59e0b"/>
+</svg>

--- a/docs/stylesheets/cheese.css
+++ b/docs/stylesheets/cheese.css
@@ -36,13 +36,13 @@
 }
 
 /* Inline code: wax-paper background */
-.md-typeset code {
+.md-typeset :not(pre) > code {
   background-color: rgba(253, 230, 138, 0.45);
   border: 1px solid rgba(180, 83, 9, 0.15);
   border-radius: 4px;
 }
 
-[data-md-color-scheme="slate"] .md-typeset code {
+[data-md-color-scheme="slate"] .md-typeset :not(pre) > code {
   background-color: rgba(180, 83, 9, 0.25);
   border-color: rgba(253, 230, 138, 0.2);
 }

--- a/docs/stylesheets/cheese.css
+++ b/docs/stylesheets/cheese.css
@@ -1,0 +1,80 @@
+/* easy-cheese — cheese-themed overrides for mkdocs-material */
+
+:root {
+  --cheese-rind: #b45309;
+  --cheese-curd: #fde68a;
+  --cheese-wheel: #f59e0b;
+  --cheese-melt: #fb923c;
+  --cheese-wax: #c2410c;
+}
+
+/* Warm the header into a wheel-of-cheese gradient */
+.md-header,
+.md-tabs {
+  background: linear-gradient(
+    135deg,
+    var(--cheese-wax) 0%,
+    var(--cheese-melt) 55%,
+    var(--cheese-wheel) 100%
+  );
+}
+
+/* Brand-mark gets a subtle melt */
+.md-header__title {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+/* Logo: a tiny gentle wobble on hover, like a wheel rocking on a board */
+.md-header__button.md-logo svg,
+.md-header__button.md-logo img {
+  transition: transform 200ms ease-in-out;
+}
+.md-header__button.md-logo:hover svg,
+.md-header__button.md-logo:hover img {
+  transform: rotate(-8deg) scale(1.05);
+}
+
+/* Inline code: wax-paper background */
+.md-typeset code {
+  background-color: rgba(253, 230, 138, 0.45);
+  border: 1px solid rgba(180, 83, 9, 0.15);
+  border-radius: 4px;
+}
+
+[data-md-color-scheme="slate"] .md-typeset code {
+  background-color: rgba(180, 83, 9, 0.25);
+  border-color: rgba(253, 230, 138, 0.2);
+}
+
+/* "Tip" admonitions get a cheese-colored stripe so cheese-flavored asides pop */
+.md-typeset .admonition.tip,
+.md-typeset details.tip {
+  border-color: var(--cheese-wheel);
+}
+.md-typeset .tip > .admonition-title,
+.md-typeset .tip > summary {
+  background-color: rgba(245, 158, 11, 0.12);
+}
+.md-typeset .tip > .admonition-title::before,
+.md-typeset .tip > summary::before {
+  background-color: var(--cheese-rind);
+}
+
+/* Tables: subtle aged-paper alternating rows */
+.md-typeset table:not([class]) tbody tr:nth-child(even) {
+  background-color: rgba(253, 230, 138, 0.08);
+}
+
+/* Footer copyright a little warmer */
+.md-footer-meta__inner {
+  font-variant-caps: small-caps;
+  letter-spacing: 0.03em;
+}
+
+/* Mermaid diagrams: nudge node fills toward the cheese palette */
+.mermaid .node rect,
+.mermaid .node polygon,
+.mermaid .node circle {
+  stroke: var(--cheese-rind) !important;
+}

--- a/docs/stylesheets/cheese.css
+++ b/docs/stylesheets/cheese.css
@@ -26,13 +26,16 @@
 }
 
 /* Logo: a tiny gentle wobble on hover, like a wheel rocking on a board */
-.md-header__button.md-logo svg,
-.md-header__button.md-logo img {
-  transition: transform 200ms ease-in-out;
-}
-.md-header__button.md-logo:hover svg,
-.md-header__button.md-logo:hover img {
-  transform: rotate(-8deg) scale(1.05);
+@media (prefers-reduced-motion: no-preference) {
+  .md-header__button.md-logo svg,
+  .md-header__button.md-logo img {
+    transition: transform 200ms ease-in-out;
+  }
+
+  .md-header__button.md-logo:hover svg,
+  .md-header__button.md-logo:hover img {
+    transform: rotate(-8deg) scale(1.05);
+  }
 }
 
 /* Inline code: wax-paper background */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: easy-cheese
-site_description: A skills plugin for Claude Code — the cheese-making pipeline for code review, implementation, and refactoring.
+site_name: 🧀 easy-cheese
+site_description: A skills plugin for Claude Code — the cheese-making pipeline that ages raw curds into shippable wheels of code.
 site_url: https://paulnsorensen.github.io/easy-cheese/
 site_author: Paul Sorensen
 
@@ -7,7 +7,7 @@ repo_name: paulnsorensen/easy-cheese
 repo_url: https://github.com/paulnsorensen/easy-cheese
 edit_uri: edit/main/
 
-copyright: Copyright &copy; 2026 Paul Sorensen — MIT License
+copyright: Copyright &copy; 2026 Paul Sorensen — MIT License · aged to perfection 🧀
 
 docs_dir: docs
 
@@ -31,25 +31,43 @@ theme:
     - search.highlight
     - search.share
     - toc.follow
+  font:
+    text: Fraunces
+    code: JetBrains Mono
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
       primary: deep orange
       accent: amber
       toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
+        icon: material/cheese
+        name: Switch to the cave (dark mode)
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       primary: deep orange
       accent: amber
       toggle:
-        icon: material/brightness-4
-        name: Switch to light mode
+        icon: material/cheese-off
+        name: Switch to the dairy (light mode)
   icon:
+    logo: material/cheese
     repo: fontawesome/brands/github
     edit: material/pencil
     view: material/eye
+    admonition:
+      note: material/cheese-off
+      abstract: material/clipboard-text
+      info: material/information
+      tip: material/cheese
+      success: material/check-decagram
+      question: material/help-circle
+      warning: material/alert
+      failure: material/close-octagon
+      danger: material/skull-crossbones
+      bug: material/bug
+      example: material/test-tube
+      quote: material/format-quote-close
+  favicon: assets/favicon.svg
 
 plugins:
   - search
@@ -92,9 +110,15 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
 
+extra_css:
+  - stylesheets/cheese.css
+
 extra:
+  generator: false
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/paulnsorensen/easy-cheese
+      name: Source code on GitHub
     - icon: fontawesome/solid/mug-hot
       link: https://www.buymeacoffee.com/paulnsorensen
+      name: Buy the cheesemonger a coffee


### PR DESCRIPTION
## What changed

Cheese-theme the rendered GitHub Pages site: cheese logo + favicon, cheese-flavored dark/light toggle, a cheese-leaning admonition icon set, warmer typography, and a small custom stylesheet.

## Why

The skills and the README already lean into the cheesemonger voice; the docs site landing was the last surface still wearing a stock mkdocs-material coat.

## How to verify

- \`just docs-serve\` and load http://localhost:8000 — confirm the wedge favicon, cheese logo, warm header gradient, and that the dark/light toggle swaps cheese ↔ cheese-off.
- \`just docs-build\` runs \`mkdocs build --strict\` clean (verified locally).
- On a deployed PR preview (if enabled) or after merge, check that \`stylesheets/cheese.css\` and \`assets/favicon.svg\` are served.

## Risk / rollout notes

Cosmetic-only — no nav, plugin, or content-pipeline changes. No new dependencies. Reverting is a single-commit revert.

## Checklist

- [x] Conventional Commits PR title (\`feat:\`, \`fix:\`, \`chore:\`, \`docs:\`, ...)
- [x] Tests added or updated (or N/A) — N/A, cosmetic
- [x] Documentation updated (or N/A) — this *is* the docs change
- [x] No secrets or credentials added