### PR TITLE
docs(site): legibility + dark-mode contrast + accurate framing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # 🧀 easy-cheese
 
-A skills plugin for [Claude Code](https://docs.claude.com/claude-code) — the cheese-making pipeline for code review, implementation, refactoring, and PR rescue.
+A set of harness-agnostic [Agent Skills](https://agentskills.io) — the cheese-making pipeline for code review, implementation, refactoring, and PR rescue.
 
 [![CI](https://img.shields.io/github/actions/workflow/status/paulnsorensen/easy-cheese/validate.yml?branch=main&label=CI&style=flat-square)](https://github.com/paulnsorensen/easy-cheese/actions/workflows/validate.yml)
 [![License: MIT](https://img.shields.io/github/license/paulnsorensen/easy-cheese?style=flat-square)](https://github.com/paulnsorensen/easy-cheese/blob/main/LICENSE)

--- a/docs/stylesheets/cheese.css
+++ b/docs/stylesheets/cheese.css
@@ -1,5 +1,8 @@
 /* easy-cheese — cheese-themed overrides for mkdocs-material */
 
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600;9..144,700&display=swap");
+
+
 :root {
   --cheese-rind: #b45309;
   --cheese-curd: #fde68a;
@@ -8,7 +11,15 @@
   --cheese-wax: #c2410c;
 }
 
-/* Warm the header into a wheel-of-cheese gradient */
+/* Headings keep the artisanal Fraunces; body stays on Inter for legibility */
+.md-typeset h1,
+.md-typeset h2 {
+  font-family: "Fraunces", "Source Serif 4", Georgia, serif;
+  font-optical-sizing: auto;
+  letter-spacing: -0.01em;
+}
+
+/* Warm the header into a wheel-of-cheese gradient (light mode) */
 .md-header,
 .md-tabs {
   background: linear-gradient(
@@ -16,6 +27,18 @@
     var(--cheese-wax) 0%,
     var(--cheese-melt) 55%,
     var(--cheese-wheel) 100%
+  );
+}
+
+/* Dark mode: swap to a deeper, aged-rind gradient so the header
+   doesn't glare against the slate page background */
+[data-md-color-scheme="slate"] .md-header,
+[data-md-color-scheme="slate"] .md-tabs {
+  background: linear-gradient(
+    135deg,
+    #7c2d12 0%,
+    #92400e 55%,
+    #b45309 100%
   );
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: 🧀 easy-cheese
-site_description: A skills plugin for Claude Code — the cheese-making pipeline that ages raw curds into shippable wheels of code.
+site_description: Harness-agnostic Agent Skills (agentskills.io) — the cheese-making pipeline that ages raw curds into shippable wheels of code.
 site_url: https://paulnsorensen.github.io/easy-cheese/
 site_author: Paul Sorensen
 
@@ -32,7 +32,7 @@ theme:
     - search.share
     - toc.follow
   font:
-    text: Fraunces
+    text: Inter
     code: JetBrains Mono
   palette:
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
## What changed

Three small follow-ups to the cheese-themed site (#58):

- **Body font → Inter** (Fraunces scoped to \`h1\`/\`h2\` only, loaded via \`@import\`), for better paragraph legibility.
- **Dark-mode header gradient** — light mode keeps the bright cheese-wheel; dark mode now uses a deeper rind → baked-amber (\`#7c2d12 → #92400e → #b45309\`), scoped via \`[data-md-color-scheme=\"slate\"]\`, so the header no longer glares against the slate page.
- **Framing fix** — \`site_description\` and \`docs/index.md\` no longer call this a Claude-Code plugin; both now describe it as a set of harness-agnostic Agent Skills (agentskills.io). README was already clean.

## Why

Fraunces was attractive but hard to read at body sizes; the saturated header was visually loud in dark mode; and calling the project a Claude-Code plugin misrepresents its harness-agnostic scope.

## How to verify

- \`just docs-serve\` → confirm paragraphs render in Inter, h1/h2 stay Fraunces, dark mode header is muted rind/amber.
- \`just docs-build\` runs \`mkdocs build --strict\` clean (verified locally).

## Risk / rollout notes

Cosmetic + copy. No nav or plugin changes. Loading Fraunces adds one Google Fonts request; revertable in one commit.

## Checklist

- [x] Conventional Commits PR title
- [x] Tests added or updated — N/A, cosmetic
- [x] Documentation updated — this *is* the docs change
- [x] No secrets or credentials added