### PR TITLE
docs(skills): add optional Serena MCP guidance to cheez-* skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Workflow skills name preferred tools when they help, with fallbacks for portabil
 | Context7 (MCP) | Library and API documentation | repo docs, package docs, vendor pages, web search |
 | Tavily (MCP) | Current web/vendor research | host web search or user-supplied sources |
 | code-review-graph (MCP) | Review impact radius, architecture framing, and embeddings-backed semantic / cross-repo search | import searches, caller searches, tests |
-| LSP / Serena | Semantic navigation and symbol understanding | `sg`, `ripgrep`, targeted reads |
+| LSP / [Serena](https://github.com/oraios/serena) (MCP) | Type-aware xrefs (`find_referencing_symbols`, `find_implementations`), symbol-bounded edits (`rename_symbol`, `replace_symbol_body`, `safe_delete_symbol`), and LSP diagnostics — concrete tools for the abstract "if your harness has an LSP" sections in cheez-* skills | `sg`, `tilth_search`, targeted reads via tilth |
 | `ripgrep` | Fast text search | `grep`, `find`, editor search |
 | `gh` | GitHub issues, PRs, checks, examples | local git commands or user-provided links/logs |
 | `delta` | Readable diffs | plain `git diff` |

--- a/skills/cheez-read/SKILL.md
+++ b/skills/cheez-read/SKILL.md
@@ -120,6 +120,17 @@ If the file is code in this repo, **always cheez-read** — the hash anchors are
 
 If no LSP is installed for the language, or the file is in a broken / incomplete state where the server cannot resolve, stay on tilth. tilth still wins on outline reading, hash-anchored prep for edits, polyglot directory listings, and any read where a `.gitignore`-aware token estimate is required.
 
+### When Serena beats tilth for symbol-table reads (if your harness has it)
+
+[Serena](https://github.com/oraios/serena) is an LSP-driven MCP. If `mcp__serena__get_symbols_overview` is in your tool list, prefer it for symbol-table reads where you don't need source lines:
+
+| Goal | Serena tool | Why |
+|------|-------------|-----|
+| Just the symbol table of one file (no source lines) | `mcp__serena__get_symbols_overview` | Cheaper than tilth outline mode — LSP-indexed, no parse pass |
+| Read a single symbol's body by name (no line range needed) | `mcp__serena__find_symbol` with body inclusion | Skips the "outline → drill into 44-89" round-trip |
+
+Stay on `tilth_read` when you need hash anchors (any edit follows up), a `tilth_files` directory listing with token estimates, or token-budgeted preview mode. Serena gives you the symbol; tilth gives you the anchor. If you're going to edit afterwards, prefer tilth so the anchor is already in hand — see [`cheez-write`](../cheez-write/SKILL.md) for the symmetric "When Serena beats `tilth_edit`" guidance.
+
 ---
 
 ## MCP Tool Reference

--- a/skills/cheez-read/SKILL.md
+++ b/skills/cheez-read/SKILL.md
@@ -122,14 +122,14 @@ If no LSP is installed for the language, or the file is in a broken / incomplete
 
 ### When Serena beats tilth for symbol-table reads (if your harness has it)
 
-[Serena](https://github.com/oraios/serena) is an LSP-driven MCP. If `mcp__serena__get_symbols_overview` is in your tool list, prefer it for symbol-table reads where you don't need source lines:
+[Serena](https://github.com/oraios/serena) is an LSP-driven MCP. When Serena is configured for the codebase (`.serena/project.yml` present) and the read is symbol-shaped, the **calling workflow skill** should route directly to Serena rather than entering `/cheez-read`:
 
 | Goal | Serena tool | Why |
 |------|-------------|-----|
 | Just the symbol table of one file (no source lines) | `mcp__serena__get_symbols_overview` | Cheaper than tilth outline mode — LSP-indexed, no parse pass |
 | Read a single symbol's body by name (no line range needed) | `mcp__serena__find_symbol` with body inclusion | Skips the "outline → drill into 44-89" round-trip |
 
-Stay on `tilth_read` when you need hash anchors (any edit follows up), a `tilth_files` directory listing with token estimates, or token-budgeted preview mode. Serena gives you the symbol; tilth gives you the anchor. If you're going to edit afterwards, prefer tilth so the anchor is already in hand — see [`cheez-write`](../cheez-write/SKILL.md) for the symmetric "When Serena beats `tilth_edit`" guidance.
+`/cheez-read` itself stays tilth-only — its `allowed-tools` frontmatter does not include `mcp__serena__*` and shouldn't. The routing decision happens in the workflow skill *before* it enters `/cheez-read`. Enter `/cheez-read` when you need hash anchors (any edit follows up), a `tilth_files` directory listing with token estimates, token-budgeted preview mode, or when Serena is unavailable. Serena gives you the symbol; tilth gives you the anchor — if you're going to edit afterwards, prefer tilth so the anchor is already in hand. See [`cheez-write`](../cheez-write/SKILL.md) for the symmetric "When Serena beats `tilth_edit`" guidance.
 
 ---
 

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -130,6 +130,19 @@ If you find yourself wanting `grep` *for code in this repo*, that's the signal t
 
 If no LSP is installed for the language, or the file is in a broken / incomplete state where the server cannot resolve, fall back to tilth — `tilth_search` still finds the symbol by name even when no semantic resolution is possible. tilth also wins on speed at scale, polyglot queries (one call across Rust + TS + Python), error-tolerant parses, and content / regex queries that LSP does not index.
 
+### When Serena beats tilth (if your harness has it)
+
+[Serena](https://github.com/oraios/serena) is an LSP-driven MCP that exposes the LSP queries above as named tools. If `mcp__serena__find_symbol` is in your tool list, prefer these concrete calls over the abstract LSP methods — same semantics, no IDE round-trip:
+
+| Question | Serena tool | Why it beats tilth |
+|----------|-------------|--------------------|
+| "Who *really* references X, accounting for aliased imports and shadowing?" | `mcp__serena__find_referencing_symbols` | Type-aware xrefs; tilth's `kind: "callers"` is name-shaped |
+| "What implements interface / trait Y?" | `mcp__serena__find_implementations` | Honors generics and re-exports; tilth surfaces every textual match |
+| "Where is the declaration of X (following imports)?" | `mcp__serena__find_declaration` | Walks the import graph; tilth returns every definition with that name |
+| "Find symbol X across the project, semantically" | `mcp__serena__find_symbol` | LSP-indexed; pair with `get_symbols_overview` for a file's symbol table |
+
+Capability detection: if `mcp__serena__find_symbol` is absent, fall back to `tilth_search` and note "Serena unavailable" in evidence — do not pretend the xref was type-validated. Serena requires `.serena/project.yml` in the repo; if missing, treat it as unconfigured rather than broken. Stay on tilth for polyglot one-call queries, content / regex search, and any case where the language server can't resolve (broken or generated code).
+
 ### When code-review-graph beats tilth (if your harness has it)
 
 [`code-review-graph`](https://github.com/tirth8205/code-review-graph) is a separate, optional MCP that builds a **persistent** call graph of one or more repositories with Tree-sitter, Louvain communities, betweenness-centrality, and (with the `[embeddings]` extra) vector embeddings. Where tilth answers "where is `handleAuth`?", code-review-graph answers "what code is *about* authentication, ranked by importance and reach across all my repos?"

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -132,16 +132,16 @@ If no LSP is installed for the language, or the file is in a broken / incomplete
 
 ### When Serena beats tilth (if your harness has it)
 
-[Serena](https://github.com/oraios/serena) is an LSP-driven MCP that exposes the LSP queries above as named tools. If `mcp__serena__find_symbol` is in your tool list, prefer these concrete calls over the abstract LSP methods — same semantics, no IDE round-trip:
+[Serena](https://github.com/oraios/serena) is an LSP-driven MCP that exposes the LSP queries above as named tools. When Serena is configured for the codebase (`.serena/project.yml` present) and the question is type-grounded, the **calling workflow skill** should route directly to Serena rather than entering `/cheez-search` — same semantics as the abstract LSP methods above, with concrete tool names:
 
 | Question | Serena tool | Why it beats tilth |
 |----------|-------------|--------------------|
 | "Who *really* references X, accounting for aliased imports and shadowing?" | `mcp__serena__find_referencing_symbols` | Type-aware xrefs; tilth's `kind: "callers"` is name-shaped |
 | "What implements interface / trait Y?" | `mcp__serena__find_implementations` | Honors generics and re-exports; tilth surfaces every textual match |
 | "Where is the declaration of X (following imports)?" | `mcp__serena__find_declaration` | Walks the import graph; tilth returns every definition with that name |
-| "Find symbol X across the project, semantically" | `mcp__serena__find_symbol` | LSP-indexed; pair with `get_symbols_overview` for a file's symbol table |
+| "Find symbol X across the project, semantically" | `mcp__serena__find_symbol` | LSP-indexed; pair with `mcp__serena__get_symbols_overview` for a file's symbol table |
 
-Capability detection: if `mcp__serena__find_symbol` is absent, fall back to `tilth_search` and note "Serena unavailable" in evidence — do not pretend the xref was type-validated. Serena requires `.serena/project.yml` in the repo; if missing, treat it as unconfigured rather than broken. Stay on tilth for polyglot one-call queries, content / regex search, and any case where the language server can't resolve (broken or generated code).
+`/cheez-search` itself stays tilth-only — the `allowed-tools` frontmatter does not (and should not) include `mcp__serena__*`. The routing decision happens in the workflow skill *before* it enters `/cheez-search`, matching the redirection-map pattern above. If Serena is unavailable, `.serena/project.yml` is missing, or the symbol isn't LSP-resolvable (broken or generated code), the workflow skill enters `/cheez-search` and uses `tilth_search` — note "Serena unavailable" in evidence so confidence calibration reflects that the xref wasn't type-validated. tilth also remains the right call for polyglot one-call queries, content / regex search, and any case where speed at scale matters more than type fidelity.
 
 ### When code-review-graph beats tilth (if your harness has it)
 

--- a/skills/cheez-write/SKILL.md
+++ b/skills/cheez-write/SKILL.md
@@ -129,6 +129,19 @@ For everything else — block edits, signature changes, body rewrites, hand-writ
 
 If no LSP is installed, or the rename touches a symbol the typechecker can't resolve (broken code, generated bindings), fall back to `sg --rewrite` with the dry-run-first protocol — see "Structural codemods" below.
 
+### When Serena beats `tilth_edit` for symbol-bounded edits (if your harness has it)
+
+[Serena](https://github.com/oraios/serena) is an LSP-driven MCP that exposes symbol-bounded edits as named tools. If `mcp__serena__rename_symbol` is in your tool list, these give the abstract LSP rename above a concrete tool — plus a broader symbol-level edit surface:
+
+| Edit | Serena tool | When to prefer over `tilth_edit` |
+|------|-------------|----------------------------------|
+| Rename a symbol type-correctly across the project | `mcp__serena__rename_symbol` | The LSP rename case above — Serena gives it a concrete tool |
+| Replace a whole function / class body by name | `mcp__serena__replace_symbol_body` | Skips the "read for anchors → edit" round-trip when the boundary is a named symbol |
+| Insert before / after a named symbol (e.g. add a method to a class, or a function next to its sibling) | `mcp__serena__insert_before_symbol`, `mcp__serena__insert_after_symbol` | No anchor needed for a moving boundary |
+| Delete a symbol and check for orphaned references | `mcp__serena__safe_delete_symbol` | Validates xrefs before the cut — `tilth_edit` would happily strand callers |
+
+**Caveat — no hash-anchor concurrency safety.** Serena's edits rely on LSP and file mtime, not the content-hash check that makes `tilth_edit` race-safe. Use Serena's symbol edits only when the file is quiescent (no parallel writers, no in-flight `/cook` or `/cure` on the same path). Fall back to `tilth_edit` whenever concurrency safety dominates, the symbol is not LSP-resolvable (broken or generated code), or the edit is sub-symbol (one line inside a function). The cheez-write floor — `tilth_edit` for everything that touches code — still applies; Serena is an acceleration, not a replacement, and capability detection follows the same pattern as the tilth probe above (absent tool ⇒ stay on `tilth_edit`, do not invent it).
+
 ---
 
 ## Hash Anchor Format

--- a/skills/cheez-write/SKILL.md
+++ b/skills/cheez-write/SKILL.md
@@ -131,7 +131,7 @@ If no LSP is installed, or the rename touches a symbol the typechecker can't res
 
 ### When Serena beats `tilth_edit` for symbol-bounded edits (if your harness has it)
 
-[Serena](https://github.com/oraios/serena) is an LSP-driven MCP that exposes symbol-bounded edits as named tools. If `mcp__serena__rename_symbol` is in your tool list, these give the abstract LSP rename above a concrete tool — plus a broader symbol-level edit surface:
+[Serena](https://github.com/oraios/serena) is an LSP-driven MCP that exposes symbol-bounded edits as named tools. When Serena is configured for the codebase (`.serena/project.yml` present) and the edit is symbol-shaped, the **calling workflow skill** should route directly to Serena rather than entering `/cheez-write` — same pattern as the abstract LSP rename above, with a broader edit surface:
 
 | Edit | Serena tool | When to prefer over `tilth_edit` |
 |------|-------------|----------------------------------|
@@ -140,7 +140,9 @@ If no LSP is installed, or the rename touches a symbol the typechecker can't res
 | Insert before / after a named symbol (e.g. add a method to a class, or a function next to its sibling) | `mcp__serena__insert_before_symbol`, `mcp__serena__insert_after_symbol` | No anchor needed for a moving boundary |
 | Delete a symbol and check for orphaned references | `mcp__serena__safe_delete_symbol` | Validates xrefs before the cut — `tilth_edit` would happily strand callers |
 
-**Caveat — no hash-anchor concurrency safety.** Serena's edits rely on LSP and file mtime, not the content-hash check that makes `tilth_edit` race-safe. Use Serena's symbol edits only when the file is quiescent (no parallel writers, no in-flight `/cook` or `/cure` on the same path). Fall back to `tilth_edit` whenever concurrency safety dominates, the symbol is not LSP-resolvable (broken or generated code), or the edit is sub-symbol (one line inside a function). The cheez-write floor — `tilth_edit` for everything that touches code — still applies; Serena is an acceleration, not a replacement, and capability detection follows the same pattern as the tilth probe above (absent tool ⇒ stay on `tilth_edit`, do not invent it).
+`/cheez-write` itself stays tilth-only — its `allowed-tools` frontmatter does not include `mcp__serena__*` and shouldn't. The routing decision happens in the workflow skill *before* it enters `/cheez-write`, preserving the hash-anchor concurrency floor.
+
+**Caveat — no hash-anchor concurrency safety.** Serena's edits rely on LSP and file mtime, not the content-hash check that makes `tilth_edit` race-safe. The workflow skill should route to Serena only when the file is quiescent (no parallel writers, no in-flight `/cook` or `/cure` on the same path). Route back into `/cheez-write` whenever concurrency safety dominates, the symbol isn't LSP-resolvable (broken or generated code), the edit is sub-symbol (one line inside a function), or Serena is unavailable. The cheez-write floor — `tilth_edit` for everything that touches code from inside this skill — still applies; Serena is a routing alternative the caller chooses, not an in-skill acceleration.
 
 ---
 


### PR DESCRIPTION
## Summary

- Extend the existing "When LSP beats tilth" sections in `cheez-search`, `cheez-read`, and `cheez-write` with concrete [Serena](https://github.com/oraios/serena) MCP tool names so harnesses that have it can use specific calls instead of abstract LSP method names.
- Update the README optional-tools row from a vague "semantic navigation" blurb to a concrete list (`find_referencing_symbols`, `rename_symbol`, `replace_symbol_body`, `safe_delete_symbol`, …) that mirrors the skill sections.
- **No contract changes.** Tilth remains the hard dependency for `cheez-*`. Serena is a capability-detected acceleration; absent tool ⇒ stay on tilth. `cheez-write` floor is preserved — Serena's symbol edits lack hash-anchor concurrency safety, called out explicitly in the skill body.

## What changed by file

| File | Section added |
|------|---------------|
| `skills/cheez-search/SKILL.md` | "When Serena beats tilth (if your harness has it)" — type-aware xrefs |
| `skills/cheez-read/SKILL.md` | "When Serena beats tilth for symbol-table reads" — `get_symbols_overview`, `find_symbol` with body |
| `skills/cheez-write/SKILL.md` | "When Serena beats `tilth_edit` for symbol-bounded edits" — symbol-bounded edits + concurrency-safety caveat |
| `README.md` | Optional-tools row now lists concrete Serena tool surfaces |

## What this PR deliberately doesn't do

- No workflow-skill changes (`/age`, `/press`, `/cook`, etc.) — they don't yet have explicit LSP integration points.
- Doesn't wire Serena's memory tools (`write_memory` / `read_memory`) — they'd duplicate `.cheese/` and the global memory system.
- Doesn't make Serena a dependency anywhere — pure additive documentation.

## Test plan

- [ ] Skim each "When Serena beats..." section to confirm tool names match the `mcp__serena__*` surface.
- [ ] Verify the README row is still legible inside the optional-tools table.
- [ ] Confirm `cheez-write` still names `tilth_edit` as the floor with hash-anchor safety called out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)