### PR TITLE
feat(skills/mold): add curd-count script for decomposability-driven handoff

### DIFF
--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -96,7 +96,7 @@ The spec splits into many independent slices, so the natural fit is fan-out para
 - **Implement manually, one phase at a time** — `/cook .cheese/specs/<slug>.md`.
 - **Stop** — dispatch none; leave the spec for later.
 
-**Non-decomposable, high-blast-radius specs (`decomposable: false`, verdict `high`):**
+**Non-decomposable, high-blast-radius specs (`decomposable: false`, verdict `high` only):**
 
 The spec is large enough that per-phase context contamination becomes a real concern: review reasoning softens when the same window contains the cook reasoning, and the parent context bloats across phases. Offer the fresh-context orchestrator and the manual compaction path:
 

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -17,7 +17,7 @@ Do not use it for free-form discussion with no artifact intent (`/culture`), dir
 3. **Sketch** — for any feature touching >1 module or a new public interface, run the shape check (`references/shape-check.md`) on the touched symbols, then lock seams in pseudocode signatures before talking spec content. Default to full signatures, not hand-waving.
 4. **Two-key handshake** — both the user (explicit verb) and the agent (coherence self-check) must agree before extraction. See `references/handshake.md`.
 5. **Curdle** — write the approved spec to `.cheese/specs/<slug>.md` (and optional `.cheese/issues/<slug>-NNN.md`). Format and slug rules in `references/curdle.md`.
-6. **Hand off** — once the spec is on disk, run `scripts/curd-count.py` (passing the shape-check verdict as `--blast-radius`) to compute the recommended downstream skill (`references/curd-count.md`), then prompt the next step via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Never dispatch before the user selects; after a non-stop selection, run the selected downstream skill immediately.
+6. **Hand off** — once the spec is on disk, run `python3 skills/mold/scripts/curd-count.py .cheese/specs/<slug>.md --blast-radius <low|medium|high>` to compute the recommended downstream skill (full procedure in `references/curd-count.md`). Omit `--blast-radius` when the shape-check verdict is `[?]` or shape-check was skipped — the script degrades to `/cook` for sub-threshold specs in that case. Then prompt the next step via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Never dispatch before the user selects; after a non-stop selection, run the selected downstream skill immediately.
 
 ## Modes
 
@@ -79,20 +79,22 @@ Default to project-local cheese artifacts when the user wants files:
 
 **Pipeline:** culture → **[mold]** → cook → press → age → cure → ship
 
-After Curdle writes the spec, run `scripts/curd-count.py` with the shape-check verdict to compute the recommended downstream skill — full procedure in [`references/curd-count.md`](references/curd-count.md):
+After Curdle writes the spec, run the curd-count script with the shape-check verdict to compute the recommended downstream skill — full procedure in [`references/curd-count.md`](references/curd-count.md):
 
 ```bash
 python3 skills/mold/scripts/curd-count.py .cheese/specs/<slug>.md --blast-radius <low|medium|high>
 ```
 
-Read the JSON digest. Its `decomposable` field (true when `candidate_curds ≥ 5`) picks the option set rendered below; its `recommended_skill` field picks which option holds the *(recommended)* slot. Then ask the user via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Lead each option with the verb; the skill command (with the spec path and any in-scope `--hard` propagation) is the backing detail.
+Omit `--blast-radius` when the shape-check verdict is `[?]` or skipped; the script accepts only `low|medium|high` and degrades to `/cook` for sub-threshold specs without the flag.
+
+Read the JSON digest. Its `decomposable` field (true when `candidate_curds ≥ 5`) picks the option set rendered below; its `recommended_skill` field picks which option holds the *(recommended)* slot — subject to one user-confirmed override in the decomposable branch (see below). Then ask the user via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Lead each option with the verb; the skill command (with the spec path and any in-scope `--hard` propagation) is the backing detail.
 
 **Decomposable specs (`decomposable: true`, `candidate_curds ≥ 5`):**
 
-The spec splits into many independent slices, so the natural fit is fan-out parallelism with reviewable PRs. Before dispatching `/cheese-factory`, confirm with the user that the candidate curds are file-disjoint (criterion 4) — the script counts signals, it does not verify independence. If any two curds share a file, fall back to `/ultracook`.
+The spec splits into many independent slices, so the natural fit is fan-out parallelism with reviewable PRs. Before rendering the menu, confirm with the user that the candidate curds are file-disjoint (criterion 4) — the script counts signals, it does not verify independence. **If the user confirms any two candidate curds share a file, override the digest's `recommended_skill`**: shift the *(recommended)* marker from `/cheese-factory` to `/ultracook` for this menu. The option list itself is unchanged.
 
