### PR TITLE
docs(site): brighten dark-mode body and heading text

### DIFF
--- a/docs/stylesheets/cheese.css
+++ b/docs/stylesheets/cheese.css
@@ -30,6 +30,24 @@
   );
 }
 
+/* Dark mode: brighten body + heading text. mkdocs-material's slate scheme
+   uses ~82% alpha on text which reads as dim against the dark background;
+   push to full opacity with a warm cream so paragraphs and headings stay
+   crisp and on-brand */
+[data-md-color-scheme="slate"] {
+  --md-typeset-color: hsla(45, 35%, 96%, 1);
+  --md-default-fg-color: hsla(45, 35%, 96%, 1);
+  --md-default-fg-color--light: hsla(45, 30%, 90%, 1);
+  --md-default-fg-color--lighter: hsla(45, 25%, 80%, 0.85);
+}
+
+[data-md-color-scheme="slate"] .md-typeset h1,
+[data-md-color-scheme="slate"] .md-typeset h2,
+[data-md-color-scheme="slate"] .md-typeset h3,
+[data-md-color-scheme="slate"] .md-typeset h4 {
+  color: #fef3c7;
+}
+
 /* Dark mode: swap to a deeper, aged-rind gradient so the header
    doesn't glare against the slate page background */
 [data-md-color-scheme="slate"] .md-header,


### PR DESCRIPTION
## What changed

Override mkdocs-material's slate-scheme typeset variables so paragraph text uses full opacity instead of the default ~82% alpha, and bump \`h1\`–\`h4\` to a brighter on-brand cream (\`#fef3c7\`).

## Why

After #58 + #60, dark mode body text looked dim against the dark page — partially the alpha, partially that the default off-white doesn't pop against slate.

## How to verify

- \`just docs-serve\`, switch to dark mode (cheese-off toggle), confirm paragraphs and headings read crisply against the slate background.
- \`just docs-build\` runs \`mkdocs build --strict\` clean (verified locally).

## Risk / rollout notes

Cosmetic, dark-mode only. Light mode untouched. Revertable in one commit.

## Checklist

- [x] Conventional Commits PR title
- [x] Tests added or updated — N/A, cosmetic
- [x] Documentation updated — this *is* the docs change
- [x] No secrets or credentials added