### PR TITLE
fix(melt): catch squash-residue via tree-match and offer non-destructive merge remedy

### DIFF
--- a/skills/melt/SKILL.md
+++ b/skills/melt/SKILL.md
@@ -44,11 +44,11 @@ If the verdict is `SQUASH-MERGED`, surface both printed remedies to the user ver
 - `--branch` — branch to check (default: current).
 - `--json` — structured output for scripting.
 
-Detection methods (most-to-least reliable, all attempted):
+Detection cascade (strongest first; later signals run only when needed):
 
-- `tree-match` — walks commits on base looking for one whose tree equals the tree at some point on the branch. That commit is a squash-equivalent of branch commits up to that point. Works offline, through fork PRs and renames, and handles branches with commits past the squash (the case `local-synth` misses).
-- `gh-api` — enriches the result with PR metadata (number, URL, merge commit) and provides an independent SHA-overlap signal.
-- `local-synth` — synthesizes a would-be squash commit from HEAD's tree and asks `git cherry` whether base contains an equivalent. Last-resort fallback; cannot enumerate squashed vs unique commits.
+- `tree-match` — walks commits on base looking for one whose tree equals the tree at some point on the branch. That commit is a squash-equivalent of branch commits up to that point. Works offline, through fork PRs and renames, and handles branches with commits past the squash (the case `local-synth` misses). Always runs first.
+- `gh-api` — runs in parallel with tree-match. Enriches a tree-match verdict with PR metadata (number, URL, merge commit) when its SHAs correlate with the squash; supplies the verdict on its own when tree-match found nothing.
+- `local-synth` — synthesizes a would-be squash commit from HEAD's tree and asks `git cherry` whether base contains an equivalent. Last-resort fallback that only runs when neither tree-match nor gh-api produced a verdict; cannot enumerate squashed vs unique commits.
 
 Verdict semantics:
 

--- a/skills/melt/SKILL.md
+++ b/skills/melt/SKILL.md
@@ -32,24 +32,38 @@ The bash-driven flows below cover the bulk of resolution. Drop into the cheez-* 
 
 ### 0. Squash-residue check
 
-Run this before the conflict summary. If the branch was squash-merged into base, mergiraf cannot help — the right answer is to abort and re-cherry-pick the unique commits.
+Run this before the conflict summary. If the branch was squash-merged into base, mergiraf cannot help — the right answer is to either merge base in (non-destructive) or abort and re-cherry-pick the unique commits (destructive).
 
 ```bash
 python3 skills/melt/scripts/detect-squash-residue.py
 ```
 
-If the verdict is `SQUASH-MERGED`, surface the printed remedy to the user verbatim and stop the cascade. The remedy is destructive (`git reset --hard`) and must be copy-pasted by the user, not auto-applied. Flags:
+If the verdict is `SQUASH-MERGED`, surface both printed remedies to the user verbatim and stop the cascade. Neither remedy is auto-applied — the user picks one and copy-pastes. Flags:
 
 - `--base` — base ref to compare against (default: `origin/main`).
 - `--branch` — branch to check (default: current).
 - `--json` — structured output for scripting.
 
+Detection methods (most-to-least reliable, all attempted):
+
+- `tree-match` — walks commits on base looking for one whose tree equals the tree at some point on the branch. That commit is a squash-equivalent of branch commits up to that point. Works offline, through fork PRs and renames, and handles branches with commits past the squash (the case `local-synth` misses).
+- `gh-api` — enriches the result with PR metadata (number, URL, merge commit) and provides an independent SHA-overlap signal.
+- `local-synth` — synthesizes a would-be squash commit from HEAD's tree and asks `git cherry` whether base contains an equivalent. Last-resort fallback; cannot enumerate squashed vs unique commits.
+
 Verdict semantics:
 
-- `SQUASH-MERGED` (via `gh-api`) — PR found and at least one local commit's SHA matched the PR; cherry-pick list derived from the unmatched (post-squash) commits.
-- `SQUASH-MERGED` (via `local-synth`) — detected offline; cherry-pick list must be reviewed by hand.
+- `SQUASH-MERGED` (`method=tree-match` or `tree-match+gh`) — strongest signal; unique-commit list is the slice of branch commits after the matched squash point.
+- `SQUASH-MERGED` (`method=gh-api`) — fallback when tree-match found nothing but the gh PR's SHAs overlap with branch commits.
+- `SQUASH-MERGED` (`method=local-synth`) — detected offline only; cherry-pick list must be reviewed by hand.
 - `not-detected` — proceed to the cascade.
 - `not-applicable` — on the base branch.
+
+The detector prints two remedies in order:
+
+- **[A] merge** (non-destructive) — `git merge <base>`. Preserves all branch history; squashed commits collapse to a no-op merge, so only real conflicts surface. Prefer this when the branch has unique work or the unique-commit list is uncertain.
+- **[B] reset-and-cherry-pick** (destructive) — `git reset --hard <base>` + `git cherry-pick <unique-shas>`. Rewrites the branch and requires force-push. Use when a clean linear history is wanted and the unique-commit list looks complete.
+
+Default to suggesting [A] first; only suggest [B] when the user has stated a preference for a linear-history workflow or the unique-commit count is small and verified.
 
 ### 1. Diagnose
 
@@ -190,7 +204,7 @@ ls .git/rr-cache/              # browse the resolution database
 
 | Script | Purpose | When |
 | --- | --- | --- |
-| `detect-squash-residue.py` | Detect that the branch was squash-merged and emit the abort+cherry-pick remedy | **Run first** — short-circuits the cascade |
+| `detect-squash-residue.py` | Detect that the branch was squash-merged and emit both the merge and reset+cherry-pick remedies | **Run first** — short-circuits the cascade |
 | `conflict-summary.py` | Structured summary with line numbers and context | After residue check |
 | `batch-resolve.py` | Run `mergiraf merge` over every conflicted file | Supported languages |
 | `conflict-pick.py` | Choose ours / theirs per hunk | Shell, SQL, formats mergiraf does not parse |
@@ -242,9 +256,10 @@ After resolution finishes, prompt the next step via the shared handoff gate in [
 
 ## Rules
 
-- Always run `detect-squash-residue.py` first; if positive, surface the remedy and stop the cascade.
+- Always run `detect-squash-residue.py` first; if positive, surface both remedies and stop the cascade.
 - Always run `conflict-summary.py` before deciding the cascade order.
 - Prefer structural resolution over manual edits when mergiraf supports the file type.
 - Never weaken or hand-edit a lockfile in place — regenerate from the manifest.
-- Surface unresolved files explicitly; do not claim a clean tree until `git status` agrees.
-- Never auto-apply the squash-residue remedy — it is destructive (`git reset --hard`); the user copy-pastes it.
+- Flag unresolved files explicitly; do not claim a clean tree until `git status` agrees.
+- Never auto-apply a squash-residue remedy — even the non-destructive merge path rewrites working state; the user copy-pastes their choice.
+- Lead with the merge remedy unless the user has asked for a linear-history workflow; reset+cherry-pick rewrites the branch and requires force-push.

--- a/skills/melt/scripts/detect-squash-residue.py
+++ b/skills/melt/scripts/detect-squash-residue.py
@@ -7,18 +7,21 @@ in base, producing useless conflicts that mergiraf cannot resolve — the right
 answer is to merge base in (non-destructive) or reset and re-cherry-pick the
 unique commits (destructive).
 
-Detection path (most-to-least reliable, all attempted):
+Detection cascade (strongest first; later signals run only when needed):
   1. Tree-match — walk recent commits on base looking for one whose tree
      equals the tree at some point on the branch. That commit is a squash
      of branch commits up to that point. Works offline, through fork PRs,
      and when the branch has additional commits past the squash (the case
-     `local-synth` misses).
+     `local-synth` misses). Always runs first.
   2. gh API — `gh pr list --state merged --head <branch>` provides PR
-     metadata (number, URL) and an independent SHA-overlap signal.
+     metadata (number, URL) and an independent SHA-overlap signal. Always
+     runs alongside tree-match so it can enrich a tree-match verdict, and
+     supplies the verdict on its own when tree-match found nothing.
   3. Local synthesis — synthesize a would-be squash commit from HEAD's
-     tree and ask `git cherry` whether base contains an equivalent. Last
-     resort; cannot enumerate squashed vs unique commits, and misses the
-     case where the branch has commits past the squash.
+     tree and ask `git cherry` whether base contains an equivalent. Only
+     runs when neither tree-match nor gh produced a verdict. Last resort;
+     cannot enumerate squashed vs unique commits, and misses the case
+     where the branch has commits past the squash.
 
 No auto-fix. Prints two remedies (merge first, then reset+cherry-pick) as
 copy-paste blocks; the user picks and runs.
@@ -121,6 +124,51 @@ def _check_via_gh(branch: str, base_ref: str) -> dict | None:
     }
 
 
+def _log_with_trees(
+    range_ref: str, *, reverse: bool = False, limit: int | None = None
+) -> list[tuple[str, str, str]] | None:
+    """git log --format='%H<tab>%T<tab>%s' <range> → [(sha, tree, subject)].
+    Returns None on git failure, [] when the range is empty.
+    """
+    args = ["log"]
+    if limit is not None:
+        args.append(f"-{limit}")
+    if reverse:
+        args.append("--reverse")
+    args += ["--format=%H%x09%T%x09%s", range_ref]
+    r = run_git(args)
+    if r.returncode != 0:
+        return None
+    rows: list[tuple[str, str, str]] = []
+    if not r.stdout.strip():
+        return rows
+    for line in r.stdout.strip().split("\n"):
+        parts = line.split("\t", 2)
+        if len(parts) == 3:
+            rows.append((parts[0], parts[1], parts[2]))
+    return rows
+
+
+def _format_commit_list(rows: list[tuple[str, str, str]]) -> list[dict]:
+    return [{"sha": sha, "short": sha[:8], "subject": subj} for sha, _, subj in rows]
+
+
+def _build_tree_match_result(
+    base_sha: str,
+    base_subject: str,
+    branch_commits: list[tuple[str, str, str]],
+    squash_index: int,
+) -> dict:
+    """Format a tree-match hit into the result dict shape."""
+    return {
+        "squash_commit": base_sha,
+        "squash_short": base_sha[:8],
+        "squash_subject": base_subject,
+        "squashed_commits": _format_commit_list(branch_commits[: squash_index + 1]),
+        "unique_commits": _format_commit_list(branch_commits[squash_index + 1 :]),
+    }
+
+
 def _check_via_tree_match(base_ref: str, head: str = "HEAD") -> dict | None:
     """Find a commit on base whose tree equals the tree at some point on the
     branch. That commit is a squash-equivalent of branch commits up to that
@@ -129,66 +177,29 @@ def _check_via_tree_match(base_ref: str, head: str = "HEAD") -> dict | None:
     Strongest of the three detection methods: works offline, through forks
     and renames, and (unlike `_check_via_synthesis`) handles the case where
     the user has committed additional work on top of the squashed commits.
-
-    Returns dict with squash_commit, squashed_commits, unique_commits when
-    a match is found; None otherwise.
     """
     mb = _merge_base(base_ref, head)
     if not mb:
         return None
 
