### PR TITLE
feat(skills): add telemetry dimension to /age review skill

### DIFF
--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: age
-description: This skill should be used when the user wants a code review on a diff, PR, branch, or path — phrases like "review this", "/age", "is this safe to merge", "find bugs", "spot security issues", "check for slop", "review my PR", "look for problems", "what's wrong with this code". Runs nine orthogonal review dimensions (correctness, security, encapsulation, spec, complexity, deslop, assertions, NIH, efficiency) over the scoped diff and emits a stake-grouped findings report at `.cheese/age/<slug>.md`. Use even when the user only asks for one dimension — the report scopes itself. Findings only — no fixes; after the report lands, age renders the cure-selection table inline and asks which findings to cure (no "should I run /cure?" meta-question), then hands off to `/cure` with the selection locked in. Supports `--auto` (propagated from `/cook --auto`) for the autonomous chain into `/cure` (see `### Auto mode`). After `/press` (optional); before `/cure`.
+description: This skill should be used when the user wants a code review on a diff, PR, branch, or path — phrases like "review this", "/age", "is this safe to merge", "find bugs", "spot security issues", "check for slop", "review my PR", "look for problems", "what's wrong with this code". Runs ten orthogonal review dimensions (correctness, security, encapsulation, spec, complexity, deslop, assertions, NIH, efficiency, telemetry) over the scoped diff and emits a stake-grouped findings report at `.cheese/age/<slug>.md`. Use even when the user only asks for one dimension — the report scopes itself. Findings only — no fixes; after the report lands, age renders the cure-selection table inline and asks which findings to cure (no "should I run /cure?" meta-question), then hands off to `/cure` with the selection locked in. Supports `--auto` (propagated from `/cook --auto`) for the autonomous chain into `/cure` (see `### Auto mode`). After `/press` (optional); before `/cure`.
 license: MIT
 ---
 
@@ -38,6 +38,7 @@ When called with a `<slug>`, resolve `.cheese/press/<slug>.md` (if present) for 
 | assertions | medium | weak tests, shallow existence checks, swallowed errors |
 | nih | medium | reinvented dependency, stdlib, or existing project helper / utility / component |
 | efficiency | medium | unnecessary work, missed concurrency, hot-path bloat, no-op updates, time-of-check/time-of-use (TOCTOU) pre-checks, memory leaks, overly broad reads |
+| telemetry | medium | silent error branches on non-interactive paths (servers, daemons, workers, outbound API/DB/queue calls), un-instrumented outbound calls, silent worker loops, hand-rolled logging infrastructure when stdlib/ecosystem covers it, missing rotation/retention/config hygiene on new file logging, unstructured logs, wrong log levels, double-logging, errors logged without context, missing correlation/trace ids, high-cardinality metric labels or span names, logs-as-metrics, `print()`/`console.log` in production, tests asserting on log strings |
 
 Per-dimension rubrics and recommendation shapes in `references/dimensions.md`. This reduced workflow intentionally omits the git-history/precedent dimension.
 
@@ -79,7 +80,7 @@ Spawn when any of these are true:
 - Caller / dependency graph expansion crosses multiple subsystems.
 - code-review-graph or `tilth_deps` output is needed for hotspot, bridge-node, or blast-radius framing.
 
-The sub-agent returns a digest: orientation paragraph, high-signal `path:line` citations, gap list. The parent owns the nine-dimension review, severity grading, and the `.cheese/age/<slug>.md` report. Do not spawn for small diffs, to outsource severity grading, or to outsource the final verdict.
+The sub-agent returns a digest: orientation paragraph, high-signal `path:line` citations, gap list. The parent owns the ten-dimension review, severity grading, and the `.cheese/age/<slug>.md` report. Do not spawn for small diffs, to outsource severity grading, or to outsource the final verdict.
 
 Digest size, parent-vs-sub-agent split, and harness-agnostic sub-agent selection live in `references/sub-agent-gate.md` — single source of truth for the cross-cutting rules.
 
@@ -166,7 +167,7 @@ When invoked with `--auto`:
 
 ### Inline-degrade mode (invoked from a sub-agent, e.g. /cheese-factory curd worker)
 
-When `/age` detects it is running as a sub-agent (the parent passes the `invoked-from: cheese-factory-curd` marker or equivalent context line in the prompt), it runs its nine dimensions inline within its own context instead of spawning per-dimension sub-agents. This honours the host's nesting-depth limit (Claude Code allows 1 level of sub-agent nesting; equivalents in other harnesses are similar).
+When `/age` detects it is running as a sub-agent (the parent passes the `invoked-from: cheese-factory-curd` marker or equivalent context line in the prompt), it runs its ten dimensions inline within its own context instead of spawning per-dimension sub-agents. This honours the host's nesting-depth limit (Claude Code allows 1 level of sub-agent nesting; equivalents in other harnesses are similar).
 
 Detection mechanism: scan the invoking prompt for an `invoked-from:` line — values like `cheese-factory-curd`, `fromagerie-curd`, or any harness-specific marker the orchestrator passes in. When present, switch modes:
 