-- **Fan out into parallel curds with reviewable PRs** *(recommended)* — `/cheese-factory .cheese/specs/<slug>.md`. Spawns per-curd worker sub-agents; ends in 1–N reviewable PRs via `/pr-stack`.
-- **Run the full pipeline in fresh-context isolation** — `/ultracook .cheese/specs/<slug>.md`. Autonomous chain with each phase blind to prior phases. Prefer when the candidate curds are not actually file-disjoint.
+- **Fan out into parallel curds with reviewable PRs** *(recommended when curds are file-disjoint)* — `/cheese-factory .cheese/specs/<slug>.md`. Spawns per-curd worker sub-agents; ends in 1–N reviewable PRs via `/pr-stack`.
+- **Run the full pipeline in fresh-context isolation** *(recommended when curds share files)* — `/ultracook .cheese/specs/<slug>.md`. Autonomous chain with each phase blind to prior phases.
 - **Implement manually, one phase at a time** — `/cook .cheese/specs/<slug>.md`.
 - **Stop** — dispatch none; leave the spec for later.
 

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -17,7 +17,7 @@ Do not use it for free-form discussion with no artifact intent (`/culture`), dir
 3. **Sketch** — for any feature touching >1 module or a new public interface, run the shape check (`references/shape-check.md`) on the touched symbols, then lock seams in pseudocode signatures before talking spec content. Default to full signatures, not hand-waving.
 4. **Two-key handshake** — both the user (explicit verb) and the agent (coherence self-check) must agree before extraction. See `references/handshake.md`.
 5. **Curdle** — write the approved spec to `.cheese/specs/<slug>.md` (and optional `.cheese/issues/<slug>-NNN.md`). Format and slug rules in `references/curdle.md`.
-6. **Hand off** — once the spec is on disk, prompt the next step via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Never dispatch before the user selects; after a non-stop selection, run the selected downstream skill immediately.
+6. **Hand off** — once the spec is on disk, run `scripts/curd-count.py` (passing the shape-check verdict as `--blast-radius`) to compute the recommended downstream skill (`references/curd-count.md`), then prompt the next step via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Never dispatch before the user selects; after a non-stop selection, run the selected downstream skill immediately.
 
 ## Modes
 
@@ -79,16 +79,24 @@ Default to project-local cheese artifacts when the user wants files:
 
 **Pipeline:** culture → **[mold]** → cook → press → age → cure → ship
 
-After the spec is written, ask the user via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Lead each option with the verb (what the user wants to *do* next); the skill command (with the spec path and any in-scope `--hard` propagation) is the backing detail. Default options vary with the shape-check verdict:
+After Curdle writes the spec, run `scripts/curd-count.py` with the shape-check verdict to compute the recommended downstream skill — full procedure in [`references/curd-count.md`](references/curd-count.md):
 
-**Low- and medium-blast-radius specs (verdict `low` or `medium`):**
+```bash
+python3 skills/mold/scripts/curd-count.py .cheese/specs/<slug>.md --blast-radius <low|medium|high>
+```
 
-- **Implement the spec** *(recommended)* — `/cook .cheese/specs/<slug>.md`.
-- **Implement and auto-review** — `/cook --auto .cheese/specs/<slug>.md`, chains straight through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Stops at the final cure pass; opening or updating the PR stays a manual step. Offer when acceptance criteria are explicit *and* the user has signalled they want the pipeline to run forward without per-step approval. Never pre-select; auto mode is opt-in.
-- **Research more first** — `/briesearch`, gather more external evidence before implementing.
+Read the JSON digest. Its `decomposable` field (true when `candidate_curds ≥ 5`) picks the option set rendered below; its `recommended_skill` field picks which option holds the *(recommended)* slot. Then ask the user via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Lead each option with the verb; the skill command (with the spec path and any in-scope `--hard` propagation) is the backing detail.
+
+**Decomposable specs (`decomposable: true`, `candidate_curds ≥ 5`):**
+
+The spec splits into many independent slices, so the natural fit is fan-out parallelism with reviewable PRs. Before dispatching `/cheese-factory`, confirm with the user that the candidate curds are file-disjoint (criterion 4) — the script counts signals, it does not verify independence. If any two curds share a file, fall back to `/ultracook`.
+
+- **Fan out into parallel curds with reviewable PRs** *(recommended)* — `/cheese-factory .cheese/specs/<slug>.md`. Spawns per-curd worker sub-agents; ends in 1–N reviewable PRs via `/pr-stack`.
+- **Run the full pipeline in fresh-context isolation** — `/ultracook .cheese/specs/<slug>.md`. Autonomous chain with each phase blind to prior phases. Prefer when the candidate curds are not actually file-disjoint.
+- **Implement manually, one phase at a time** — `/cook .cheese/specs/<slug>.md`.
 - **Stop** — dispatch none; leave the spec for later.
 
-**High-blast-radius specs (verdict `high` only):**
+**Non-decomposable, high-blast-radius specs (`decomposable: false`, verdict `high`):**
 
 The spec is large enough that per-phase context contamination becomes a real concern: review reasoning softens when the same window contains the cook reasoning, and the parent context bloats across phases. Offer the fresh-context orchestrator and the manual compaction path:
 
