### PR TITLE
ci(security): add CodeQL workflow for python and actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+# CodeQL — GitHub's semantic code analysis for finding security
+# vulnerabilities and code quality issues. Runs on PRs, pushes to main,
+# and weekly to catch newly disclosed query updates.
+# See: https://github.com/github/codeql-action
+name: codeql
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "32 5 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, actions]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,12 @@ jobs:
   analyze:
     name: analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
+    # Fork PRs can't get security-events: write (GitHub restricts the
+    # GITHUB_TOKEN), so the upload step would 403. Skip the whole job on
+    # fork PRs; push/schedule runs still cover the same code.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       security-events: write
       packages: read


### PR DESCRIPTION
## Summary

Adds GitHub CodeQL semantic analysis for the two languages present in this repo:

- **python** — covers all skill scripts, shared helpers, install/gen-docs scripts, and tests
- **actions** — scans the workflow files themselves for misconfigurations

Uses the `security-and-quality` query suite (broader than the default `security-extended`). Results land in the repo's **Code scanning** view alongside Scorecard SARIF.

## Triggers

- PRs targeting `main`
- Pushes to `main`
- Weekly schedule (Monday 05:32 UTC, offset from scorecard's Monday 04:26 UTC to spread runner load)

## Test plan

- [ ] CodeQL workflow appears in Actions tab after merge
- [ ] First run completes successfully on push to main
- [ ] Findings (if any) appear under Security → Code scanning
- [ ] yamllint passes (validated locally)

🧀 Generated with [Claude Code](https://claude.com/claude-code)