--- a/skills/age/references/dimensions.md
+++ b/skills/age/references/dimensions.md
@@ -106,6 +106,30 @@ Look for:
 
 Recommendation shape: "Hoist `<call>` out of the loop" / "Run `<a>` and `<b>` in parallel with `Promise.all` (or equivalent)" / "Guard the store write on a value change" / "Drop the existence pre-check; handle the error from `<op>` instead" / "Bound `<structure>` or add cleanup on `<teardown>`" / "Read only the needed range/columns".
 
+### telemetry
+
+Covers logging, metrics, and tracing hygiene — both **presence** (is the path instrumented at all?) and **shape** (structure / levels / context / cardinality). Non-interactive paths need real telemetry (HTTP/RPC handlers, outbound API/DB/queue/cache calls, daemons, queue consumers, schedulers, background workers, retry loops); interactive paths where the operator watches stdout (CLI tools, dev scripts, one-shot commands) do not need backend-shipped telemetry on the happy path, though structured error output still helps. Secrets-in-logs stays under `security`; hot-path log-volume cost stays under `efficiency`; exceptions swallowed with no handling at all stay under `correctness`.
+
+Look for:
+- **Silent error branches on non-interactive paths.** `catch` / `except` / `if err != nil` blocks in servers, daemons, workers, and outbound calls that handle the error but emit no log and no metric. The failure becomes invisible to anyone not attached to a debugger.
+- **Outbound calls without observability.** HTTP / RPC / DB / queue / cache calls with no surrounding span, no error log, and no failure counter. Operators learn the integration broke only from downstream symptoms.
+- **Silent daemons / workers / schedulers.** Long-running processes with no startup log, no heartbeat or per-iteration progress signal, and no per-item error emission. When the worker stalls or crashes, there is nothing to grep.
+- **Missing request/response instrumentation on server handlers.** New routes or RPC methods added with no entry/exit log, no latency metric, and no error counter.
+- **Hand-rolled logging infrastructure.** New logger class, formatter, level filter, JSON serializer, ring buffer, or log-shipping code when the project already wires a logger or the ecosystem has a standard one (Python `logging` / `structlog`; Node `pino` / `winston`; Go `slog` / `zerolog`; Rust `tracing` / `log`; Java `slf4j` / `logback`). Overlaps with `nih`; both dimensions may flag the same line.
+- **Missing operational hygiene on new file-based logging.** Logs written to disk without rotation (size cap, age cap, archive policy), no retention bound, hardcoded log paths that bypass project config, synchronous writes on the request path, or custom log-shipping where the project's standard handler / sidecar / OTel collector already does the job.
+- Unstructured or string-concatenated log messages where structured (key-value or JSON) fields would be queryable — `f"user {id} failed"` instead of `log.error("operation failed", user_id=id)`.
+- Wrong log levels: DEBUG-spam in production hot paths, ERROR used for expected outcomes, everything-at-INFO walls that bury real signal.
+- Double-logging: code that logs an error and then rethrows / returns it, so the same failure appears at every frame up the stack.
+- Errors logged without context: `log.error("failed")` with no exception object, stack trace, or causal fields. Use `exc_info=True` (Python) / `{ err }` (JS) / equivalent.
+- Missing correlation: cross-service or async work without a trace/request/correlation id threaded through the log line and span.
+- High-cardinality metric labels or span names: `user_id`, `request_id`, full URLs with query strings, timestamps, or other unbounded values used as metric labels or in span names. Belongs in span attributes (sampled) or log fields, not in metric label sets.
+- Logs-as-metrics: counting log occurrences in a downstream pipeline instead of emitting a counter, gauge, or histogram directly.
+- `print()` / `console.log` / raw stderr scribbles left in production code paths instead of the project's logger.
+- Tests asserting on log strings — couples implementation details to test assertions and breaks on cosmetic log changes.
+- Unbounded list / object / request-body dumps into logs (can balloon log volume and leak sensitive structure).
+
+Recommendation shape: "Emit a structured error log (and a failure counter) in this catch block before re-raising" / "Wrap the outbound `<call>` in a span and add a failure-counter metric" / "Add startup + per-iteration logs to the `<worker>` loop with the failing item id on error" / "Add entry/exit log + latency metric to the new `<handler>`" / "Use the project's existing logger / standard `<stdlib-or-ecosystem-library>` instead of the hand-rolled `<class>`" / "Configure rotation (size + age cap, retention policy) on the new file handler" / "Read log path / level from project config instead of hardcoding" / "Replace string-concat log with structured fields" / "Demote to DEBUG (or drop)" / "Log once at the boundary, not at every catch" / "Add `exc_info=True` (or equivalent) to capture the stack" / "Thread `trace_id` through the log context at the request boundary" / "Move `<high-cardinality-attr>` from metric label to span attribute" / "Emit a counter instead of grepping logs" / "Replace `print()` with the project logger" / "Assert on behavior, not on log text".
+
 ## Stake assignment
 
 Stake is fixed per dimension. Do not vary it at runtime based on diff size or perceived severity — the rubric already encodes severity. A high-stake dimension produces fewer findings when the rubric does not match the diff; do not promote a medium-stake finding to fill space.