-    branch_log = run_git(
-        ["log", "--reverse", "--format=%H%x09%T%x09%s", f"{mb}..{head}"]
-    )
-    if branch_log.returncode != 0 or not branch_log.stdout.strip():
-        return None
-
-    branch_commits: list[tuple[str, str, str]] = []
-    for line in branch_log.stdout.strip().split("\n"):
-        parts = line.split("\t", 2)
-        if len(parts) == 3:
-            branch_commits.append((parts[0], parts[1], parts[2]))
-
+    branch_commits = _log_with_trees(f"{mb}..{head}", reverse=True)
     if not branch_commits:
         return None
 
-    # Map tree SHA -> latest branch index with that tree. If multiple branch
-    # commits share a tree, prefer the latest so the unique-commit list is
-    # the smallest set that needs replaying.
-    branch_tree_to_index: dict[str, int] = {}
-    for i, (_, tree, _) in enumerate(branch_commits):
-        branch_tree_to_index[tree] = i
+    # Map tree SHA -> latest branch index with that tree. Revert-then-redo
+    # collisions prefer the latest so the unique-commit replay set stays small.
+    branch_tree_to_index = {tree: i for i, (_, tree, _) in enumerate(branch_commits)}
 
     # Cap base log at 500 commits to stay fast on long-running base branches.
-    base_log = run_git(
-        ["log", "-500", "--format=%H%x09%T%x09%s", f"{mb}..{base_ref}"]
-    )
-    if base_log.returncode != 0:
+    base_commits = _log_with_trees(f"{mb}..{base_ref}", limit=500)
+    if base_commits is None:
         return None
 
-    for line in base_log.stdout.strip().split("\n"):
-        parts = line.split("\t", 2)
-        if len(parts) != 3:
-            continue
-        base_sha, base_tree, base_subject = parts
+    for base_sha, base_tree, base_subject in base_commits:
         if base_tree in branch_tree_to_index:
-            idx = branch_tree_to_index[base_tree]
-            squashed = branch_commits[: idx + 1]
-            unique = branch_commits[idx + 1 :]
-            return {
-                "squash_commit": base_sha,
-                "squash_short": base_sha[:8],
-                "squash_subject": base_subject,
-                "squashed_commits": [
-                    {"sha": sha, "short": sha[:8], "subject": subj}
-                    for sha, _, subj in squashed
-                ],
-                "unique_commits": [
-                    {"sha": sha, "short": sha[:8], "subject": subj}
-                    for sha, _, subj in unique
-                ],
-            }
-
+            return _build_tree_match_result(
+                base_sha, base_subject, branch_commits, branch_tree_to_index[base_tree]
+            )
     return None
 
 
@@ -254,60 +265,77 @@ def _resolve_head(branch: str) -> str:
     return "HEAD"
 
 
-def _build_remedies(result: dict, base_ref: str) -> list[dict]:
-    """Build both non-destructive (merge) and destructive (reset+cherry-pick)
-    remedies. Order: non-destructive first so the user sees it as the default.
-    """
-    abort = _in_progress_abort()
-    has_unique = bool(result["unique_commits"])
-    method = result["method"] or ""
-
-    merge_commands: list[str] = []
+def _build_merge_remedy(base_ref: str, abort: str | None) -> dict:
+    commands: list[str] = []
     if abort:
-        merge_commands.append(abort)
-    merge_commands.append(f"git merge {base_ref}")
-    merge_commands.append(
+        commands.append(abort)
+    commands.append(f"git merge {base_ref}")
+    commands.append(
         "# resolve any remaining conflicts with /melt — squashed commits "
         "collapse to no-ops, so only real edits should remain"
     )
+    return {
+        "name": "merge",
+        "destructive": False,
+        "description": (
+            "Merge base into branch. Non-destructive: preserves all "
+            "branch history and refs. Squashed commits collapse to a "
+            "no-op merge, so only real conflicts surface. Prefer this "
+            "when the branch has unique work or you are not sure the "
+            "unique-commit list below is complete."
+        ),
+        "commands": commands,
+    }
 
-    reset_commands: list[str] = []
+
+def _build_reset_remedy(result: dict, base_ref: str, abort: str | None) -> dict:
+    commands: list[str] = []
     if abort:
-        reset_commands.append(abort)
-    reset_commands.append(f"git reset --hard {base_ref}")
-    if has_unique:
+        commands.append(abort)
+    commands.append(f"git reset --hard {base_ref}")
+    if result["unique_commits"]:
         shas = " ".join(c["sha"] for c in result["unique_commits"])
-        reset_commands.append(f"git cherry-pick {shas}")
-    elif method == "local-synth":
-        reset_commands.append("# review and cherry-pick unique commits manually:")
+        commands.append(f"git cherry-pick {shas}")
+    elif result["method"] == "local-synth":
+        commands.append("# review and cherry-pick unique commits manually:")
         for c in result["branch_commits"]:
-            reset_commands.append(f"#   {c['short']} {c['subject']}")
+            commands.append(f"#   {c['short']} {c['subject']}")
+    return {
+        "name": "reset-and-cherry-pick",
+        "destructive": True,
+        "description": (
+            "Reset to base and replay only the unique commits. "
+            "DESTRUCTIVE: rewrites the branch and requires force-push. "
+            "Use when you want a clean linear history and the "
+            "unique-commit list looks complete."
+        ),
+        "commands": commands,
+    }
 
+
+def _build_remedies(result: dict, base_ref: str) -> list[dict]:
+    """Both remedies, non-destructive first so the user sees it as the default."""
+    abort = _in_progress_abort()
     return [
-        {
-            "name": "merge",
-            "destructive": False,
-            "description": (
-                "Merge base into branch. Non-destructive: preserves all "
-                "branch history and refs. Squashed commits collapse to a "
-                "no-op merge, so only real conflicts surface. Prefer this "
-                "when the branch has unique work or you are not sure the "
-                "unique-commit list below is complete."
-            ),
-            "commands": merge_commands,
-        },
-        {
-            "name": "reset-and-cherry-pick",
-            "destructive": True,
-            "description": (
-                "Reset to base and replay only the unique commits. "
-                "DESTRUCTIVE: rewrites the branch and requires force-push. "
-                "Use when you want a clean linear history and the "
-                "unique-commit list looks complete."
-            ),
-            "commands": reset_commands,
-        },
+        _build_merge_remedy(base_ref, abort),
+        _build_reset_remedy(result, base_ref, abort),
     ]
+
+
+def _gh_correlates_with_tree(gh: dict, tree: dict) -> bool:
+    """True iff the gh PR is the same squash that tree-match found.
+
+    Branch names get reused across PRs, so the gh PR currently advertising
+    this branch is not always the one whose squash sits on base. Confirm
+    via merge-commit equality (strongest) or SHA overlap between the PR's
+    source commits and the tree-match squashed set before attaching gh
+    metadata — otherwise we'd point the user at an unrelated PR.
+    """
+    if gh.get("merge_commit") and gh["merge_commit"] == tree["squash_commit"]:
+        return True
+    pr_shas = set(gh.get("pr_commits", []))
+    squashed_shas = {c["sha"] for c in tree.get("squashed_commits", [])}
+    return bool(pr_shas & squashed_shas)
 
 
 def detect(branch: str, base_ref: str) -> dict:
@@ -348,14 +376,14 @@ def detect(branch: str, base_ref: str) -> dict:
 
     if tree:
         result["verdict"] = "squash-merged"
-        result["method"] = "tree-match+gh" if gh else "tree-match"
         result["squash_commit"] = {
             "sha": tree["squash_commit"],
             "short": tree["squash_short"],
             "subject": tree["squash_subject"],
         }
         result["unique_commits"] = tree["unique_commits"]
-        if gh:
+        if gh and _gh_correlates_with_tree(gh, tree):
+            result["method"] = "tree-match+gh"
             result["pr"] = {
                 "number": gh["number"],
                 "url": gh["url"],
@@ -366,6 +394,14 @@ def detect(branch: str, base_ref: str) -> dict:
             if gh["multiple_prs"]:
                 result["warnings"].append(
                     "multiple merged PRs from this branch — using most recent"
+                )
+        else:
+            result["method"] = "tree-match"
+            if gh:
+                result["warnings"].append(
+                    f"gh found PR #{gh['number']} ({gh['url']}) but its "
+                    "commits do not correlate with the tree-match squash — "
+                    "branch name may have been reused; not attaching PR metadata"
                 )
     elif gh:
         squashed = set(gh["pr_commits"])

--- a/skills/melt/scripts/detect-squash-residue.py
+++ b/skills/melt/scripts/detect-squash-residue.py
@@ -356,6 +356,46 @@ def _pr_metadata(gh: dict) -> dict:
     }
 
 
+def _warn_multiple_prs(result: dict, gh: dict) -> None:
+    """Both apply paths surface the same caveat when gh found more than one
+    merged PR — single edit point for the wording."""
+    if gh["multiple_prs"]:
+        result["warnings"].append(
+            "multiple merged PRs from this branch — using most recent"
+        )
+
+
+def _init_result(branch: str, base_ref: str, head_ref: str) -> dict:
+    return {
+        "verdict": "not-detected",
+        "method": None,
+        "branch": branch,
+        "base": base_ref,
+        "head_ref": head_ref,
+        "pr": None,
+        "squash_commit": None,
+        "branch_commits": [],
+        "squashed_shas": [],
+        "unique_commits": [],
+        "remedies": [],
+        "warnings": [],
+    }
+
+
+def _apply_synth_fallback(result: dict, base_ref: str, head_ref: str) -> None:
+    """Last-resort detection when tree-match and gh both came up empty.
+    `git cherry`-based equivalence check — cannot enumerate squashed vs
+    unique commits, so the user has to review the branch list by hand."""
+    synth = _check_via_synthesis(base_ref, head_ref)
+    if synth:
+        result["verdict"] = "squash-merged"
+        result["method"] = "local-synth"
+        result["warnings"].append(
+            "detected via local synthesis; cannot enumerate which commits "
+            "were squashed vs unique — review branch commits manually"
+        )
+
+
 def _apply_tree_match_to_result(result: dict, tree: dict, gh: dict | None) -> None:
     """Populate result with the tree-match verdict, enriched by gh when the
     gh PR correlates with the squash."""
@@ -376,10 +416,7 @@ def _apply_tree_match_to_result(result: dict, tree: dict, gh: dict | None) -> No
                 f"differs from tree-match squash {tree['squash_commit'][:8]} — "
                 "PR commits overlap but the recorded squash may be a different one"
             )