@@ -97,7 +105,14 @@ The spec is large enough that per-phase context contamination becomes a real con
 - **Compact and resume by hand** — dispatch none; clear context, then dispatch `/cook .cheese/specs/<slug>.md` or `/ultracook .cheese/specs/<slug>.md` directly. (`/cheese --continue` scans phase handoff slugs only — fresh specs don't surface there until cook lands a slug — so dispatching the explicit command is the resumption path here.)
 - **Stop** — dispatch none; leave the spec for later.
 
-`/cook --auto` is omitted from the high-blast-radius offer set: with a large footprint, the fresh-context property of `/ultracook` is the actual motivation for going autonomous, and the in-session chain it offers is the wrong transport for that need. Never pre-select an autonomous option; the user must opt in. `medium` blast radius keeps the standard handoff because the in-session `/cook --auto` chain is still the right tool for that footprint — the fresh-context premium is only worth paying when the spec actually crosses module boundaries broadly enough to flip the verdict to `high`.
+**Non-decomposable, low- or medium-blast-radius specs (`decomposable: false`, verdict `low` or `medium`):**
+
+- **Implement the spec** *(recommended)* — `/cook .cheese/specs/<slug>.md`.
+- **Implement and auto-review** — `/cook --auto .cheese/specs/<slug>.md`, chains straight through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Stops at the final cure pass; opening or updating the PR stays a manual step. Offer when acceptance criteria are explicit *and* the user has signalled they want the pipeline to run forward without per-step approval. Never pre-select; auto mode is opt-in.
+- **Research more first** — `/briesearch`, gather more external evidence before implementing.
+- **Stop** — dispatch none; leave the spec for later.
+
+`/cook --auto` is omitted from the decomposable and high-blast-radius offer sets: with many parallel curds or a wide footprint, fan-out parallelism (`/cheese-factory`) or fresh-context isolation (`/ultracook`) is the actual motivation for going autonomous, and the in-session chain is the wrong transport. Never pre-select an autonomous option; the user must opt in. `medium` blast radius keeps the standard handoff because the in-session `/cook --auto` chain is still the right tool for that footprint — the fresh-context premium is only worth paying when the spec actually crosses module boundaries broadly enough to flip the verdict to `high`, or when the spec decomposes into 5+ independent curds.
 
 ## Rules
 

--- a/skills/mold/references/curd-count.md
+++ b/skills/mold/references/curd-count.md
@@ -7,11 +7,16 @@ and stays out of the conversation's token budget.
 ## What it answers
 
 Which downstream skill should hold the *(recommended)* slot in the Handoff menu —
-`/cheese-factory`, `/ultracook`, `/cook --auto`, or `/cook`?
+`/cheese-factory`, `/ultracook`, or `/cook`?
+
+`/cook --auto` is a user-opt-in alternative the menu always offers in the
+non-decomposable low/medium branch, but it is never a *recommended* pick: per
+existing mold rules, "Never pre-select; auto mode is opt-in" — so the script
+does not consider it.
 
 `/cheese-factory`'s own trigger is "decomposes into 5+ independent behavioural
-curds". Below that count, the choice between `/cook`, `/cook --auto`, and
-`/ultracook` is driven by the shape-check's blast-radius verdict.
+curds". Below that count, the choice between `/cook` and `/ultracook` is driven
+by the shape-check's blast-radius verdict.
 
 ## Procedure
 
@@ -85,8 +90,9 @@ slot should fall back to `/ultracook` even when the count clears the threshold.
 ## When tilth / Python is unavailable
 
 The script depends only on the Python 3 stdlib. If the host has no `python3`,
-mold falls back to the pre-script Handoff: blast-radius alone picks
-`/ultracook` (high) or `/cook --auto`/`/cook` (low or medium), and
+mold falls back to the pre-script Handoff: blast-radius alone picks `/ultracook`
+(high) or `/cook` (low or medium) for the *(recommended)* slot, and
 `/cheese-factory` appears in the option list with a manual "if this spec
-decomposes into 5+ independent curds, pick this" tagline. The user makes the
-call without a computed recommendation. Say the substitution out loud.
+decomposes into 5+ independent curds, pick this" tagline. `/cook --auto` stays
+where it always lives — as a user-opt-in alternative in the non-decomposable
+low/medium menu, never the recommended pick. Say the substitution out loud.

--- a/skills/mold/references/curd-count.md
+++ b/skills/mold/references/curd-count.md
@@ -1,0 +1,92 @@
+# Curd count — recommendation driver
+
+Runs after Curdle writes the spec, before the Handoff menu renders. Pushes the
+parse-and-count work into a Python script so the recommendation is deterministic
+and stays out of the conversation's token budget.
+
+## What it answers
+
+Which downstream skill should hold the *(recommended)* slot in the Handoff menu —
+`/cheese-factory`, `/ultracook`, `/cook --auto`, or `/cook`?
+
+`/cheese-factory`'s own trigger is "decomposes into 5+ independent behavioural
+curds". Below that count, the choice between `/cook`, `/cook --auto`, and
+`/ultracook` is driven by the shape-check's blast-radius verdict.
+
+## Procedure
+
+After `curdle.md` writes the spec to disk, run the script and read the JSON
+digest into context:
+
+```bash
+python3 skills/mold/scripts/curd-count.py .cheese/specs/<slug>.md \
+  --blast-radius <low|medium|high>
+```
+
+Pass the `--blast-radius` value verbatim from the shape-check verdict line
+(see `shape-check.md`). If shape-check was skipped or its verdict was `[?]`,
+omit the flag — the recommendation will degrade to `/cook` for sub-threshold
+specs.
+
+## Signals counted
+
+| Signal | Source in the spec |
+| --- | --- |
+| `goals` | Bullets under `## Goals` |
+| `quality_gates` | Bullets under `## Quality gates` (also matches `## Acceptance criteria` for legacy specs) |
+| `decisions` | Bullets under `## Decisions` (reported but not used in the rule) |
+
+`candidate_curds = max(goals, quality_gates)`. Decisions are reported as a
+sanity check — a spec with 8 decisions but 2 goals is usually one coherent
+change with many tradeoffs, not 8 curds.
+
+## Decision rule
+
+The script only picks among the three skills that can hold the *(recommended)*
+slot. `--auto` variants (`/cook --auto`, etc.) are user-opt-in alternatives
+surfaced by the Handoff menu — the script never recommends them, because
+"Never pre-select; auto mode is opt-in" is an existing mold rule.
+
+| `candidate_curds` | `blast_radius` | Recommended |
+| --- | --- | --- |
+| ≥ 5 | any | `/cheese-factory` |
+| < 5 | `high` | `/ultracook` |
+| < 5 | `medium`, `low`, or unknown | `/cook` |
+
+## Digest shape
+
+```json
+{
+  "spec_path": ".cheese/specs/<slug>.md",
+  "slug": "<slug>",
+  "blast_radius": "high",
+  "candidate_curds": 7,
+  "signals": {"goals": 7, "quality_gates": 6, "decisions": 3},
+  "threshold": 5,
+  "decomposable": true,
+  "recommended_skill": "/cheese-factory",
+  "rationale": "7 candidate curds >= 5 threshold",
+  "notes": [
+    "Count is a signal, not a verdict.",
+    "Confirm curd independence (criterion 4: file-disjoint) before dispatching /cheese-factory."
+  ]
+}
+```
+
+## Independence is the user's call
+
+The script counts; it cannot verify that the candidate curds are file-disjoint
+(`/cheese-factory`'s criterion 4) from spec text alone. Before dispatching
+`/cheese-factory`, mold must confirm independence with the user — typically by
+naming the file footprints captured in `## Interface sketches` and asking
+whether any two candidate curds touch the same file. If they do, the recommended
+slot should fall back to `/ultracook` even when the count clears the threshold.
+
+## When tilth / Python is unavailable
+
+The script depends only on the Python 3 stdlib. If the host has no `python3`,
+mold falls back to the pre-script Handoff: blast-radius alone picks
+`/ultracook` (high) or `/cook --auto`/`/cook` (low or medium), and
+`/cheese-factory` appears in the option list with a manual "if this spec
+decomposes into 5+ independent curds, pick this" tagline. The user makes the
+call without a computed recommendation. Say the substitution out loud.

--- a/skills/mold/scripts/curd-count.py
+++ b/skills/mold/scripts/curd-count.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Count candidate curds in a mold-generated spec and recommend the next skill.
+
+Reads `.cheese/specs/<slug>.md`, counts behavioural curd candidates from the
+`## Goals` and `## Quality gates` sections, and emits a JSON digest naming
+the recommended downstream skill based on the count plus the shape-check
+blast-radius verdict.
+
+Decision rule (recommended slot only — `--auto` variants are user-opt-in
+alternatives surfaced by the Handoff menu, not picks the script makes):
+
+  candidate_curds = max(goals_bullets, quality_gates_bullets)
+  candidate_curds >= 5                   -> /cheese-factory
+  candidate_curds <  5 and blast == high -> /ultracook
+  candidate_curds <  5 (else)            -> /cook
+
+The count is a signal, not a verdict — mold and the user must confirm
+file-disjointness (criterion 4) before dispatching /cheese-factory.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+CURD_THRESHOLD = 5
+
+HEADING_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+BULLET_RE = re.compile(r"^\s*[-*+]\s+\S", re.MULTILINE)
+
+GOALS_HEADINGS = {"goals", "goal"}
+QUALITY_GATES_HEADINGS = {
+    "quality gates",
+    "quality gate",
+    "acceptance criteria",
+    "acceptance",
+}
+DECISIONS_HEADINGS = {"decisions", "decision"}
+
+
+def _extract_section(body: str, headings: set[str]) -> str | None:
+    matches = list(HEADING_RE.finditer(body))
+    for i, match in enumerate(matches):
+        if match.group(1).strip().lower() in headings:
+            start = match.end()
+            end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+            return body[start:end]
+    return None
+
+
+def _count_bullets(section: str | None) -> int:
+    if not section:
+        return 0
+    return sum(1 for _ in BULLET_RE.finditer(section))
+
+
+def _recommend(candidate_curds: int, blast_radius: str | None) -> tuple[str, str]:
+    if candidate_curds >= CURD_THRESHOLD:
+        return (
+            "/cheese-factory",
+            f"{candidate_curds} candidate curds >= {CURD_THRESHOLD} threshold",
+        )
+    radius = (blast_radius or "").lower()
+    if radius == "high":
+        return (
+            "/ultracook",
+            f"{candidate_curds} candidate curds < {CURD_THRESHOLD}; blast radius high",
+        )
+    return (
+        "/cook",
+        f"{candidate_curds} candidate curds < {CURD_THRESHOLD}; "
+        f"blast radius {radius or 'unknown'}",
+    )
+
+
+def analyze(spec_path: Path, blast_radius: str | None) -> dict:
+    body = spec_path.read_text()
+    goals = _count_bullets(_extract_section(body, GOALS_HEADINGS))
+    quality_gates = _count_bullets(_extract_section(body, QUALITY_GATES_HEADINGS))
+    decisions = _count_bullets(_extract_section(body, DECISIONS_HEADINGS))
+
+    candidate_curds = max(goals, quality_gates)
+    recommended, rationale = _recommend(candidate_curds, blast_radius)
+
+    return {
+        "spec_path": str(spec_path),
+        "slug": spec_path.stem,
+        "blast_radius": blast_radius,
+        "candidate_curds": candidate_curds,
+        "signals": {
+            "goals": goals,
+            "quality_gates": quality_gates,
+            "decisions": decisions,
+        },
+        "threshold": CURD_THRESHOLD,
+        "decomposable": candidate_curds >= CURD_THRESHOLD,
+        "recommended_skill": recommended,
+        "rationale": rationale,
+        "notes": [
+            "Count is a signal, not a verdict.",
+            "Confirm curd independence (criterion 4: file-disjoint) before dispatching /cheese-factory.",
+        ],
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description=(__doc__ or "").splitlines()[0],
+    )
+    parser.add_argument(
+        "spec_path",
+        type=Path,
+        help="Path to the spec markdown file (typically .cheese/specs/<slug>.md).",
+    )
+    parser.add_argument(
+        "--blast-radius",
+        choices=["low", "medium", "high"],
+        help="Verdict from mold's shape-check; drives the recommendation when curds < threshold.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.spec_path.exists():
+        print(f"error: spec not found: {args.spec_path}", file=sys.stderr)
+        return 2
+    if not args.spec_path.is_file():
+        print(f"error: not a file: {args.spec_path}", file=sys.stderr)
+        return 2
+
+    digest = analyze(args.spec_path, args.blast_radius)
+    json.dump(digest, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/skills/mold/scripts/curd-count.py
+++ b/skills/mold/scripts/curd-count.py
@@ -75,8 +75,23 @@ def _recommend(candidate_curds: int, blast_radius: str | None) -> tuple[str, str
     )
 
 
+class SpecReadError(Exception):
+    """Raised when the spec file cannot be read or decoded."""
+
+
+def _read_spec(spec_path: Path) -> str:
+    try:
+        return spec_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        raise SpecReadError(
+            f"spec is not valid UTF-8 ({exc.reason} at byte {exc.start})"
+        ) from exc
+    except OSError as exc:
+        raise SpecReadError(f"could not read spec: {exc.strerror or exc}") from exc
+
+
 def analyze(spec_path: Path, blast_radius: str | None) -> dict:
-    body = spec_path.read_text()
+    body = _read_spec(spec_path)
     goals = _count_bullets(_extract_section(body, GOALS_HEADINGS))
     quality_gates = _count_bullets(_extract_section(body, QUALITY_GATES_HEADINGS))
     decisions = _count_bullets(_extract_section(body, DECISIONS_HEADINGS))
@@ -128,7 +143,11 @@ def main(argv: list[str]) -> int:
         print(f"error: not a file: {args.spec_path}", file=sys.stderr)
         return 2
 
-    digest = analyze(args.spec_path, args.blast_radius)
+    try:
+        digest = analyze(args.spec_path, args.blast_radius)
+    except SpecReadError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     json.dump(digest, sys.stdout, indent=2)
     sys.stdout.write("\n")
     return 0

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,7 +1,7 @@
 """Shared pytest config.
 
-The melt scripts use hyphenated filenames that can't be imported by the
-normal `import` machinery, so we load them by path with importlib.
+The melt and mold scripts use hyphenated filenames that can't be imported by
+the normal `import` machinery, so we load them by path with importlib.
 """
 
 from __future__ import annotations
@@ -14,6 +14,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / "skills" / "melt" / "scripts"
+MOLD_SCRIPTS_DIR = REPO_ROOT / "skills" / "mold" / "scripts"
 SHARED_SCRIPTS = REPO_ROOT / "shared" / "scripts"
 
 
@@ -49,3 +50,8 @@ def batch_resolve() -> ModuleType:
 @pytest.fixture(scope="session")
 def detect_squash_residue() -> ModuleType:
     return _load("detect_squash_residue", SCRIPTS_DIR / "detect-squash-residue.py")
+
+
+@pytest.fixture(scope="session")
+def curd_count() -> ModuleType:
+    return _load("curd_count", MOLD_SCRIPTS_DIR / "curd-count.py")

--- a/tests/python/test_curd_count.py
+++ b/tests/python/test_curd_count.py
@@ -1,0 +1,334 @@
+"""Tests for skills/mold/scripts/curd-count.py.
+
+Covers section extraction, bullet counting, the recommendation decision rule,
+the full analyze() digest, and the CLI entry point. Pure functions plus a
+synthetic spec on disk; no real specs touched.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SPEC_LARGE = """\
+---
+slug: ignored-by-stem
+---
+
+# Big spec
+
+## Problem
+Many things.
+
+## Goals
+- Add A
+- Add B
+- Add C
+- Add D
+- Add E
+- Add F
+- Add G
+
+## Approach
+Hexagonal-ish.
+
+## Decisions
+- Use JWT — less server state
+- Postgres — already in stack
+
+## Quality gates
+- `pytest tests/a`: green
+- `pytest tests/b`: green
+- `pytest tests/c`: green
+"""
+
+SPEC_SMALL = """\
+---
+slug: ignored
+---
+
+# Small spec
+
+## Goals
+- Fix the bug
+
+## Quality gates
+- `pytest tests/auth`: green
+"""
+
+SPEC_EMPTY = """\
+# Spec with no goals or gates
+
+## Problem
+Nothing actionable yet.
+"""
+
+
+class TestExtractSection:
+    def test_returns_none_when_heading_missing(self, curd_count: ModuleType) -> None:
+        assert curd_count._extract_section("# title\n", {"goals"}) is None
+
+    def test_matches_exact_heading(self, curd_count: ModuleType) -> None:
+        body = "## Goals\n- one\n- two\n"
+        section = curd_count._extract_section(body, {"goals"})
+        assert section is not None
+        assert "- one" in section
+        assert "- two" in section
+
+    def test_case_insensitive(self, curd_count: ModuleType) -> None:
+        body = "## GOALS\n- one\n"
+        assert curd_count._extract_section(body, {"goals"}) is not None
+
+    def test_alias_matching(self, curd_count: ModuleType) -> None:
+        body = "## Acceptance criteria\n- one\n"
+        section = curd_count._extract_section(
+            body,
+            {"quality gates", "acceptance criteria"},
+        )
+        assert section is not None
+        assert "- one" in section
+
+    def test_stops_at_next_h2_heading(self, curd_count: ModuleType) -> None:
+        body = "## Goals\n- one\n- two\n\n## Approach\n- skip me\n"
+        section = curd_count._extract_section(body, {"goals"})
+        assert section is not None
+        assert "- one" in section
+        assert "- skip me" not in section
+
+    def test_last_section_extends_to_end(self, curd_count: ModuleType) -> None:
+        body = "## Approach\nstuff\n\n## Goals\n- final\n"
+        section = curd_count._extract_section(body, {"goals"})
+        assert section is not None
+        assert "- final" in section
+
+
+class TestCountBullets:
+    def test_none_returns_zero(self, curd_count: ModuleType) -> None:
+        assert curd_count._count_bullets(None) == 0
+
+    def test_empty_returns_zero(self, curd_count: ModuleType) -> None:
+        assert curd_count._count_bullets("") == 0
+
+    def test_counts_dash_bullets(self, curd_count: ModuleType) -> None:
+        assert curd_count._count_bullets("- a\n- b\n- c\n") == 3
+
+    def test_counts_asterisk_and_plus_bullets(self, curd_count: ModuleType) -> None:
+        assert curd_count._count_bullets("* a\n+ b\n") == 2
+
+    def test_ignores_non_bullet_lines(self, curd_count: ModuleType) -> None:
+        assert curd_count._count_bullets("preamble\n- one\nmore prose\n- two\n") == 2
+
+    def test_counts_indented_bullets(self, curd_count: ModuleType) -> None:
+        assert curd_count._count_bullets("  - nested\n    - deeper\n") == 2
+
+    def test_ignores_bare_dash_separator(self, curd_count: ModuleType) -> None:
+        # The bullet regex requires a non-whitespace char after the marker,
+        # so "---" and "-" alone shouldn't count.
+        assert curd_count._count_bullets("---\n-\n") == 0
+
+
+class TestRecommend:
+    def test_threshold_picks_cheese_factory(self, curd_count: ModuleType) -> None:
+        skill, rationale = curd_count._recommend(5, "high")
+        assert skill == "/cheese-factory"
+        assert "5" in rationale
+
+    def test_above_threshold_picks_cheese_factory(self, curd_count: ModuleType) -> None:
+        skill, _ = curd_count._recommend(12, "low")
+        assert skill == "/cheese-factory"
+
+    def test_below_threshold_high_blast_picks_ultracook(
+        self, curd_count: ModuleType
+    ) -> None:
+        skill, rationale = curd_count._recommend(4, "high")
+        assert skill == "/ultracook"
+        assert "high" in rationale
+
+    def test_below_threshold_medium_blast_picks_cook(
+        self, curd_count: ModuleType
+    ) -> None:
+        skill, _ = curd_count._recommend(3, "medium")
+        assert skill == "/cook"
+
+    def test_below_threshold_low_blast_picks_cook(self, curd_count: ModuleType) -> None:
+        skill, _ = curd_count._recommend(1, "low")
+        assert skill == "/cook"
+
+    def test_below_threshold_unknown_blast_picks_cook(
+        self, curd_count: ModuleType
+    ) -> None:
+        skill, rationale = curd_count._recommend(2, None)
+        assert skill == "/cook"
+        assert "unknown" in rationale
+
+    def test_blast_radius_case_insensitive(self, curd_count: ModuleType) -> None:
+        skill, _ = curd_count._recommend(3, "HIGH")
+        assert skill == "/ultracook"
+
+
+class TestAnalyze:
+    def _write(self, tmp_path: Path, name: str, body: str) -> Path:
+        path = tmp_path / name
+        path.write_text(body)
+        return path
+
+    def test_decomposable_spec_recommends_cheese_factory(
+        self, curd_count: ModuleType, tmp_path: Path
+    ) -> None:
+        spec = self._write(tmp_path, "big.md", SPEC_LARGE)
+        digest = curd_count.analyze(spec, "high")
+        assert digest["candidate_curds"] == 7
+        assert digest["decomposable"] is True
+        assert digest["recommended_skill"] == "/cheese-factory"
+
+    def test_small_spec_high_blast_recommends_ultracook(
+        self, curd_count: ModuleType, tmp_path: Path
+    ) -> None:
+        spec = self._write(tmp_path, "small.md", SPEC_SMALL)
+        digest = curd_count.analyze(spec, "high")
+        assert digest["candidate_curds"] == 1
+        assert digest["decomposable"] is False
+        assert digest["recommended_skill"] == "/ultracook"
+
+    def test_small_spec_low_blast_recommends_cook(
+        self, curd_count: ModuleType, tmp_path: Path
+    ) -> None:
+        spec = self._write(tmp_path, "small.md", SPEC_SMALL)
+        digest = curd_count.analyze(spec, "low")
+        assert digest["recommended_skill"] == "/cook"
+
+    def test_small_spec_no_blast_radius_recommends_cook(
+        self, curd_count: ModuleType, tmp_path: Path
+    ) -> None:
+        spec = self._write(tmp_path, "small.md", SPEC_SMALL)
+        digest = curd_count.analyze(spec, None)
+        assert digest["recommended_skill"] == "/cook"
+
+    def test_candidate_curds_is_max_of_goals_and_gates(
+        self, curd_count: ModuleType, tmp_path: Path
+    ) -> None:
+        # SPEC_LARGE has 7 goals + 3 gates; max is 7.
+        spec = self._write(tmp_path, "big.md", SPEC_LARGE)
+        digest = curd_count.analyze(spec, "high")
+        assert digest["signals"]["goals"] == 7
+        assert digest["signals"]["quality_gates"] == 3
+        assert digest["candidate_curds"] == 7
+
+    def test_decisions_counted_but_not_used(
+        self, curd_count: ModuleType, tmp_path: Path
+    ) -> None:
+        spec = self._write(tmp_path, "big.md", SPEC_LARGE)
+        digest = curd_count.analyze(spec, "high")
+        assert digest["signals"]["decisions"] == 2
+
+    def test_empty_spec_yields_zero_candidates(
+        self, curd_count: ModuleType, tmp_path: Path
+    ) -> None:
+        spec = self._write(tmp_path, "empty.md", SPEC_EMPTY)
+        digest = curd_count.analyze(spec, "high")
+        assert digest["candidate_curds"] == 0
+        assert digest["decomposable"] is False
+        assert digest["recommended_skill"] == "/ultracook"
+
+    def test_slug_extracted_from_filename(
+        self, curd_count: ModuleType, tmp_path: Path
+    ) -> None:
+        spec = self._write(tmp_path, "my-feature-slug.md", SPEC_SMALL)
+        digest = curd_count.analyze(spec, "low")
+        assert digest["slug"] == "my-feature-slug"
+
+    def test_digest_has_all_expected_keys(
+        self, curd_count: ModuleType, tmp_path: Path
+    ) -> None:
+        spec = self._write(tmp_path, "small.md", SPEC_SMALL)
+        digest = curd_count.analyze(spec, "low")
+        expected = {
+            "spec_path",
+            "slug",
+            "blast_radius",
+            "candidate_curds",
+            "signals",
+            "threshold",
+            "decomposable",
+            "recommended_skill",
+            "rationale",
+            "notes",
+        }
+        assert expected <= set(digest.keys())
+
+    def test_threshold_field_matches_constant(
+        self, curd_count: ModuleType, tmp_path: Path
+    ) -> None:
+        spec = self._write(tmp_path, "small.md", SPEC_SMALL)
+        digest = curd_count.analyze(spec, "low")
+        assert digest["threshold"] == curd_count.CURD_THRESHOLD
+
+    def test_notes_warn_about_independence(
+        self, curd_count: ModuleType, tmp_path: Path
+    ) -> None:
+        spec = self._write(tmp_path, "small.md", SPEC_SMALL)
+        digest = curd_count.analyze(spec, "low")
+        joined = " ".join(digest["notes"])
+        assert "criterion 4" in joined
+        assert "signal" in joined or "verdict" in joined
+
+
+class TestMain:
+    def test_missing_file_exits_with_2(
+        self, curd_count: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code = curd_count.main([str(tmp_path / "nope.md")])
+        assert exit_code == 2
+        err = capsys.readouterr().err
+        assert "not found" in err
+
+    def test_directory_exits_with_2(
+        self, curd_count: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        exit_code = curd_count.main([str(tmp_path)])
+        assert exit_code == 2
+        err = capsys.readouterr().err
+        assert "not a file" in err
+
+    def test_valid_file_returns_0_and_emits_json(
+        self, curd_count: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        spec = tmp_path / "small.md"
+        spec.write_text(SPEC_SMALL)
+        exit_code = curd_count.main([str(spec), "--blast-radius", "high"])
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        digest = json.loads(out)
+        assert digest["recommended_skill"] == "/ultracook"
+        assert digest["blast_radius"] == "high"
+
+    def test_no_blast_radius_arg_still_works(
+        self, curd_count: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        spec = tmp_path / "small.md"
+        spec.write_text(SPEC_SMALL)
+        exit_code = curd_count.main([str(spec)])
+        assert exit_code == 0
+        digest = json.loads(capsys.readouterr().out)
+        assert digest["blast_radius"] is None
+        assert digest["recommended_skill"] == "/cook"
+
+    def test_invalid_blast_radius_rejected_by_argparse(
+        self, curd_count: ModuleType, tmp_path: Path
+    ) -> None:
+        spec = tmp_path / "small.md"
+        spec.write_text(SPEC_SMALL)
+        with pytest.raises(SystemExit):
+            curd_count.main([str(spec), "--blast-radius", "extreme"])
+
+    def test_emits_trailing_newline(
+        self, curd_count: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        spec = tmp_path / "small.md"
+        spec.write_text(SPEC_SMALL)
+        curd_count.main([str(spec)])
+        out = capsys.readouterr().out
+        assert out.endswith("\n")

--- a/tests/python/test_curd_count.py
+++ b/tests/python/test_curd_count.py
@@ -332,3 +332,31 @@ class TestMain:
         curd_count.main([str(spec)])
         out = capsys.readouterr().out
         assert out.endswith("\n")
+
+
+class TestSpecReadError:
+    def test_analyze_raises_on_non_utf8(
+        self, curd_count: ModuleType, tmp_path: Path
+    ) -> None:
+        spec = tmp_path / "bad-encoding.md"
+        # latin-1-only bytes that are invalid UTF-8 start sequences
+        spec.write_bytes(b"## Goals\n- bad byte: \xff\n")
+        with pytest.raises(curd_count.SpecReadError) as exc_info:
+            curd_count.analyze(spec, "low")
+        assert "UTF-8" in str(exc_info.value)
+
+    def test_main_returns_2_on_non_utf8(
+        self, curd_count: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        spec = tmp_path / "bad-encoding.md"
+        spec.write_bytes(b"## Goals\n- bad byte: \xff\n")
+        exit_code = curd_count.main([str(spec)])
+        assert exit_code == 2
+        err = capsys.readouterr().err
+        assert "UTF-8" in err
+        # Stack trace must not leak — only the clean error line.
+        assert "Traceback" not in err
+
+    def test_specreaderror_is_exception_subclass(self, curd_count: ModuleType) -> None:
+        # Importable as a public type so callers can catch it specifically.
+        assert issubclass(curd_count.SpecReadError, Exception)


### PR DESCRIPTION
## Summary

Closes the gap where `/mold` doesn't surface `/cheese-factory` as an option in the handoff menu.

Adds a Python script (`skills/mold/scripts/curd-count.py`) that detects whether a spec decomposes into 5+ independent behavioural curds. When it does, mold recommends `/cheese-factory` for fan-out parallel implementation with reviewable PRs; otherwise it recommends `/ultracook` (high blast) or `/cook` (low/medium) per the existing blast-radius verdict.

The script implements **heavy-touch decomposability detection** — moves the parse-and-count work into a deterministic Python subprocess to keep the token budget of the handoff decision light and deterministic.

## Changes

- `skills/mold/scripts/curd-count.py` (new) — counts `## Goals` and `## Quality gates` bullets, takes `candidate_curds = max(goals, quality_gates)` (the larger of the two signals; not a sum), emits JSON digest with curd count + recommended skill
- `skills/mold/references/curd-count.md` (new) — invocation contract, decision rule, output shape, fallback for missing python3
- `skills/mold/SKILL.md` — Flow step 6 invokes the script; Handoff section rewritten to branch on decomposability (`candidate_curds ≥ 5`) and surface `/cheese-factory` with dependency confirmation gate
- `tests/python/test_curd_count.py` (new) — 40 unit tests covering section extraction, bullet counting, all four decision-rule branches, digest shape, CLI behaviour, and the `SpecReadError` path

## Notes

- Script counts signals but doesn't verify file-disjointness (criterion 4). The handoff explicitly gates `/cheese-factory` dispatch on user confirmation of independence; if curds share files, the *(recommended)* marker shifts to `/ultracook` for that menu.
- Fallback for missing `python3`: mold renders `/cheese-factory` in the menu with a manual "5+ curds?" tagline and lets the user decide.
- Decision rule (recommended-slot only): `≥5 curds` → `/cheese-factory`; `<5 + high blast` → `/ultracook`; `<5 + medium/low/unknown` → `/cook`. `/cook --auto` is a user-opt-in alternative in the menu, never a recommended pick (matches the existing "Never pre-select; auto mode is opt-in" rule).
- When the shape-check verdict is `[?]` or skipped, callers omit `--blast-radius` — the script only accepts `low|medium|high` and degrades to `/cook` for sub-threshold specs without the flag.

## Testing

```bash
python3 -m pytest tests/python/test_curd_count.py -v  # 40 passed
just test                                              # full suite green
```