--- a/skills/cheese-factory/references/curd-prompt.md
+++ b/skills/cheese-factory/references/curd-prompt.md
@@ -32,14 +32,14 @@ Do NOT run the full test suite.
 
 1. /cook --auto {hard_flag}                  — implement the behaviour against the acceptance criterion
 2. /press --auto                             — adversarial test hardening (single pass)
-3. /age --auto                               — nine-dimension review of YOUR diff only, inline-degrade
+3. /age --auto                               — ten-dimension review of YOUR diff only, inline-degrade
 4. /cure --auto --stake medium+ {hard_flag}  — fix every medium-or-above finding
 5. /commit (or git commit direct)            — single commit with conventional message
 6. Write pr-metadata.json: {{title, body}} for the slicer to pick up later
 
 ## /age inline-degrade contract
 
-You are running as a sub-agent. The /age skill must run its nine dimensions
+You are running as a sub-agent. The /age skill must run its ten dimensions
 INLINE within your own context — do not spawn sub-agents for parallel review.
 The nesting-depth limit in Claude Code (and equivalents in other harnesses)
 blocks level-2 nesting.

--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -72,7 +72,7 @@ Each phase spawns a **full peer** sub-agent — same model as the parent, full t
 
 - `/cook` writes code across the changed files.
 - `/press` runs the project's test suite and adds tests.
-- `/age` reviews nine dimensions over the diff.
+- `/age` reviews ten dimensions over the diff.
 - `/cure` applies fixes via `cheez-write` and re-runs test gates.
 
 Diminutive defaults (haiku model, restricted tools, `Explore`-style read-only workers) will choke phases that need to edit dozens of files or run real test suites.


### PR DESCRIPTION
## Summary

Adds a 10th review dimension to `/age` covering logging, metrics, and tracing hygiene.

**Coverage:**
- **Instrumentation presence** on non-interactive paths: servers, daemons, outbound API/DB/queue/cache calls, worker loops, and server handlers. Flags silent error branches and completely un-instrumented paths.
- **Signal quality**: structured vs string-concat logs, correct log levels, errors logged with context + stack traces, correlation IDs threaded through, high-cardinality metric labels/span names, logs-as-metrics anti-pattern, stray `print()`/`console.log` in production.
- **Operational hygiene on new logging**: no hand-rolled logger when stdlib/ecosystem covers it (Python `logging`, Node `pino`/`winston`, Go `slog`, Rust `tracing`, Java `slf4j`), and rotation/retention/config properly set up on file-based logs.

**Carve-out:** CLI tools, dev scripts, and one-shot commands where the operator watches stdout do not need backend-shipped telemetry on the happy path (structured error output still useful).

**Orthogonality:** Secrets-in-logs → `security`; swallowed-with-no-handling → `correctness`; hot-path log cost → `efficiency`; hand-rolled logger overlaps `nih` (both dimensions may flag the same line).

**Stake:** Medium (matches `deslop`, `complexity`, `assertions`, `nih`, `efficiency`; below high-stake merge blockers).

Updates peer-skill references in `/ultracook` and `/cheese-factory` curd prompt from nine to ten dimensions.

## Testing

- Briesearch validation: Honeycomb, OpenObserve, OneUptime, OpenTelemetry docs, sematext, last9 consensus on telemetry anti-patterns (structured logging, log levels, cardinality, instrumentation presence)
- Two passes of self-eval: conformance check (cross-file consistency, stake justification, prose slop), found and fixed three stale "nine-dimension" refs in peer skills
- All "nine"/"nine-dimension" refs replaced with "ten" across the skill tree

🧀 Ready to ship.