-        if gh["multiple_prs"]:
-            result["warnings"].append(
-                "multiple merged PRs from this branch — using most recent"
-            )
+        _warn_multiple_prs(result, gh)
         return
     result["method"] = "tree-match"
     if gh:
@@ -408,28 +445,12 @@ def _apply_gh_only_to_result(result: dict, gh: dict) -> None:
     result["pr"] = _pr_metadata(gh)
     result["squashed_shas"] = gh["pr_commits"]
     result["unique_commits"] = unique
-    if gh["multiple_prs"]:
-        result["warnings"].append(
-            "multiple merged PRs from this branch — using most recent"
-        )
+    _warn_multiple_prs(result, gh)
 
 
 def detect(branch: str, base_ref: str) -> dict:
     head_ref = _resolve_head(branch)
-    result = {
-        "verdict": "not-detected",
-        "method": None,
-        "branch": branch,
-        "base": base_ref,
-        "head_ref": head_ref,
-        "pr": None,
-        "squash_commit": None,
-        "branch_commits": [],
-        "squashed_shas": [],
-        "unique_commits": [],
-        "remedies": [],
-        "warnings": [],
-    }
+    result = _init_result(branch, base_ref, head_ref)
 
     branch_commits = _commits_since(base_ref, head_ref)
     if branch_commits is None:
@@ -456,14 +477,7 @@ def detect(branch: str, base_ref: str) -> dict:
         _apply_gh_only_to_result(result, gh)
 
     if result["verdict"] == "not-detected":
-        synth = _check_via_synthesis(base_ref, head_ref)
-        if synth:
-            result["verdict"] = "squash-merged"
-            result["method"] = "local-synth"
-            result["warnings"].append(
-                "detected via local synthesis; cannot enumerate which commits "
-                "were squashed vs unique — review branch commits manually"
-            )
+        _apply_synth_fallback(result, base_ref, head_ref)
 
     if result["verdict"] == "squash-merged":
         result["remedies"] = _build_remedies(result, base_ref)

--- a/skills/melt/scripts/detect-squash-residue.py
+++ b/skills/melt/scripts/detect-squash-residue.py
@@ -4,16 +4,24 @@
 When a PR is squash-merged into the base branch, the local branch retains the
 pre-squash commits. Rebasing then re-applies commits whose content is already
 in base, producing useless conflicts that mergiraf cannot resolve — the right
-answer is to abort and re-cherry-pick the commits that postdate the squash.
+answer is to merge base in (non-destructive) or reset and re-cherry-pick the
+unique commits (destructive).
 
-Detection path:
-  1. gh API — `gh pr list --state merged --head <branch>` returns both the
-     verdict (PR exists) and the cherry-pick list (PR commit SHAs).
-  2. Local fallback — synthesize a would-be squash commit via `commit-tree`,
-     then ask `git cherry` whether base already contains an equivalent. Works
-     offline but cannot enumerate which commits were squashed.
+Detection path (most-to-least reliable, all attempted):
+  1. Tree-match — walk recent commits on base looking for one whose tree
+     equals the tree at some point on the branch. That commit is a squash
+     of branch commits up to that point. Works offline, through fork PRs,
+     and when the branch has additional commits past the squash (the case
+     `local-synth` misses).
+  2. gh API — `gh pr list --state merged --head <branch>` provides PR
+     metadata (number, URL) and an independent SHA-overlap signal.
+  3. Local synthesis — synthesize a would-be squash commit from HEAD's
+     tree and ask `git cherry` whether base contains an equivalent. Last
+     resort; cannot enumerate squashed vs unique commits, and misses the
+     case where the branch has commits past the squash.
 
-No auto-fix. Prints the remedy as a copy-paste block; the user runs it.
+No auto-fix. Prints two remedies (merge first, then reset+cherry-pick) as
+copy-paste blocks; the user picks and runs.
 """
 
 from __future__ import annotations
@@ -113,6 +121,77 @@ def _check_via_gh(branch: str, base_ref: str) -> dict | None:
     }
 
 
+def _check_via_tree_match(base_ref: str, head: str = "HEAD") -> dict | None:
+    """Find a commit on base whose tree equals the tree at some point on the
+    branch. That commit is a squash-equivalent of branch commits up to that
+    point — the canonical signature of a squash-merge.
+
+    Strongest of the three detection methods: works offline, through forks
+    and renames, and (unlike `_check_via_synthesis`) handles the case where
+    the user has committed additional work on top of the squashed commits.
+
+    Returns dict with squash_commit, squashed_commits, unique_commits when
+    a match is found; None otherwise.
+    """
+    mb = _merge_base(base_ref, head)
+    if not mb:
+        return None
+
+    branch_log = run_git(
+        ["log", "--reverse", "--format=%H%x09%T%x09%s", f"{mb}..{head}"]
+    )
+    if branch_log.returncode != 0 or not branch_log.stdout.strip():
+        return None
+
+    branch_commits: list[tuple[str, str, str]] = []
+    for line in branch_log.stdout.strip().split("\n"):
+        parts = line.split("\t", 2)
+        if len(parts) == 3:
+            branch_commits.append((parts[0], parts[1], parts[2]))
+
+    if not branch_commits:
+        return None
+
+    # Map tree SHA -> latest branch index with that tree. If multiple branch
+    # commits share a tree, prefer the latest so the unique-commit list is
+    # the smallest set that needs replaying.
+    branch_tree_to_index: dict[str, int] = {}
+    for i, (_, tree, _) in enumerate(branch_commits):
+        branch_tree_to_index[tree] = i
+
+    # Cap base log at 500 commits to stay fast on long-running base branches.
+    base_log = run_git(
+        ["log", "-500", "--format=%H%x09%T%x09%s", f"{mb}..{base_ref}"]
+    )
+    if base_log.returncode != 0:
+        return None
+
+    for line in base_log.stdout.strip().split("\n"):
+        parts = line.split("\t", 2)
+        if len(parts) != 3:
+            continue
+        base_sha, base_tree, base_subject = parts
+        if base_tree in branch_tree_to_index:
+            idx = branch_tree_to_index[base_tree]
+            squashed = branch_commits[: idx + 1]
+            unique = branch_commits[idx + 1 :]
+            return {
+                "squash_commit": base_sha,
+                "squash_short": base_sha[:8],
+                "squash_subject": base_subject,
+                "squashed_commits": [
+                    {"sha": sha, "short": sha[:8], "subject": subj}
+                    for sha, _, subj in squashed
+                ],
+                "unique_commits": [
+                    {"sha": sha, "short": sha[:8], "subject": subj}
+                    for sha, _, subj in unique
+                ],
+            }
+
+    return None
+
+
 def _check_via_synthesis(base_ref: str, head: str = "HEAD") -> bool | None:
     """Build a would-be squash commit from head's tree, then ask `git cherry`
     whether base_ref already contains an equivalent. Returns True if yes.
@@ -175,6 +254,62 @@ def _resolve_head(branch: str) -> str:
     return "HEAD"
 
 
+def _build_remedies(result: dict, base_ref: str) -> list[dict]:
+    """Build both non-destructive (merge) and destructive (reset+cherry-pick)
+    remedies. Order: non-destructive first so the user sees it as the default.
+    """
+    abort = _in_progress_abort()
+    has_unique = bool(result["unique_commits"])
+    method = result["method"] or ""
+
+    merge_commands: list[str] = []
+    if abort:
+        merge_commands.append(abort)
+    merge_commands.append(f"git merge {base_ref}")
+    merge_commands.append(
+        "# resolve any remaining conflicts with /melt — squashed commits "
+        "collapse to no-ops, so only real edits should remain"
+    )
+
+    reset_commands: list[str] = []
+    if abort:
+        reset_commands.append(abort)
+    reset_commands.append(f"git reset --hard {base_ref}")
+    if has_unique:
+        shas = " ".join(c["sha"] for c in result["unique_commits"])
+        reset_commands.append(f"git cherry-pick {shas}")
+    elif method == "local-synth":
+        reset_commands.append("# review and cherry-pick unique commits manually:")
+        for c in result["branch_commits"]:
+            reset_commands.append(f"#   {c['short']} {c['subject']}")
+
+    return [
+        {
+            "name": "merge",
+            "destructive": False,
+            "description": (
+                "Merge base into branch. Non-destructive: preserves all "
+                "branch history and refs. Squashed commits collapse to a "
+                "no-op merge, so only real conflicts surface. Prefer this "
+                "when the branch has unique work or you are not sure the "
+                "unique-commit list below is complete."
+            ),
+            "commands": merge_commands,
+        },
+        {
+            "name": "reset-and-cherry-pick",
+            "destructive": True,
+            "description": (
+                "Reset to base and replay only the unique commits. "
+                "DESTRUCTIVE: rewrites the branch and requires force-push. "
+                "Use when you want a clean linear history and the "
+                "unique-commit list looks complete."
+            ),
+            "commands": reset_commands,
+        },
+    ]
+
+
 def detect(branch: str, base_ref: str) -> dict:
     head_ref = _resolve_head(branch)
     result = {
@@ -184,10 +319,11 @@ def detect(branch: str, base_ref: str) -> dict:
         "base": base_ref,
         "head_ref": head_ref,
         "pr": None,
+        "squash_commit": None,
         "branch_commits": [],
         "squashed_shas": [],
         "unique_commits": [],
-        "remedy": [],
+        "remedies": [],
         "warnings": [],
     }
 
@@ -203,19 +339,46 @@ def detect(branch: str, base_ref: str) -> dict:
         result["warnings"].append(f"no commits between {base_ref} and {head_ref}")
         return result
 
+    # Run tree-match first — strongest signal, works offline, and unlike
+    # gh-api or local-synth it handles the case where the branch has commits
+    # past the squash (the textbook squash-residue shape this script kept
+    # missing). gh-api still runs to enrich the result with PR metadata.
+    tree = _check_via_tree_match(base_ref, head_ref)
     gh = _check_via_gh(branch, base_ref)
-    if gh:
+
+    if tree:
+        result["verdict"] = "squash-merged"
+        result["method"] = "tree-match+gh" if gh else "tree-match"
+        result["squash_commit"] = {
+            "sha": tree["squash_commit"],
+            "short": tree["squash_short"],
+            "subject": tree["squash_subject"],
+        }
+        result["unique_commits"] = tree["unique_commits"]
+        if gh:
+            result["pr"] = {
+                "number": gh["number"],
+                "url": gh["url"],
+                "merged_at": gh["merged_at"],
+                "merge_commit": gh["merge_commit"],
+            }
+            result["squashed_shas"] = gh["pr_commits"]
+            if gh["multiple_prs"]:
+                result["warnings"].append(
+                    "multiple merged PRs from this branch — using most recent"
+                )
+    elif gh:
         squashed = set(gh["pr_commits"])
         unique = [c for c in result["branch_commits"] if c["sha"] not in squashed]
         matched = len(result["branch_commits"]) - len(unique)
         if matched == 0:
-            # PR name matched but zero SHAs overlap — too weak to trust as
-            # squash residue. Could be a reused branch name or a fully
-            # rebased branch. Fall through to local-synth (tree equivalence)
-            # for a stronger signal.
+            # PR name matched but zero SHAs overlap, and tree-match found
+            # nothing either. Could be a reused branch name or a fully
+            # rebased branch. Too weak to call squash-residue.
             result["warnings"].append(
-                f"gh found PR #{gh['number']} ({gh['url']}) for this branch but "
-                "no local commits matched its SHAs — treating as inconclusive"
+                f"gh found PR #{gh['number']} ({gh['url']}) but no local "
+                "commits matched its SHAs and tree-match found no equivalent "
+                "commit on base — treating as inconclusive"
             )
         else:
             result["verdict"] = "squash-merged"
@@ -244,21 +407,7 @@ def detect(branch: str, base_ref: str) -> dict:
             )
 
     if result["verdict"] == "squash-merged":
-        remedy = []
-        abort = _in_progress_abort()
-        if abort:
-            remedy.append(abort)
-        remedy.append(f"git reset --hard {base_ref}")
-        if result["unique_commits"]:
-            shas = " ".join(c["sha"] for c in result["unique_commits"])
-            remedy.append(f"git cherry-pick {shas}")
-        elif result["method"] == "local-synth":
-            # No PR data available — list branch commits so the user has a
-            # recovery path before running `reset --hard`.
-            remedy.append("# review and cherry-pick unique commits manually:")
-            for c in result["branch_commits"]:
-                remedy.append(f"#   {c['short']} {c['subject']}")
-        result["remedy"] = remedy
+        result["remedies"] = _build_remedies(result, base_ref)
 
     return result
 
@@ -272,14 +421,16 @@ def format_terse(d: dict) -> str:
 
     lines = []
     pr = d["pr"]
+    sc = d.get("squash_commit")
+    header = f"verdict: SQUASH-MERGED method={d['method']}"
     if pr:
-        lines.append(
-            f"verdict: SQUASH-MERGED via PR #{pr['number']} "
-            f"merged={pr['merged_at']} method={d['method']}"
-        )
-        lines.append(f"  url: {pr['url']}")
-    else:
-        lines.append(f"verdict: SQUASH-MERGED method={d['method']}")
+        header += f" PR=#{pr['number']}"
+    lines.append(header)
+    if pr:
+        lines.append(f"  pr-url: {pr['url']}")
+        lines.append(f"  merged-at: {pr['merged_at']}")
+    if sc:
+        lines.append(f"  squash-commit: {sc['short']} {sc['subject']}")
 
     for w in d["warnings"]:
         lines.append(f"warn: {w}")
@@ -292,10 +443,19 @@ def format_terse(d: dict) -> str:
         lines.append(f"branch commits ({len(d['branch_commits'])}):")
         for c in d["branch_commits"]:
             lines.append(f"  {c['short']} {c['subject']}")
+    else:
+        lines.append("unique commits: 0 (branch is fully contained in base)")
 
-    lines.append("remedy (copy-paste — destructive, review first):")
-    for r in d["remedy"]:
-        lines.append(f"  {r}")
+    lines.append("")
+    lines.append("remedies — pick one, copy-paste, review before running:")
+    for i, r in enumerate(d.get("remedies", [])):
+        label = chr(ord("A") + i)
+        marker = "DESTRUCTIVE" if r["destructive"] else "non-destructive"
+        lines.append("")
+        lines.append(f"  [{label}] {r['name']} ({marker})")
+        lines.append(f"      {r['description']}")
+        for cmd in r["commands"]:
+            lines.append(f"      {cmd}")
     return "\n".join(lines)
 
 

--- a/skills/melt/scripts/detect-squash-residue.py
+++ b/skills/melt/scripts/detect-squash-residue.py
@@ -338,6 +338,82 @@ def _gh_correlates_with_tree(gh: dict, tree: dict) -> bool:
     return bool(pr_shas & squashed_shas)
 
 
+def _gh_merge_commit_disagrees(gh: dict, tree: dict) -> bool:
+    """True iff gh recorded a merge_commit that differs from the tree-match
+    squash commit. Soft signal — correlation may still hold via SHA overlap,
+    but the recorded merge points elsewhere, so warn the user.
+    """
+    mc = gh.get("merge_commit")
+    return bool(mc and mc != tree["squash_commit"])
+
+
+def _pr_metadata(gh: dict) -> dict:
+    return {
+        "number": gh["number"],
+        "url": gh["url"],
+        "merged_at": gh["merged_at"],
+        "merge_commit": gh["merge_commit"],
+    }
+
+
+def _apply_tree_match_to_result(result: dict, tree: dict, gh: dict | None) -> None:
+    """Populate result with the tree-match verdict, enriched by gh when the
+    gh PR correlates with the squash."""
+    result["verdict"] = "squash-merged"
+    result["squash_commit"] = {
+        "sha": tree["squash_commit"],
+        "short": tree["squash_short"],
+        "subject": tree["squash_subject"],
+    }
+    result["unique_commits"] = tree["unique_commits"]
+    if gh and _gh_correlates_with_tree(gh, tree):
+        result["method"] = "tree-match+gh"
+        result["pr"] = _pr_metadata(gh)
+        result["squashed_shas"] = gh["pr_commits"]
+        if _gh_merge_commit_disagrees(gh, tree):
+            result["warnings"].append(
+                f"gh PR #{gh['number']} merge-commit {gh['merge_commit'][:8]} "
+                f"differs from tree-match squash {tree['squash_commit'][:8]} — "
+                "PR commits overlap but the recorded squash may be a different one"
+            )
+        if gh["multiple_prs"]:
+            result["warnings"].append(
+                "multiple merged PRs from this branch — using most recent"
+            )
+        return
+    result["method"] = "tree-match"
+    if gh:
+        result["warnings"].append(
+            f"gh found PR #{gh['number']} ({gh['url']}) but its "
+            "commits do not correlate with the tree-match squash — "
+            "branch name may have been reused; not attaching PR metadata"
+        )
+
+
+def _apply_gh_only_to_result(result: dict, gh: dict) -> None:
+    """Populate result from gh alone when tree-match found nothing. Treat
+    zero SHA overlap as inconclusive (reused branch name or full rebase)."""
+    squashed = set(gh["pr_commits"])
+    unique = [c for c in result["branch_commits"] if c["sha"] not in squashed]
+    matched = len(result["branch_commits"]) - len(unique)
+    if matched == 0:
+        result["warnings"].append(
+            f"gh found PR #{gh['number']} ({gh['url']}) but no local "
+            "commits matched its SHAs and tree-match found no equivalent "
+            "commit on base — treating as inconclusive"
+        )
+        return
+    result["verdict"] = "squash-merged"
+    result["method"] = "gh-api"
+    result["pr"] = _pr_metadata(gh)
+    result["squashed_shas"] = gh["pr_commits"]
+    result["unique_commits"] = unique
+    if gh["multiple_prs"]:
+        result["warnings"].append(
+            "multiple merged PRs from this branch — using most recent"
+        )
+
+
 def detect(branch: str, base_ref: str) -> dict:
     head_ref = _resolve_head(branch)
     result = {
@@ -369,68 +445,15 @@ def detect(branch: str, base_ref: str) -> dict:
 
     # Run tree-match first — strongest signal, works offline, and unlike
     # gh-api or local-synth it handles the case where the branch has commits
-    # past the squash (the textbook squash-residue shape this script kept
-    # missing). gh-api still runs to enrich the result with PR metadata.
+    # past the squash. gh runs in parallel to enrich tree-match or to
+    # supply the verdict on its own.
     tree = _check_via_tree_match(base_ref, head_ref)
     gh = _check_via_gh(branch, base_ref)
 
     if tree:
-        result["verdict"] = "squash-merged"
-        result["squash_commit"] = {
-            "sha": tree["squash_commit"],
-            "short": tree["squash_short"],
-            "subject": tree["squash_subject"],
-        }
-        result["unique_commits"] = tree["unique_commits"]
-        if gh and _gh_correlates_with_tree(gh, tree):
-            result["method"] = "tree-match+gh"
-            result["pr"] = {
-                "number": gh["number"],
-                "url": gh["url"],
-                "merged_at": gh["merged_at"],
-                "merge_commit": gh["merge_commit"],
-            }
-            result["squashed_shas"] = gh["pr_commits"]
-            if gh["multiple_prs"]:
-                result["warnings"].append(
-                    "multiple merged PRs from this branch — using most recent"
-                )
-        else:
-            result["method"] = "tree-match"
-            if gh:
-                result["warnings"].append(
-                    f"gh found PR #{gh['number']} ({gh['url']}) but its "
-                    "commits do not correlate with the tree-match squash — "
-                    "branch name may have been reused; not attaching PR metadata"
-                )
+        _apply_tree_match_to_result(result, tree, gh)
     elif gh:
-        squashed = set(gh["pr_commits"])
-        unique = [c for c in result["branch_commits"] if c["sha"] not in squashed]
-        matched = len(result["branch_commits"]) - len(unique)
-        if matched == 0:
-            # PR name matched but zero SHAs overlap, and tree-match found
-            # nothing either. Could be a reused branch name or a fully
-            # rebased branch. Too weak to call squash-residue.
-            result["warnings"].append(
-                f"gh found PR #{gh['number']} ({gh['url']}) but no local "
-                "commits matched its SHAs and tree-match found no equivalent "
-                "commit on base — treating as inconclusive"
-            )
-        else:
-            result["verdict"] = "squash-merged"
-            result["method"] = "gh-api"
-            result["pr"] = {
-                "number": gh["number"],
-                "url": gh["url"],
-                "merged_at": gh["merged_at"],
-                "merge_commit": gh["merge_commit"],
-            }
-            result["squashed_shas"] = gh["pr_commits"]
-            result["unique_commits"] = unique
-            if gh["multiple_prs"]:
-                result["warnings"].append(
-                    "multiple merged PRs from this branch — using most recent"
-                )
+        _apply_gh_only_to_result(result, gh)
 
     if result["verdict"] == "not-detected":
         synth = _check_via_synthesis(base_ref, head_ref)

--- a/tests/python/test_detect_squash_residue.py
+++ b/tests/python/test_detect_squash_residue.py
@@ -39,11 +39,17 @@ def _commits(*subjects: str) -> list[dict]:
     ]
 
 
-def _gh_payload(*, number: int, commit_oids: list[str], merged_at: str) -> dict:
+def _gh_payload(
+    *,
+    number: int,
+    commit_oids: list[str],
+    merged_at: str,
+    merge_commit: str | None = None,
+) -> dict:
     return {
         "number": number,
         "url": f"https://example.com/pr/{number}",
-        "merge_commit": "f" * 40,
+        "merge_commit": merge_commit,
         "merged_at": merged_at,
         "pr_commits": commit_oids,
         "multiple_prs": False,
@@ -1008,8 +1014,8 @@ class TestDetectViaTreeMatch:
             number=77,
             commit_oids=["a" * 40, "b" * 40],  # diverged source SHAs
             merged_at="2026-05-15T12:00:00Z",
+            merge_commit="s" * 40,  # merge commit equals the squash
         )
-        gh["merge_commit"] = "s" * 40  # but the merge commit equals the squash
         with (
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=commits),
@@ -1022,6 +1028,49 @@ class TestDetectViaTreeMatch:
         assert result["method"] == "tree-match+gh"
         assert result["pr"]["number"] == 77
         assert not any("do not correlate" in w for w in result["warnings"])
+        assert not any("differs from tree-match squash" in w for w in result["warnings"])
+
+    def test_tree_match_warns_when_gh_merge_commit_disagrees_but_shas_overlap(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # Soft-signal case: gh PR's source SHAs overlap the squashed set so
+        # correlation passes and metadata attaches — but gh's recorded
+        # merge_commit points somewhere else, suggesting the PR currently
+        # advertised on this branch may not be the one whose squash sits on
+        # base. User gets a warning even though enrichment proceeds.
+        commits = _commits("a", "b")
+        tree_hit = {
+            "squash_commit": "s" * 40,
+            "squash_short": "s" * 8,
+            "squash_subject": "Squashed",
+            "squashed_commits": commits,
+            "unique_commits": [],
+        }
+        gh = _gh_payload(
+            number=55,
+            commit_oids=[c["sha"] for c in commits],  # SHA overlap → correlate True
+            merged_at="2026-05-15T12:00:00Z",
+            merge_commit="m" * 40,  # but the recorded merge differs from the squash
+        )
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=tree_hit),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["method"] == "tree-match+gh"
+        assert result["pr"]["number"] == 55
+        # Disagreement warning fires, citing both short SHAs.
+        assert any(
+            "PR #55" in w
+            and "differs from tree-match squash" in w
+            and "mmmmmmmm" in w
+            and "ssssssss" in w
+            for w in result["warnings"]
+        )
 
     def test_tree_match_skips_local_synth(
         self, detect_squash_residue: ModuleType
@@ -1054,6 +1103,106 @@ class TestDetectViaTreeMatch:
         assert result["verdict"] == "squash-merged"
         assert result["method"] == "tree-match"
         assert synth_calls == []
+
+
+class TestGhCorrelatesWithTree:
+    """Direct unit tests for the gate that decides whether a gh PR is the
+    same squash that tree-match found. Branch names get reused — this gate
+    is what prevents an unrelated PR's metadata from being attached to a
+    tree-match result."""
+
+    def test_returns_true_when_merge_commit_equals_squash_commit(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # Strongest signal: gh's recorded merge commit IS the tree-match
+        # squash. Even with no overlapping SHAs (rebased PR), this is
+        # provably the same merge.
+        gh = {"merge_commit": "s" * 40, "pr_commits": ["x" * 40]}
+        tree = {"squash_commit": "s" * 40, "squashed_commits": [{"sha": "y" * 40}]}
+        assert detect_squash_residue._gh_correlates_with_tree(gh, tree) is True
+
+    def test_returns_true_on_pr_sha_overlap_even_when_merge_commit_differs(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # Fallback signal: merge commits diverge but at least one PR source
+        # commit appears in the squashed set. Real-world case: gh recorded a
+        # different merge for some reason but the same source commits.
+        gh = {"merge_commit": "m" * 40, "pr_commits": ["a" * 40, "b" * 40]}
+        tree = {
+            "squash_commit": "s" * 40,
+            "squashed_commits": [{"sha": "b" * 40}, {"sha": "c" * 40}],
+        }
+        assert detect_squash_residue._gh_correlates_with_tree(gh, tree) is True
+
+    def test_returns_false_when_neither_merge_commit_nor_shas_match(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # Both signals fail → no correlation. The gate's whole reason for
+        # being: do not let an unrelated PR get attached.
+        gh = {"merge_commit": "m" * 40, "pr_commits": ["a" * 40, "b" * 40]}
+        tree = {
+            "squash_commit": "s" * 40,
+            "squashed_commits": [{"sha": "c" * 40}, {"sha": "d" * 40}],
+        }
+        assert detect_squash_residue._gh_correlates_with_tree(gh, tree) is False
+
+    def test_returns_false_when_merge_commit_missing_and_no_sha_overlap(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # gh did not record a merge commit (None) and SHAs don't overlap.
+        # The strong check must short-circuit on falsy merge_commit, not
+        # raise from comparing None to a string.
+        gh = {"merge_commit": None, "pr_commits": ["a" * 40]}
+        tree = {"squash_commit": "s" * 40, "squashed_commits": [{"sha": "b" * 40}]}
+        assert detect_squash_residue._gh_correlates_with_tree(gh, tree) is False
+
+    def test_returns_false_when_pr_commits_field_missing(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # Defensive: empty / missing pr_commits must not crash the set
+        # intersection. Returning False is the safer default.
+        gh = {"merge_commit": None}
+        tree = {"squash_commit": "s" * 40, "squashed_commits": [{"sha": "b" * 40}]}
+        assert detect_squash_residue._gh_correlates_with_tree(gh, tree) is False
+
+
+class TestGhMergeCommitDisagrees:
+    """Soft-signal helper: PR commits correlate via SHA overlap so we still
+    attach metadata, but the recorded merge commit disagrees with the
+    tree-match squash. Used to warn the user that the linked PR may not be
+    the one whose squash sits on base."""
+
+    def test_returns_true_when_merge_commit_differs_from_squash(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        gh = {"merge_commit": "m" * 40}
+        tree = {"squash_commit": "s" * 40}
+        assert detect_squash_residue._gh_merge_commit_disagrees(gh, tree) is True
+
+    def test_returns_false_when_merge_commit_equals_squash(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # No disagreement when they're the same SHA — that's the strongest
+        # correlation, not a warning case.
+        gh = {"merge_commit": "s" * 40}
+        tree = {"squash_commit": "s" * 40}
+        assert detect_squash_residue._gh_merge_commit_disagrees(gh, tree) is False
+
+    def test_returns_false_when_merge_commit_missing(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # No recorded merge commit → nothing to disagree with → no warning.
+        gh = {"merge_commit": None}
+        tree = {"squash_commit": "s" * 40}
+        assert detect_squash_residue._gh_merge_commit_disagrees(gh, tree) is False
+
+    def test_returns_false_when_merge_commit_field_absent(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # Defensive: dict without the key at all behaves like None.
+        gh: dict = {}
+        tree = {"squash_commit": "s" * 40}
+        assert detect_squash_residue._gh_merge_commit_disagrees(gh, tree) is False
 
 
 class TestBuildRemedies:

--- a/tests/python/test_detect_squash_residue.py
+++ b/tests/python/test_detect_squash_residue.py
@@ -1,13 +1,17 @@
 """Tests for detect-squash-residue.
 
 Covers detect() across all paths:
+- Tree-match positive: branch commit's tree found on base → strongest signal.
+- Tree-match + gh: PR metadata enriches tree-match result.
+- Tree-match negative + gh positive: falls back to SHA-overlap detection.
 - gh-api positive: PR found, SHAs match → unique commits computed, no warning.
 - gh-api positive: PR found, SHAs diverged → warning about manual review.
 - gh-api positive: multiple PRs → most recent wins, warning emitted.
-- Local-synthesis fallback when gh returns None.
-- Negative path: neither detector fires.
-- In-progress operation detection → correct abort command in remedy.
+- Local-synthesis fallback when tree-match and gh both return nothing.
+- Negative path: no detector fires.
+- In-progress operation detection → correct abort command in both remedies.
 - Empty branch (no commits ahead of base) → not-detected with warning.
+- Dual remedy structure: merge (non-destructive) listed first, then reset+cherry-pick.
 """
 
 from __future__ import annotations
@@ -46,6 +50,14 @@ def _gh_payload(*, number: int, commit_oids: list[str], merged_at: str) -> dict:
     }
 
 
+def _remedy(remedies: list[dict], name: str) -> dict:
+    """Look up a remedy by name. Fails the test if missing."""
+    for r in remedies:
+        if r["name"] == name:
+            return r
+    raise AssertionError(f"remedy {name!r} missing; got {[r['name'] for r in remedies]}")
+
+
 class TestDetectViaGhApi:
     def test_pr_found_shas_match_yields_no_unique_commits(
         self, detect_squash_residue: ModuleType
@@ -59,6 +71,7 @@ class TestDetectViaGhApi:
         with (
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=None),
             patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
             patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
         ):
@@ -69,7 +82,14 @@ class TestDetectViaGhApi:
         assert result["pr"]["number"] == 42
         assert result["unique_commits"] == []
         assert not any("verify the cherry-pick list" in w for w in result["warnings"])
-        assert result["remedy"] == ["git reset --hard origin/main"]
+        merge = _remedy(result["remedies"], "merge")
+        assert merge["destructive"] is False
+        assert "git merge origin/main" in merge["commands"]
+        reset = _remedy(result["remedies"], "reset-and-cherry-pick")
+        assert reset["destructive"] is True
+        # No follow-ups → reset is just `reset --hard`, no cherry-pick line.
+        assert "git reset --hard origin/main" in reset["commands"]
+        assert not any("cherry-pick" in c for c in reset["commands"])
 
     def test_pr_found_with_unique_followups_lists_cherry_picks(
         self, detect_squash_residue: ModuleType
@@ -89,6 +109,7 @@ class TestDetectViaGhApi:
         with (
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=all_commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=None),
             patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
             patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
         ):
@@ -97,9 +118,12 @@ class TestDetectViaGhApi:
         assert result["verdict"] == "squash-merged"
         unique_subjects = [c["subject"] for c in result["unique_commits"]]
         assert unique_subjects == ["post-merge-fix", "another-post-merge"]
-        cherry_pick_line = next((r for r in result["remedy"] if "cherry-pick" in r), None)
+        reset = _remedy(result["remedies"], "reset-and-cherry-pick")
+        cherry_pick_line = next((c for c in reset["commands"] if "cherry-pick" in c), None)
         assert cherry_pick_line is not None
         assert all(c["sha"] in cherry_pick_line for c in followups)
+        # Merge remedy is still offered as the non-destructive first choice.
+        assert result["remedies"][0]["name"] == "merge"
 
     def test_zero_sha_overlap_downgrades_to_not_detected_when_synth_negative(
         self, detect_squash_residue: ModuleType
@@ -116,6 +140,7 @@ class TestDetectViaGhApi:
         with (
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=local_commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=None),
             patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
             patch.object(detect_squash_residue, "_check_via_synthesis", return_value=False),
             patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
@@ -125,7 +150,7 @@ class TestDetectViaGhApi:
         assert result["verdict"] == "not-detected"
         assert result["method"] is None
         assert result["pr"] is None
-        assert result["remedy"] == []
+        assert result["remedies"] == []
         assert any("no local commits matched its SHAs" in w for w in result["warnings"])
         assert any("inconclusive" in w for w in result["warnings"])
 
@@ -143,6 +168,7 @@ class TestDetectViaGhApi:
         with (
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=local_commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=None),
             patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
             patch.object(detect_squash_residue, "_check_via_synthesis", return_value=True),
             patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
@@ -153,21 +179,25 @@ class TestDetectViaGhApi:
         assert result["method"] == "local-synth"
         assert result["pr"] is None  # gh-api result was discarded
         assert any("no local commits matched its SHAs" in w for w in result["warnings"])
-        # Manual review block emitted since local-synth has no SHA list.
-        assert any(r.startswith("# review") for r in result["remedy"])
+        # Manual review block emitted in the destructive remedy since
+        # local-synth has no SHA list.
+        reset = _remedy(result["remedies"], "reset-and-cherry-pick")
+        assert any(c.startswith("# review") for c in reset["commands"])
 
 
 class TestRemedyCompleteness:
-    """The remedy must give the user a recovery path: a cherry-pick line when
-    follow-up commits exist, and nothing extra when all branch commits were
-    squashed (no follow-ups to recover)."""
+    """Every squash-merged verdict must offer both options: a non-destructive
+    merge and a destructive reset+cherry-pick. The destructive option must
+    give the user a recovery path (cherry-pick line when follow-ups exist,
+    manual-review block when local-synth, no extras when fully contained)."""
 
     def test_force_pushed_branch_recovery_via_local_synth(
         self, detect_squash_residue: ModuleType
     ) -> None:
-        # SHAs diverged from PR (post-merge rebase). gh-api downgrades to
-        # inconclusive; local-synth confirms via tree equivalence and the
-        # remedy is the manual-review block listing all local commits.
+        # SHAs diverged from PR (post-merge rebase). Tree-match misses,
+        # gh-api downgrades to inconclusive, local-synth confirms via tree
+        # equivalence. The destructive remedy must include the manual-review
+        # block listing all local commits.
         local = _commits("rebased-local-1", "rebased-local-2")
         gh = _gh_payload(
             number=1,
@@ -177,6 +207,7 @@ class TestRemedyCompleteness:
         with (
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=local),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=None),
             patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
             patch.object(detect_squash_residue, "_check_via_synthesis", return_value=True),
             patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
@@ -184,16 +215,19 @@ class TestRemedyCompleteness:
             result = detect_squash_residue.detect("feature", "origin/main")
 
         assert result["method"] == "local-synth"
-        assert any(r.startswith("# review") for r in result["remedy"])
+        reset = _remedy(result["remedies"], "reset-and-cherry-pick")
+        review_lines = [c for c in reset["commands"] if c.startswith("#   ")]
+        assert review_lines, "manual-review block missing"
         # Every branch commit appears in the manual-review block.
-        review_lines = [r for r in result["remedy"] if r.startswith("#   ")]
         assert all(any(c["short"] in line for line in review_lines) for c in local)
+        # The non-destructive option is still offered.
+        assert _remedy(result["remedies"], "merge")["destructive"] is False
 
-    def test_full_sha_match_remedy_is_reset_only(
+    def test_full_sha_match_destructive_path_is_reset_only(
         self, detect_squash_residue: ModuleType
     ) -> None:
-        # All local commits matched PR commits → no follow-ups → `reset --hard`
-        # is the complete remedy. No cherry-pick, no manual review block.
+        # All local commits matched PR commits → no follow-ups → the destructive
+        # remedy is just `reset --hard`. No cherry-pick, no manual review block.
         commits = _commits("squashed-a", "squashed-b")
         gh = _gh_payload(
             number=2,
@@ -203,12 +237,37 @@ class TestRemedyCompleteness:
         with (
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=None),
             patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
             patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
         ):
             result = detect_squash_residue.detect("feature", "origin/main")
 
-        assert result["remedy"] == ["git reset --hard origin/main"]
+        reset = _remedy(result["remedies"], "reset-and-cherry-pick")
+        assert reset["commands"] == ["git reset --hard origin/main"]
+
+    def test_remedies_listed_in_safety_order(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # The non-destructive merge remedy must always come first so the user
+        # sees the safer option before the destructive one.
+        commits = _commits("a")
+        gh = _gh_payload(
+            number=3,
+            commit_oids=[c["sha"] for c in commits],
+            merged_at="2026-05-15T12:00:00Z",
+        )
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=None),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert [r["name"] for r in result["remedies"]] == ["merge", "reset-and-cherry-pick"]
+        assert [r["destructive"] for r in result["remedies"]] == [False, True]
 
     def test_multiple_prs_warns_and_uses_most_recent(
         self, detect_squash_residue: ModuleType
@@ -223,6 +282,7 @@ class TestRemedyCompleteness:
         with (
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=None),
             patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
             patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
         ):
@@ -232,13 +292,14 @@ class TestRemedyCompleteness:
 
 
 class TestDetectViaLocalSynthesis:
-    def test_synth_positive_when_gh_returns_none(
+    def test_synth_positive_when_tree_and_gh_return_none(
         self, detect_squash_residue: ModuleType
     ) -> None:
         commits = _commits("a", "b")
         with (
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=None),
             patch.object(detect_squash_residue, "_check_via_gh", return_value=None),
             patch.object(detect_squash_residue, "_check_via_synthesis", return_value=True),
             patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
@@ -249,9 +310,12 @@ class TestDetectViaLocalSynthesis:
         assert result["method"] == "local-synth"
         assert result["unique_commits"] == []
         assert any("review branch commits manually" in w for w in result["warnings"])
-        # Remedy must include the manual-review comment block.
-        assert any(r.startswith("# review") for r in result["remedy"])
-        assert any(c["short"] in r for c in commits for r in result["remedy"] if r.startswith("#"))
+        # Destructive remedy must include the manual-review comment block
+        # listing all branch commits (no SHA enumeration available).
+        reset = _remedy(result["remedies"], "reset-and-cherry-pick")
+        assert any(c.startswith("# review") for c in reset["commands"])
+        for commit in commits:
+            assert any(commit["short"] in c for c in reset["commands"] if c.startswith("#"))
 
     def test_synth_negative_yields_not_detected(
         self, detect_squash_residue: ModuleType
@@ -260,13 +324,14 @@ class TestDetectViaLocalSynthesis:
         with (
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=None),
             patch.object(detect_squash_residue, "_check_via_gh", return_value=None),
             patch.object(detect_squash_residue, "_check_via_synthesis", return_value=False),
         ):
             result = detect_squash_residue.detect("feature", "origin/main")
 
         assert result["verdict"] == "not-detected"
-        assert result["remedy"] == []
+        assert result["remedies"] == []
 
 
 class TestCommitsSince:
@@ -347,7 +412,7 @@ class TestEdgeCases:
         assert result["verdict"] == "not-detected"
         assert any("no commits between" in w for w in result["warnings"])
 
-    def test_in_progress_rebase_prepends_abort(
+    def test_in_progress_rebase_prepends_abort_to_both_remedies(
         self, detect_squash_residue: ModuleType
     ) -> None:
         commits = _commits("a")
@@ -357,6 +422,7 @@ class TestEdgeCases:
         with (
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=None),
             patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
             patch.object(
                 detect_squash_residue, "_in_progress_abort", return_value="git rebase --abort"
@@ -364,8 +430,12 @@ class TestEdgeCases:
         ):
             result = detect_squash_residue.detect("feature", "origin/main")
 
-        assert result["remedy"][0] == "git rebase --abort"
-        assert result["remedy"][1] == "git reset --hard origin/main"
+        merge = _remedy(result["remedies"], "merge")
+        assert merge["commands"][0] == "git rebase --abort"
+        assert "git merge origin/main" in merge["commands"]
+        reset = _remedy(result["remedies"], "reset-and-cherry-pick")
+        assert reset["commands"][0] == "git rebase --abort"
+        assert reset["commands"][1] == "git reset --hard origin/main"
 
     def test_in_progress_cherry_pick_prepends_correct_abort(
         self, detect_squash_residue: ModuleType
@@ -377,6 +447,7 @@ class TestEdgeCases:
         with (
             patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
             patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=None),
             patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
             patch.object(
                 detect_squash_residue,
@@ -386,7 +457,8 @@ class TestEdgeCases:
         ):
             result = detect_squash_residue.detect("feature", "origin/main")
 
-        assert result["remedy"][0] == "git cherry-pick --abort"
+        for r in result["remedies"]:
+            assert r["commands"][0] == "git cherry-pick --abort"
 
 
 class TestInProgressAbort:
@@ -611,31 +683,440 @@ class TestFormatTerse:
         })
         assert "verdict: not-detected" in out
 
-    def test_squash_merged_includes_pr_and_remedy(
+    def test_squash_merged_includes_pr_and_both_remedies(
         self, detect_squash_residue: ModuleType
     ) -> None:
         d = {
             "verdict": "squash-merged",
-            "method": "gh-api",
+            "method": "tree-match+gh",
             "pr": {
                 "number": 42,
                 "url": "https://example.com/pr/42",
                 "merged_at": "2026-05-15T12:00:00Z",
+            },
+            "squash_commit": {
+                "sha": "c" * 40,
+                "short": "c" * 8,
+                "subject": "Squashed feature (#42)",
             },
             "warnings": [],
             "unique_commits": [
                 {"sha": "a" * 40, "short": "a" * 8, "subject": "follow-up"}
             ],
             "branch_commits": [],
-            "remedy": [
-                "git rebase --abort",
-                "git reset --hard origin/main",
-                "git cherry-pick aaaaaaaa",
+            "remedies": [
+                {
+                    "name": "merge",
+                    "destructive": False,
+                    "description": "Merge base into branch (non-destructive).",
+                    "commands": ["git rebase --abort", "git merge origin/main"],
+                },
+                {
+                    "name": "reset-and-cherry-pick",
+                    "destructive": True,
+                    "description": "Reset and replay (DESTRUCTIVE).",
+                    "commands": [
+                        "git rebase --abort",
+                        "git reset --hard origin/main",
+                        "git cherry-pick aaaaaaaa",
+                    ],
+                },
             ],
         }
         out = detect_squash_residue.format_terse(d)
-        assert "SQUASH-MERGED via PR #42" in out
+        assert "SQUASH-MERGED" in out
+        assert "PR=#42" in out
         assert "https://example.com/pr/42" in out
+        assert "Squashed feature (#42)" in out
         assert "follow-up" in out
-        assert "git rebase --abort" in out
-        assert "destructive, review first" in out
+        # Both remedies labeled and ordered.
+        assert "[A] merge" in out
+        assert "(non-destructive)" in out
+        assert "[B] reset-and-cherry-pick" in out
+        assert "(DESTRUCTIVE)" in out
+        assert out.index("[A] merge") < out.index("[B] reset-and-cherry-pick")
+        assert "git merge origin/main" in out
+        assert "git cherry-pick aaaaaaaa" in out
+
+
+def _make_git_log(rows: list[tuple[str, str, str]]) -> subprocess.CompletedProcess:
+    """Build a fake `git log --format=%H%x09%T%x09%s` response from rows of
+    (sha, tree, subject)."""
+    body = "\n".join(f"{sha}\t{tree}\t{subj}" for sha, tree, subj in rows)
+    return make_completed(stdout=body)
+
+
+class TestCheckViaTreeMatch:
+    """The detector this fix is for. A commit on base whose tree equals the
+    tree at some point on the branch is the canonical squash-merge signature.
+    This catches the textbook case the old detector missed: a branch that has
+    additional commits past the squash."""
+
+    def test_finds_squash_when_base_commit_tree_matches_branch_tip(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        branch_rows = [
+            ("sha-feat-1", "tree-1", "feat-1"),
+            ("sha-feat-2", "tree-2", "feat-2"),
+            ("sha-feat-3", "tree-3", "feat-3"),
+        ]
+        base_rows = [("sha-squash", "tree-3", "Squashed feat (#42)")]
+
+        def fake_run_git(args: list[str]) -> subprocess.CompletedProcess:
+            if args[:1] == ["merge-base"]:
+                return make_completed(stdout="sha-mb")
+            if args[:1] == ["log"] and "--reverse" in args:
+                return _make_git_log(branch_rows)
+            if args[:1] == ["log"]:
+                return _make_git_log(base_rows)
+            return make_completed(returncode=1)
+
+        with patch.object(detect_squash_residue, "run_git", side_effect=fake_run_git):
+            result = detect_squash_residue._check_via_tree_match("origin/main", "HEAD")
+
+        assert result is not None
+        assert result["squash_commit"] == "sha-squash"
+        assert [c["subject"] for c in result["squashed_commits"]] == [
+            "feat-1",
+            "feat-2",
+            "feat-3",
+        ]
+        assert result["unique_commits"] == []
+
+    def test_finds_squash_with_followups_past_the_squash(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # The textbook missed case: PR was squash-merged with 3 of 4 branch
+        # commits; the 4th commit landed after the merge. Old local-synth
+        # missed this because the full HEAD tree no longer matches the squash.
+        branch_rows = [
+            ("sha-1", "tree-1", "feat-1"),
+            ("sha-2", "tree-2", "feat-2"),
+            ("sha-3", "tree-3", "feat-3"),  # squash point
+            ("sha-4", "tree-4", "follow-up after squash"),
+        ]
+        base_rows = [("sha-squash", "tree-3", "Squashed feat (#42)")]
+
+        def fake_run_git(args: list[str]) -> subprocess.CompletedProcess:
+            if args[:1] == ["merge-base"]:
+                return make_completed(stdout="sha-mb")
+            if "--reverse" in args:
+                return _make_git_log(branch_rows)
+            return _make_git_log(base_rows)
+
+        with patch.object(detect_squash_residue, "run_git", side_effect=fake_run_git):
+            result = detect_squash_residue._check_via_tree_match("origin/main", "HEAD")
+
+        assert result is not None
+        assert result["squash_commit"] == "sha-squash"
+        assert [c["subject"] for c in result["squashed_commits"]] == [
+            "feat-1",
+            "feat-2",
+            "feat-3",
+        ]
+        assert [c["subject"] for c in result["unique_commits"]] == [
+            "follow-up after squash"
+        ]
+
+    def test_returns_none_when_no_base_commit_matches(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        branch_rows = [("sha-1", "tree-1", "feat-1")]
+        base_rows = [
+            ("sha-x", "tree-x", "unrelated"),
+            ("sha-y", "tree-y", "also unrelated"),
+        ]
+
+        def fake_run_git(args: list[str]) -> subprocess.CompletedProcess:
+            if args[:1] == ["merge-base"]:
+                return make_completed(stdout="sha-mb")
+            if "--reverse" in args:
+                return _make_git_log(branch_rows)
+            return _make_git_log(base_rows)
+
+        with patch.object(detect_squash_residue, "run_git", side_effect=fake_run_git):
+            assert detect_squash_residue._check_via_tree_match("origin/main", "HEAD") is None
+
+    def test_returns_none_on_merge_base_failure(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        with patch.object(
+            detect_squash_residue, "run_git", return_value=make_completed(returncode=128)
+        ):
+            assert detect_squash_residue._check_via_tree_match("origin/main", "HEAD") is None
+
+    def test_returns_none_on_empty_branch_log(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        def fake_run_git(args: list[str]) -> subprocess.CompletedProcess:
+            if args[:1] == ["merge-base"]:
+                return make_completed(stdout="sha-mb")
+            return make_completed(stdout="")
+
+        with patch.object(detect_squash_residue, "run_git", side_effect=fake_run_git):
+            assert detect_squash_residue._check_via_tree_match("origin/main", "HEAD") is None
+
+    def test_prefers_latest_branch_index_when_tree_repeats(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # If two branch commits share a tree (e.g. revert-then-redo), the
+        # match must point at the LATER one — that gives the smallest
+        # unique-commit set to replay.
+        branch_rows = [
+            ("sha-1", "tree-A", "first"),
+            ("sha-2", "tree-B", "second"),
+            ("sha-3", "tree-A", "third (same tree as first)"),
+            ("sha-4", "tree-C", "fourth"),
+        ]
+        base_rows = [("sha-squash", "tree-A", "Squashed")]
+
+        def fake_run_git(args: list[str]) -> subprocess.CompletedProcess:
+            if args[:1] == ["merge-base"]:
+                return make_completed(stdout="sha-mb")
+            if "--reverse" in args:
+                return _make_git_log(branch_rows)
+            return _make_git_log(base_rows)
+
+        with patch.object(detect_squash_residue, "run_git", side_effect=fake_run_git):
+            result = detect_squash_residue._check_via_tree_match("origin/main", "HEAD")
+
+        assert result is not None
+        # Latest index with tree-A is sha-3 → unique is just the trailing commit.
+        assert [c["subject"] for c in result["unique_commits"]] == ["fourth"]
+
+
+class TestDetectViaTreeMatch:
+    """Tree-match is the new primary path through detect(). It must win over
+    gh-api when both fire, and supply the unique-commit list directly."""
+
+    def test_tree_match_alone_yields_tree_match_method(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        commits = _commits("a", "b", "c", "post")
+        tree_hit = {
+            "squash_commit": "s" * 40,
+            "squash_short": "s" * 8,
+            "squash_subject": "Squashed feature (#42)",
+            "squashed_commits": commits[:3],
+            "unique_commits": commits[3:],
+        }
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=tree_hit),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=None),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["verdict"] == "squash-merged"
+        assert result["method"] == "tree-match"
+        assert result["pr"] is None
+        assert result["squash_commit"]["subject"] == "Squashed feature (#42)"
+        assert [c["subject"] for c in result["unique_commits"]] == ["post"]
+        # Cherry-pick line in the destructive remedy must use the unique SHA.
+        reset = _remedy(result["remedies"], "reset-and-cherry-pick")
+        cherry = next((c for c in reset["commands"] if "cherry-pick" in c), None)
+        assert cherry is not None and commits[3]["sha"] in cherry
+
+    def test_tree_match_plus_gh_enriches_with_pr_metadata(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        commits = _commits("a", "b")
+        tree_hit = {
+            "squash_commit": "s" * 40,
+            "squash_short": "s" * 8,
+            "squash_subject": "Squashed",
+            "squashed_commits": commits,
+            "unique_commits": [],
+        }
+        gh = _gh_payload(
+            number=42,
+            commit_oids=[c["sha"] for c in commits],
+            merged_at="2026-05-15T12:00:00Z",
+        )
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=tree_hit),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["verdict"] == "squash-merged"
+        assert result["method"] == "tree-match+gh"
+        assert result["pr"]["number"] == 42
+        assert result["pr"]["url"] == "https://example.com/pr/42"
+        assert result["squash_commit"]["short"] == "s" * 8
+
+    def test_tree_match_takes_precedence_when_gh_disagrees(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # gh found a PR but with non-overlapping SHAs (rebased branch). Old
+        # detector downgraded to inconclusive. With tree-match, the verdict
+        # is squash-merged — tree equivalence is a stronger signal than
+        # SHA overlap.
+        commits = _commits("rebased-1", "rebased-2", "rebased-3")
+        tree_hit = {
+            "squash_commit": "s" * 40,
+            "squash_short": "s" * 8,
+            "squash_subject": "Squashed (rebased)",
+            "squashed_commits": commits[:2],
+            "unique_commits": commits[2:],
+        }
+        gh = _gh_payload(
+            number=99,
+            commit_oids=["a" * 40, "b" * 40],  # diverged from rebased SHAs
+            merged_at="2026-05-15T12:00:00Z",
+        )
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=tree_hit),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["verdict"] == "squash-merged"
+        assert result["method"] == "tree-match+gh"
+        # Unique commits come from tree-match, not gh's SHA diff.
+        assert [c["subject"] for c in result["unique_commits"]] == ["rebased-3"]
+        # No "inconclusive" warning — tree-match overrode the weak gh signal.
+        assert not any("inconclusive" in w for w in result["warnings"])
+
+    def test_tree_match_skips_local_synth(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # When tree-match fires, local-synth must NOT run — calling it would
+        # be wasteful and could produce conflicting results.
+        commits = _commits("a")
+        tree_hit = {
+            "squash_commit": "s" * 40,
+            "squash_short": "s" * 8,
+            "squash_subject": "Squashed",
+            "squashed_commits": commits,
+            "unique_commits": [],
+        }
+        synth_calls = []
+        def fake_synth(*a: object, **kw: object) -> bool:
+            synth_calls.append((a, kw))
+            return True
+
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=tree_hit),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=None),
+            patch.object(detect_squash_residue, "_check_via_synthesis", side_effect=fake_synth),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["verdict"] == "squash-merged"
+        assert result["method"] == "tree-match"
+        assert synth_calls == []
+
+
+class TestBuildRemedies:
+    """The dual-remedy structure — both options always offered, safety order
+    enforced, abort prefix applied to both when an operation is in progress."""
+
+    def _scaffold(self, **overrides: object) -> dict:
+        base = {
+            "verdict": "squash-merged",
+            "method": "tree-match",
+            "branch_commits": [],
+            "unique_commits": [],
+            "squash_commit": None,
+            "pr": None,
+            "warnings": [],
+        }
+        base.update(overrides)
+        return base
+
+    def test_merge_remedy_is_non_destructive(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        with patch.object(
+            detect_squash_residue, "_in_progress_abort", return_value=None
+        ):
+            remedies = detect_squash_residue._build_remedies(self._scaffold(), "origin/main")
+
+        merge = _remedy(remedies, "merge")
+        assert merge["destructive"] is False
+        assert merge["commands"] == [
+            "git merge origin/main",
+            # The trailing `# resolve …` comment is informational only.
+            next(c for c in merge["commands"] if c.startswith("#")),
+        ]
+        # No reset/cherry-pick commands leak into the merge option.
+        assert not any("reset --hard" in c for c in merge["commands"])
+        assert not any("cherry-pick" in c for c in merge["commands"] if not c.startswith("#"))
+
+    def test_reset_remedy_is_destructive(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        unique = _commits("unique-1", "unique-2")
+        with patch.object(
+            detect_squash_residue, "_in_progress_abort", return_value=None
+        ):
+            remedies = detect_squash_residue._build_remedies(
+                self._scaffold(unique_commits=unique), "origin/main"
+            )
+
+        reset = _remedy(remedies, "reset-and-cherry-pick")
+        assert reset["destructive"] is True
+        assert "git reset --hard origin/main" in reset["commands"]
+        cherry = next((c for c in reset["commands"] if "cherry-pick" in c), None)
+        assert cherry is not None
+        for c in unique:
+            assert c["sha"] in cherry
+
+    def test_abort_prefix_applied_to_both_remedies(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        with patch.object(
+            detect_squash_residue, "_in_progress_abort", return_value="git rebase --abort"
+        ):
+            remedies = detect_squash_residue._build_remedies(self._scaffold(), "origin/main")
+
+        for r in remedies:
+            assert r["commands"][0] == "git rebase --abort"
+
+    def test_local_synth_emits_manual_review_in_destructive_remedy_only(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        branch = _commits("a", "b")
+        scaffold = self._scaffold(
+            method="local-synth",
+            branch_commits=branch,
+            unique_commits=[],
+        )
+        with patch.object(
+            detect_squash_residue, "_in_progress_abort", return_value=None
+        ):
+            remedies = detect_squash_residue._build_remedies(scaffold, "origin/main")
+
+        merge = _remedy(remedies, "merge")
+        # Merge remedy stays clean — no per-commit review block needed.
+        assert not any(c.startswith("#   ") for c in merge["commands"])
+        reset = _remedy(remedies, "reset-and-cherry-pick")
+        review_lines = [c for c in reset["commands"] if c.startswith("#   ")]
+        assert len(review_lines) == 2
+        for c in branch:
+            assert any(c["short"] in line for line in review_lines)
+
+    def test_no_unique_no_cherry_pick_in_reset_remedy(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        with patch.object(
+            detect_squash_residue, "_in_progress_abort", return_value=None
+        ):
+            remedies = detect_squash_residue._build_remedies(
+                self._scaffold(method="tree-match", unique_commits=[]), "origin/main"
+            )
+
+        reset = _remedy(remedies, "reset-and-cherry-pick")
+        assert reset["commands"] == ["git reset --hard origin/main"]

--- a/tests/python/test_detect_squash_residue.py
+++ b/tests/python/test_detect_squash_residue.py
@@ -950,13 +950,13 @@ class TestDetectViaTreeMatch:
         assert result["pr"]["url"] == "https://example.com/pr/42"
         assert result["squash_commit"]["short"] == "s" * 8
 
-    def test_tree_match_takes_precedence_when_gh_disagrees(
+    def test_tree_match_keeps_verdict_when_gh_pr_does_not_correlate(
         self, detect_squash_residue: ModuleType
     ) -> None:
-        # gh found a PR but with non-overlapping SHAs (rebased branch). Old
-        # detector downgraded to inconclusive. With tree-match, the verdict
-        # is squash-merged — tree equivalence is a stronger signal than
-        # SHA overlap.
+        # gh found a PR with this branch name but its commits don't overlap
+        # the tree-match squash (different PR, reused branch name). The
+        # verdict still stands on tree-match alone; gh metadata must NOT
+        # attach, and a warning must surface so the user knows why.
         commits = _commits("rebased-1", "rebased-2", "rebased-3")
         tree_hit = {
             "squash_commit": "s" * 40,
@@ -980,11 +980,48 @@ class TestDetectViaTreeMatch:
             result = detect_squash_residue.detect("feature", "origin/main")
 
         assert result["verdict"] == "squash-merged"
-        assert result["method"] == "tree-match+gh"
+        # Gate refuses gh enrichment when SHAs and merge_commit both diverge.
+        assert result["method"] == "tree-match"
+        assert result["pr"] is None
         # Unique commits come from tree-match, not gh's SHA diff.
         assert [c["subject"] for c in result["unique_commits"]] == ["rebased-3"]
-        # No "inconclusive" warning — tree-match overrode the weak gh signal.
-        assert not any("inconclusive" in w for w in result["warnings"])
+        # User gets a "did not correlate" warning citing the diverged PR.
+        assert any(
+            "PR #99" in w and "do not correlate" in w for w in result["warnings"]
+        )
+
+    def test_tree_match_plus_gh_attached_when_merge_commit_matches_squash(
+        self, detect_squash_residue: ModuleType
+    ) -> None:
+        # Strongest correlation: gh's mergeCommit.oid equals the tree-match
+        # squash commit. Even with no SHA overlap (rebased branch), the PR
+        # is provably the same one and metadata must attach.
+        commits = _commits("rebased-1", "rebased-2")
+        tree_hit = {
+            "squash_commit": "s" * 40,
+            "squash_short": "s" * 8,
+            "squash_subject": "Squashed (rebased)",
+            "squashed_commits": commits,
+            "unique_commits": [],
+        }
+        gh = _gh_payload(
+            number=77,
+            commit_oids=["a" * 40, "b" * 40],  # diverged source SHAs
+            merged_at="2026-05-15T12:00:00Z",
+        )
+        gh["merge_commit"] = "s" * 40  # but the merge commit equals the squash
+        with (
+            patch.object(detect_squash_residue, "_resolve_head", return_value="HEAD"),
+            patch.object(detect_squash_residue, "_commits_since", return_value=commits),
+            patch.object(detect_squash_residue, "_check_via_tree_match", return_value=tree_hit),
+            patch.object(detect_squash_residue, "_check_via_gh", return_value=gh),
+            patch.object(detect_squash_residue, "_in_progress_abort", return_value=None),
+        ):
+            result = detect_squash_residue.detect("feature", "origin/main")
+
+        assert result["method"] == "tree-match+gh"
+        assert result["pr"]["number"] == 77
+        assert not any("do not correlate" in w for w in result["warnings"])
 
     def test_tree_match_skips_local_synth(
         self, detect_squash_residue: ModuleType


### PR DESCRIPTION
## What changed

Two fixes to the `/melt` skill's squash-residue detector and remedy:

**1. Detection — added `_check_via_tree_match` as the primary path.** Walks commits on base looking for one whose tree equals the tree at some point on the branch. That commit is a squash-equivalent of branch commits up to that point — the canonical squash-merge signature. Works offline, through fork PRs and renames, and (unlike the existing `_check_via_synthesis`) handles the case where the branch has additional commits past the squash. `gh-api` still runs in parallel to enrich the result with PR metadata.

**2. Remedy — split single destructive command list into two labeled options.**

- **[A] merge** (non-destructive) — `git merge <base>`. Preserves branch history; squashed commits collapse to a no-op so only real conflicts surface. Listed first.
- **[B] reset-and-cherry-pick** (destructive) — `git reset --hard <base>` + `git cherry-pick <unique-shas>`. Requires force-push.

SKILL.md guidance updated: lead with the merge remedy unless the user has asked for a linear-history workflow.

## Why

The detector returned `not-detected` on a textbook squash-residue this week — a PR squash-merged into `main` with the branch carrying one extra commit past the squash. `gh-api` matches on PR-commit SHAs (which never match the new squash commit on base), and `local-synth` compared the full HEAD tree (which no longer matches once any post-squash commit lands).

And the only remedy was destructive: `git reset --hard` + `cherry-pick` + force-push. `git merge origin/main` would have been a one-line non-destructive alternative — and worked in the case that triggered this fix.

## How to verify

```bash
just test             # 281 pytest pass (52 in this suite, +15 new)
just lint-md          # clean
python3 skills/melt/scripts/detect-squash-residue.py --help
```

Synthetic end-to-end check (the case the old detector missed):

```bash
# In a scratch dir:
git init -b main && git config user.email t@t && git config user.name t
echo 1 > f && git add . && git commit -m init
git checkout -b feat
for v in a b c; do echo $v > f && git add . && git commit -m "feat-$v"; done
git checkout main && git merge --squash feat && git commit -m 'Squashed feat (#42)'
git checkout feat && echo post > g && git add . && git commit -m 'feat-post-squash'
python3 <path>/skills/melt/scripts/detect-squash-residue.py --base main --branch feat
```

Expected: `verdict: SQUASH-MERGED method=tree-match`, one unique commit listed (`feat-post-squash`), both remedies printed in order (merge first, reset+cherry-pick second).

## Risk / rollout notes

- **API change in detector JSON output**: `remedy: list[str]` → `remedies: list[{name, destructive, description, commands}]`; added `squash_commit` field. Pure-internal — no other script in this repo consumes the JSON.
- New detection path runs an extra `git log -500` on base; capped to avoid hitting long-running base branches hard.
- All existing test paths covered: tree-match positive, tree-match + gh combined, tree-match takes precedence when gh disagrees, fallback to gh-api when tree-match misses, fallback to local-synth when both miss, no-detection negative.
- `tree-match` skips `_check_via_synthesis` once a match is found (test asserts this).

## Checklist

- [x] Conventional Commits PR title
- [x] Tests added or updated — 15 new tests, 11 migrated
- [x] Documentation updated — SKILL.md detection methods, verdict semantics, remedy options, and rules sections
- [x] No secrets or credentials added