### PR TITLE
refactor(scripts): succinctness pass across 14 scripts (−341 LOC)

### DIFF
--- a/.github/scripts/validate_skills.py
+++ b/.github/scripts/validate_skills.py
@@ -1,18 +1,5 @@
 #!/usr/bin/env python3
-"""Validate every SKILL.md in the repository.
-
-Per-file checks:
-- Lives at exactly skills/<name>/SKILL.md (no scope, no nested sub-skills).
-- Begins with a YAML frontmatter block (--- ... ---). CRLF and missing
-  trailing newline are tolerated.
-- Frontmatter parses as a YAML mapping.
-- Required keys present and non-empty: name, description.
-- Only spec-allowed keys (plus Claude Code extensions) are present.
-- name is kebab-case, 1-64 chars, no leading/trailing/consecutive hyphens.
-- name matches the parent directory name.
-
-Exit 0 on success, 1 on any failure.
-"""
+"""Validate every SKILL.md in the repository. Exit 0 on success, 1 on any failure."""
 from __future__ import annotations
 
 import re
@@ -20,6 +7,13 @@ import sys
 from pathlib import Path
 
 import yaml
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SHARED_SCRIPTS = SCRIPT_DIR.parents[1] / "shared" / "scripts"
+if str(SHARED_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SHARED_SCRIPTS))
+
+from paths import KEBAB_SLUG  # noqa: E402
 
 ALLOWED_KEYS = {
     "name",
@@ -38,7 +32,6 @@ ALLOWED_KEYS = {
     "hooks",
 }
 
-NAME_RE = re.compile(r"^(?!-)(?!.*--)[a-z0-9-]{1,64}(?<!-)$")
 FRONTMATTER_RE = re.compile(r"\A---\r?\n(.*?)\r?\n---\s*(\r?\n|\Z)", re.DOTALL)
 
 # Codex rejects skills whose description exceeds 1024 characters.
@@ -78,7 +71,7 @@ def validate_frontmatter(path: Path) -> list[str]:
     elif not isinstance(name, str):
         errors.append(f"{path}: 'name' must be a string")
     else:
-        if not NAME_RE.match(name):
+        if not KEBAB_SLUG.match(name):
             errors.append(
                 f"{path}: name '{name}' is not kebab-case "
                 f"(1-64 chars, lowercase a-z 0-9, no leading/trailing/consecutive hyphens)"

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -71,7 +71,6 @@ def _split_anchor(path: str) -> tuple[str, str]:
 
 
 def rewrite_skill_link(url: str, skill_name: str) -> str:
-    """Rewrite link from skills/<name>/SKILL.md space to docs/skills/<name>.md space."""
     if url.startswith(("http://", "https://", "mailto:", "#")):
         return url
     path, anchor = _split_anchor(url)
@@ -105,7 +104,6 @@ def rewrite_skill_link(url: str, skill_name: str) -> str:
 
 
 def rewrite_ref_link(url: str, skill_name: str) -> str:
-    """Rewrite link from skills/<name>/references/<file>.md to docs/skills/<name>/references/<file>.md."""
     if url.startswith(("http://", "https://", "mailto:", "#")):
         return url
     path, anchor = _split_anchor(url)
@@ -132,7 +130,6 @@ def rewrite_ref_link(url: str, skill_name: str) -> str:
 
 
 def rewrite_root_passthrough_link(url: str) -> str:
-    """Rewrite link inside CONTRIBUTING/SECURITY/CODE_OF_CONDUCT after they move into docs/."""
     if url.startswith(("http://", "https://", "mailto:", "#")):
         return url
     path, anchor = _split_anchor(url)
@@ -246,13 +243,7 @@ def extract_h2_section(
     drop_header: bool = False,
     bump_headings: bool = False,
 ) -> str:
-    """Return the body of a `## <title>` section from a Markdown document.
-
-    Stops at the next `## ` header. With ``drop_header`` the section's own
-    `## <title>` line is omitted; with ``bump_headings`` every `###` inside
-    the section is promoted to `##` (used when the section's H2 wrapper is
-    dropped, to keep heading hierarchy contiguous under the page H1).
-    """
+    # Stops at the next `## ` header.
     out: list[str] = []
     in_section = False
     for line in text.splitlines(keepends=True):
@@ -273,7 +264,6 @@ def extract_h2_section(
 
 
 def emit_install_page() -> bool:
-    """Generate docs/install.md by slicing README.md's install-related H2s."""
     src = REPO_ROOT / "README.md"
     if not src.exists():
         return False
@@ -331,18 +321,7 @@ def emit_root_passthrough(filename: str, dest: str, title: str) -> bool:
 
 
 def emit_shared_pages() -> list[tuple[str, str]]:
-    """Emit shared/<file>.md into docs/shared/<file>.md.
-
-    The shared/ directory holds cross-skill contracts (e.g. handoff-gate.md)
-    that skill SKILL.md bodies reference via ``../../shared/<file>.md``. That
-    relative path already resolves correctly from docs/skills/<name>.md to
-    docs/shared/<file>.md, so no link rewriting is needed — but the target
-    file has to exist in the docs tree, and mkdocs --strict requires it to
-    be in the nav.
-
-    Returns ``(title, docs_path)`` pairs for ``emit_nav`` to render under a
-    "Shared contracts" section.
-    """
+    # mkdocs --strict requires shared files to exist in the docs tree and the nav.
     if not SHARED_DIR.is_dir():
         return []
 

--- a/shared/scripts/gates.py
+++ b/shared/scripts/gates.py
@@ -1,11 +1,4 @@
-"""Readiness verdicts and iteration caps shared across press / cure / age.
-
-Two-cure-pass cap (see skills/cook/SKILL.md § Auto mode, skills/age/SKILL.md):
-the age → cure cycle in an auto chain stops after the second cure pass writes
-its handoff. Centralising the counter makes the cap testable and prevents
-drift when the chain shape changes.
-
-Press readiness verdict (see skills/press/SKILL.md § Rules):
+"""Press readiness verdict (see skills/press/SKILL.md § Rules):
 
     ready for /age          hard floor met, level-1/3 gaps closed
     follow-up recommended   hard floor met, only level-4/5 gaps remain
@@ -14,35 +7,13 @@ Press readiness verdict (see skills/press/SKILL.md § Rules):
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from enum import Enum
-
-CURE_PASS_CAP = 2
-GAP_ITERATION_CAP = 3  # skills/press/SKILL.md § Spinning-wheels rule
 
 
 class Readiness(str, Enum):
     READY = "ready for /age"
     FOLLOW_UP = "follow-up recommended"
     BLOCKED = "blocked"
-
-
-@dataclass
-class GapState:
-    """Per-gap state for the iteration-cap rule."""
-
-    name: str
-    attempts: int = 0
-    closed: bool = False
-
-    def record_attempt(self) -> None:
-        self.attempts += 1
-
-    def close(self) -> None:
-        self.closed = True
-
-    def is_spinning(self, cap: int = GAP_ITERATION_CAP) -> bool:
-        return not self.closed and self.attempts >= cap
 
 
 def classify_readiness(
@@ -53,13 +24,6 @@ def classify_readiness(
     has_open_level_4_or_5: bool,
     any_spinning: bool,
 ) -> Readiness:
-    """Map the press scoreboard to a readiness verdict.
-
-    Inputs are booleans because the underlying gap taxonomy
-    (skills/press/references/gap-analysis.md) demands model judgment to
-    classify each gap's level. The function then maps the deterministic
-    summary state to the verdict.
-    """
     # hard_floor_met is a precondition: without it, the press scoreboard is
     # incomplete (failing gates, missing tests, etc.) and the verdict is
     # BLOCKED regardless of which gap levels are still open.
@@ -70,29 +34,3 @@ def classify_readiness(
     if has_open_level_4_or_5:
         return Readiness.FOLLOW_UP
     return Readiness.READY
-
-
-@dataclass
-class CurePassCounter:
-    """Track cure passes in an auto-mode chain. Cap is enforced inside /age."""
-
-    completed: int = 0
-    cap: int = CURE_PASS_CAP
-
-    def record_pass(self) -> None:
-        self.completed += 1
-
-    @property
-    def at_cap(self) -> bool:
-        return self.completed >= self.cap
-
-    def next_action(self) -> str:
-        """Return the next chain action: 'cure' (more passes allowed) or 'done'."""
-        if self.completed >= self.cap:
-            return "done"
-        return "cure"
-
-
-def detect_halt(status: str, halt_reason: str | None) -> bool:
-    """Mirror handoff.HandoffSlug.is_halt for code that only has the strings."""
-    return status == "halt" and bool(halt_reason)

--- a/shared/scripts/git_utils.py
+++ b/shared/scripts/git_utils.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Shared git utilities for melt skill."""
+"""Git subprocess wrappers and conflict-marker helpers."""
 
 from __future__ import annotations
 

--- a/shared/scripts/paths.py
+++ b/shared/scripts/paths.py
@@ -39,10 +39,6 @@ PHASES: frozenset[str] = frozenset(
 CHAIN_PHASES: tuple[str, ...] = ("cook", "press", "age", "cure")
 
 
-def is_valid_slug(slug: str) -> bool:
-    return bool(KEBAB_SLUG.match(slug))
-
-
 def validate_slug(slug: str) -> str | None:
     """Return an error string if invalid, else None."""
     if not isinstance(slug, str) or not slug:
@@ -83,12 +79,9 @@ def artifact_path(phase: str, slug: str, *, root: Path | str = ".cheese") -> Pat
 
 
 def parse_artifact_path(path: Path | str) -> tuple[str, str]:
-    """Extract (phase, slug) from a canonical ``.cheese/<phase>/<slug>.md`` path.
-
-    Only the canonical root is parsed — paths produced by ``artifact_path``
-    with a custom ``root=`` argument (e.g. a pytest ``tmp_path``) are not
-    round-trippable here. Callers operating outside ``.cheese/`` should
-    construct (phase, slug) themselves.
+    """Only the canonical ``.cheese/`` root is parsed. Paths produced by
+    ``artifact_path`` with a custom ``root=`` (e.g. pytest ``tmp_path``)
+    are not round-trippable here.
     """
     p = Path(path)
     parts = p.parts

--- a/skills/cheese-factory/scripts/pr_plan_to_branches.py
+++ b/skills/cheese-factory/scripts/pr_plan_to_branches.py
@@ -50,11 +50,7 @@ Supported shapes (from the plan's "shape" field):
 
 
 def sq(value: str) -> str:
-    """Single-quote a value for a POSIX shell command line, always wrapping.
-
-    Mirrors the four-character escape used by the previous bash implementation:
-    close quote, backslash-escaped quote, open quote — ``'\\''``.
-    """
+    # Single-quote a value for POSIX shell using the four-character escape '\''.
     return "'" + value.replace("'", "'\\''") + "'"
 
 

--- a/skills/cheese-factory/scripts/validate_decomposition.py
+++ b/skills/cheese-factory/scripts/validate_decomposition.py
@@ -1,24 +1,5 @@
 #!/usr/bin/env python3
-"""Validate a cheese-factory decomposition manifest against the five criteria.
-
-Reads a manifest YAML/JSON file (or stdin), runs the validation checks below, and
-either exits 0 (valid) or 1 (invalid, with one error per line on stderr).
-
-Checks:
-
-1. Behaviour overlap — each curd's behaviour is a single declarative sentence
-   without an "and" joining two distinct verbs.
-2. Acceptance criterion presence — every curd names its AC; 1:1 spec coverage
-   is decomposer-side (the validator can't read the spec file).
-3. Test target check — each curd has a non-empty test_target.
-4. File disjointness — no file appears in two curds.
-5. Wiring DAG check — no cycles, every depends_on references a known wiring id.
-6. Seed minimality — seed files are foundational (validation here only checks
-   the field exists; the "2+ curds depend on" check is decomposer-side because
-   curd file-imports aren't represented in the manifest).
-
-The script accepts YAML via PyYAML and JSON via the stdlib json module.
-"""
+"""Validate a cheese-factory decomposition manifest. Exit 0 on success, 1 on errors (one per line on stderr)."""
 from __future__ import annotations
 
 import re
@@ -52,7 +33,6 @@ _TWO_VERB_AND = re.compile(
 
 
 def check_one_behaviour(curd: dict) -> str | None:
-    """Criterion 1: one behaviour per curd."""
     behavior = curd.get("behavior", "")
     if not isinstance(behavior, str) or not behavior.strip():
         return f"curd {curd.get('id', '?')}: missing or empty 'behavior'"
@@ -65,7 +45,6 @@ def check_one_behaviour(curd: dict) -> str | None:
 
 
 def check_acceptance_criterion(curd: dict) -> str | None:
-    """Criterion 2: one acceptance criterion."""
     ac = curd.get("acceptance_criterion", "")
     if not isinstance(ac, str) or not ac.strip():
         return f"curd {curd.get('id', '?')}: missing or empty 'acceptance_criterion'"
@@ -73,7 +52,6 @@ def check_acceptance_criterion(curd: dict) -> str | None:
 
 
 def check_test_target(curd: dict) -> str | None:
-    """Criterion 3: one test target."""
     tt = curd.get("test_target", "")
     if not isinstance(tt, str) or not tt.strip():
         return f"curd {curd.get('id', '?')}: missing or empty 'test_target'"
@@ -116,7 +94,6 @@ def check_file_disjointness(curds: Iterable[dict]) -> list[str]:
 
 
 def check_wiring_dag(wiring: Iterable[dict]) -> list[str]:
-    """Criterion: wiring DAG has no cycles and references only known ids."""
     # Drop non-dict entries up front — the validator is a user-facing CLI and
     # a stack trace on garbage input is a usability defect (mirrors the
     # check_file_disjointness defense for curds[]).
@@ -163,18 +140,17 @@ def check_wiring_dag(wiring: Iterable[dict]) -> list[str]:
     return errors
 
 
-def check_minimum_curd_count(curds: list[dict], minimum: int = 5) -> str | None:
+def check_minimum_curd_count(curds: list[dict]) -> str | None:
     """The spec routes to /ultracook below five curds."""
-    if len(curds) < minimum:
+    if len(curds) < 5:
         return (
-            f"only {len(curds)} curd(s) — /cheese-factory requires at least {minimum}; "
+            f"only {len(curds)} curd(s) — /cheese-factory requires at least 5; "
             f"use /ultracook for smaller decompositions"
         )
     return None
 
 
 def validate_manifest(manifest: dict) -> list[str]:
-    """Run every check; return a list of error strings (empty = valid)."""
     errors: list[str] = []
     curds = manifest.get("curds", [])
     if not isinstance(curds, list):

--- a/skills/cheese-factory/scripts/validate_manifest.py
+++ b/skills/cheese-factory/scripts/validate_manifest.py
@@ -144,7 +144,6 @@ def _validate_post_review(post_review: object) -> list[str]:
 
 
 def validate_run_manifest(manifest: dict[str, Any]) -> list[str]:
-    """Return validation errors for a cheese-factory run manifest."""
     errors: list[str] = []
     required = (
         "slug",

--- a/skills/cheese-factory/scripts/validate_pr_plan.py
+++ b/skills/cheese-factory/scripts/validate_pr_plan.py
@@ -20,7 +20,7 @@ for _path in (SCRIPT_DIR, SHARED_SCRIPTS):
         sys.path.insert(0, str(_path))
 
 from manifest_io import ManifestLoadError, read_mapping_arg_or_stdin
-from schema import non_empty_string, type_name
+from schema import non_empty_string, string_list, type_name
 
 SHAPES = {"single", "orthogonal_flat", "stacked_linear", "diamond_stack"}
 BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
@@ -43,20 +43,7 @@ def _validate_commits(commits: object, where: str) -> list[str]:
     return errors
 
 
-def _validate_depends_on(depends_on: object, where: str) -> list[str]:
-    if depends_on is None:
-        return []
-    if not isinstance(depends_on, list):
-        return [f"{where}.depends_on must be a list when present"]
-    errors: list[str] = []
-    for index, dep in enumerate(depends_on, start=1):
-        if not isinstance(dep, str) or not dep.strip():
-            errors.append(f"{where}.depends_on[{index}] must be a non-empty string")
-    return errors
-
-
 def validate_pr_plan(plan: dict[str, Any]) -> list[str]:
-    """Return validation errors for a pr-plan document."""
     errors: list[str] = []
     shape = plan.get("shape")
     if shape not in SHAPES:
@@ -91,7 +78,7 @@ def validate_pr_plan(plan: dict[str, Any]) -> list[str]:
                 errors.append(f"{where}.branch contains characters unsafe for a branch name")
 
         errors.extend(_validate_commits(group.get("commits"), where))
-        errors.extend(_validate_depends_on(group.get("depends_on", []), where))
+        errors.extend(string_list(group.get("depends_on") or [], f"{where}.depends_on"))
 
     if shape == "single" and len(groups) != 1:
         errors.append("single shape must contain exactly one group")

--- a/skills/cheese-factory/scripts/validate_pr_plan.py
+++ b/skills/cheese-factory/scripts/validate_pr_plan.py
@@ -78,7 +78,9 @@ def validate_pr_plan(plan: dict[str, Any]) -> list[str]:
                 errors.append(f"{where}.branch contains characters unsafe for a branch name")
 
         errors.extend(_validate_commits(group.get("commits"), where))
-        errors.extend(string_list(group.get("depends_on") or [], f"{where}.depends_on"))
+        depends_on = group.get("depends_on")
+        if depends_on is not None:
+            errors.extend(string_list(depends_on, f"{where}.depends_on"))
 
     if shape == "single" and len(groups) != 1:
         errors.append("single shape must contain exactly one group")

--- a/skills/melt/scripts/batch-resolve.py
+++ b/skills/melt/scripts/batch-resolve.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -25,16 +26,7 @@ from git_utils import (
 )
 
 
-def check_mergiraf_available() -> bool:
-    try:
-        result = subprocess.run(["mergiraf", "--version"], capture_output=True, text=True)
-        return result.returncode == 0
-    except FileNotFoundError:
-        return False
-
-
 def resolve_file(path: str, dry_run: bool = True, verbose: bool = False) -> dict:
-    """Attempt to resolve a single file with mergiraf. Returns status dict."""
     result = {
         "path": path,
         "supported": is_mergiraf_supported(path),
@@ -111,11 +103,7 @@ def resolve_file(path: str, dry_run: bool = True, verbose: bool = False) -> dict
 
 
 def debug_file(path: str, keep_dir: str | None = None) -> dict:
-    """Run mergiraf on a single file with debug logging; keep the tempdir for inspection.
-
-    Returns a dict describing where the artifacts live. Never modifies the working
-    tree — the caller inspects the merged output manually.
-    """
+    """Run mergiraf with debug logging; never modifies the working tree."""
     result = {
         "path": path,
         "supported": is_mergiraf_supported(path),
@@ -266,7 +254,7 @@ def main():
 
     args = parser.parse_args()
 
-    if not check_mergiraf_available():
+    if not shutil.which("mergiraf"):
         print("mergiraf not found — install with: cargo install mergiraf", file=sys.stderr)
         return 1
 

--- a/skills/melt/scripts/conflict-summary.py
+++ b/skills/melt/scripts/conflict-summary.py
@@ -104,7 +104,6 @@ def _render_hunk_terse(hunk: dict) -> list[str]:
 
 
 def format_terse_output(summaries: list) -> str:
-    """Compact, LLM-oriented format. One header line per file, minimal hunk framing."""
     if not summaries:
         return "no conflicts"
 
@@ -151,7 +150,6 @@ def _render_hunk_verbose(hunk: dict) -> list[str]:
 
 
 def format_verbose_output(summaries: list) -> str:
-    """Markdown-formatted human view, retained for --verbose."""
     if not summaries:
         return "No conflicted files found."
 

--- a/skills/melt/scripts/detect-squash-residue.py
+++ b/skills/melt/scripts/detect-squash-residue.py
@@ -72,9 +72,6 @@ def _commits_since(base: str, head: str = "HEAD") -> list[dict] | None:
     return commits
 
 
-def _gh_available() -> bool:
-    return shutil.which("gh") is not None
-
 
 def _base_branch_name(base_ref: str) -> str:
     """Strip the remote prefix from a base ref so it matches gh's --base flag.
@@ -93,7 +90,7 @@ def _base_branch_name(base_ref: str) -> str:
 
 
 def _check_via_gh(branch: str, base_ref: str) -> dict | None:
-    if not _gh_available():
+    if shutil.which("gh") is None:
         return None
     cmd = [
         "gh", "pr", "list",
@@ -170,11 +167,7 @@ def _build_tree_match_result(
 
 
 def _check_via_tree_match(base_ref: str, head: str = "HEAD") -> dict | None:
-    """Find a commit on base whose tree equals the tree at some point on the
-    branch. That commit is a squash-equivalent of branch commits up to that
-    point — the canonical signature of a squash-merge.
-
-    Strongest of the three detection methods: works offline, through forks
+    """Strongest of the three detection methods: works offline, through forks
     and renames, and (unlike `_check_via_synthesis`) handles the case where
     the user has committed additional work on top of the squashed commits.
     """
@@ -313,15 +306,6 @@ def _build_reset_remedy(result: dict, base_ref: str, abort: str | None) -> dict:
     }
 
 
-def _build_remedies(result: dict, base_ref: str) -> list[dict]:
-    """Both remedies, non-destructive first so the user sees it as the default."""
-    abort = _in_progress_abort()
-    return [
-        _build_merge_remedy(base_ref, abort),
-        _build_reset_remedy(result, base_ref, abort),
-    ]
-
-
 def _gh_correlates_with_tree(gh: dict, tree: dict) -> bool:
     """True iff the gh PR is the same squash that tree-match found.
 
@@ -345,24 +329,6 @@ def _gh_merge_commit_disagrees(gh: dict, tree: dict) -> bool:
     """
     mc = gh.get("merge_commit")
     return bool(mc and mc != tree["squash_commit"])
-
-
-def _pr_metadata(gh: dict) -> dict:
-    return {
-        "number": gh["number"],
-        "url": gh["url"],
-        "merged_at": gh["merged_at"],
-        "merge_commit": gh["merge_commit"],
-    }
-
-
-def _warn_multiple_prs(result: dict, gh: dict) -> None:
-    """Both apply paths surface the same caveat when gh found more than one
-    merged PR — single edit point for the wording."""
-    if gh["multiple_prs"]:
-        result["warnings"].append(
-            "multiple merged PRs from this branch — using most recent"
-        )
 
 
 def _init_result(branch: str, base_ref: str, head_ref: str) -> dict:
@@ -397,8 +363,6 @@ def _apply_synth_fallback(result: dict, base_ref: str, head_ref: str) -> None:
 
 
 def _apply_tree_match_to_result(result: dict, tree: dict, gh: dict | None) -> None:
-    """Populate result with the tree-match verdict, enriched by gh when the
-    gh PR correlates with the squash."""
     result["verdict"] = "squash-merged"
     result["squash_commit"] = {
         "sha": tree["squash_commit"],
@@ -408,7 +372,7 @@ def _apply_tree_match_to_result(result: dict, tree: dict, gh: dict | None) -> No
     result["unique_commits"] = tree["unique_commits"]
     if gh and _gh_correlates_with_tree(gh, tree):
         result["method"] = "tree-match+gh"
-        result["pr"] = _pr_metadata(gh)
+        result["pr"] = {k: gh[k] for k in ("number", "url", "merged_at", "merge_commit")}
         result["squashed_shas"] = gh["pr_commits"]
         if _gh_merge_commit_disagrees(gh, tree):
             result["warnings"].append(
@@ -416,7 +380,8 @@ def _apply_tree_match_to_result(result: dict, tree: dict, gh: dict | None) -> No
                 f"differs from tree-match squash {tree['squash_commit'][:8]} — "
                 "PR commits overlap but the recorded squash may be a different one"
             )
-        _warn_multiple_prs(result, gh)
+        if gh["multiple_prs"]:
+            result["warnings"].append("multiple merged PRs from this branch — using most recent")
         return
     result["method"] = "tree-match"
     if gh:
@@ -428,8 +393,7 @@ def _apply_tree_match_to_result(result: dict, tree: dict, gh: dict | None) -> No
 
 
 def _apply_gh_only_to_result(result: dict, gh: dict) -> None:
-    """Populate result from gh alone when tree-match found nothing. Treat
-    zero SHA overlap as inconclusive (reused branch name or full rebase)."""
+    """Zero SHA overlap is treated as inconclusive (reused branch name or full rebase)."""
     squashed = set(gh["pr_commits"])
     unique = [c for c in result["branch_commits"] if c["sha"] not in squashed]
     matched = len(result["branch_commits"]) - len(unique)
@@ -442,10 +406,11 @@ def _apply_gh_only_to_result(result: dict, gh: dict) -> None:
         return
     result["verdict"] = "squash-merged"
     result["method"] = "gh-api"
-    result["pr"] = _pr_metadata(gh)
+    result["pr"] = {k: gh[k] for k in ("number", "url", "merged_at", "merge_commit")}
     result["squashed_shas"] = gh["pr_commits"]
     result["unique_commits"] = unique
-    _warn_multiple_prs(result, gh)
+    if gh["multiple_prs"]:
+        result["warnings"].append("multiple merged PRs from this branch — using most recent")
 
 
 def detect(branch: str, base_ref: str) -> dict:
@@ -480,7 +445,11 @@ def detect(branch: str, base_ref: str) -> dict:
         _apply_synth_fallback(result, base_ref, head_ref)
 
     if result["verdict"] == "squash-merged":
-        result["remedies"] = _build_remedies(result, base_ref)
+        abort = _in_progress_abort()
+        result["remedies"] = [
+            _build_merge_remedy(base_ref, abort),
+            _build_reset_remedy(result, base_ref, abort),
+        ]
 
     return result
 

--- a/skills/melt/scripts/lockfile-resolve.py
+++ b/skills/melt/scripts/lockfile-resolve.py
@@ -121,7 +121,7 @@ def resolve_lockfile(
         config["regen_cmd"],
         capture_output=True,
         text=True,
-        cwd=Path(lockfile_path).parent or ".",
+        cwd=Path(lockfile_path).parent,
     )
 
     if regen_result.returncode != 0:

--- a/skills/mold/scripts/curd-count.py
+++ b/skills/mold/scripts/curd-count.py
@@ -76,7 +76,7 @@ def _recommend(candidate_curds: int, blast_radius: str | None) -> tuple[str, str
 
 
 class SpecReadError(Exception):
-    """Raised when the spec file cannot be read or decoded."""
+    pass
 
 
 def _read_spec(spec_path: Path) -> str:

--- a/tests/cheese-factory/python/test_validate_manifest.py
+++ b/tests/cheese-factory/python/test_validate_manifest.py
@@ -172,6 +172,29 @@ class TestPrPlanValidator:
         plan["groups"][0].pop("body", None)
         assert validate_pr_plan.validate_pr_plan(plan) == []
 
+    def test_depends_on_omitted_is_allowed(self, validate_pr_plan: ModuleType) -> None:
+        plan = _pr_plan()
+        plan["groups"][0].pop("depends_on", None)
+        assert validate_pr_plan.validate_pr_plan(plan) == []
+
+    def test_depends_on_none_is_allowed(self, validate_pr_plan: ModuleType) -> None:
+        plan = _pr_plan()
+        plan["groups"][0]["depends_on"] = None
+        assert validate_pr_plan.validate_pr_plan(plan) == []
+
+    def test_depends_on_string_is_rejected(self, validate_pr_plan: ModuleType) -> None:
+        # Regression: `depends_on or []` silently accepted falsy non-lists.
+        plan = _pr_plan()
+        plan["groups"][0]["depends_on"] = ""
+        errors = validate_pr_plan.validate_pr_plan(plan)
+        assert any("depends_on must be a list" in error for error in errors)
+
+    def test_depends_on_non_list_is_rejected(self, validate_pr_plan: ModuleType) -> None:
+        plan = _pr_plan()
+        plan["groups"][0]["depends_on"] = "main"
+        errors = validate_pr_plan.validate_pr_plan(plan)
+        assert any("depends_on must be a list" in error for error in errors)
+
 
 class TestCLIs:
     def test_validate_manifest_cli_accepts_yaml(self, tmp_path: Path) -> None:

--- a/tests/python/test_detect_squash_residue.py
+++ b/tests/python/test_detect_squash_residue.py
@@ -527,14 +527,14 @@ class TestGhApiCall:
     def test_returns_none_when_gh_missing(
         self, detect_squash_residue: ModuleType
     ) -> None:
-        with patch.object(detect_squash_residue, "_gh_available", return_value=False):
+        with patch.object(detect_squash_residue.shutil, "which", return_value=None):
             assert detect_squash_residue._check_via_gh("feature", "origin/main") is None
 
     def test_returns_none_on_gh_failure(
         self, detect_squash_residue: ModuleType
     ) -> None:
         with (
-            patch.object(detect_squash_residue, "_gh_available", return_value=True),
+            patch.object(detect_squash_residue.shutil, "which", return_value="/usr/bin/gh"),
             patch.object(
                 detect_squash_residue.subprocess,
                 "run",
@@ -547,7 +547,7 @@ class TestGhApiCall:
         self, detect_squash_residue: ModuleType
     ) -> None:
         with (
-            patch.object(detect_squash_residue, "_gh_available", return_value=True),
+            patch.object(detect_squash_residue.shutil, "which", return_value="/usr/bin/gh"),
             patch.object(
                 detect_squash_residue.subprocess,
                 "run",
@@ -576,7 +576,7 @@ class TestGhApiCall:
             },
         ])
         with (
-            patch.object(detect_squash_residue, "_gh_available", return_value=True),
+            patch.object(detect_squash_residue.shutil, "which", return_value="/usr/bin/gh"),
             patch.object(
                 detect_squash_residue.subprocess,
                 "run",
@@ -604,7 +604,7 @@ class TestGhApiCall:
             return make_completed(stdout="[]")
 
         with (
-            patch.object(detect_squash_residue, "_gh_available", return_value=True),
+            patch.object(detect_squash_residue.shutil, "which", return_value="/usr/bin/gh"),
             patch.object(detect_squash_residue.subprocess, "run", side_effect=fake_run),
         ):
             detect_squash_residue._check_via_gh("feature", "origin/main")
@@ -1204,105 +1204,3 @@ class TestGhMergeCommitDisagrees:
         tree = {"squash_commit": "s" * 40}
         assert detect_squash_residue._gh_merge_commit_disagrees(gh, tree) is False
 
-
-class TestBuildRemedies:
-    """The dual-remedy structure — both options always offered, safety order
-    enforced, abort prefix applied to both when an operation is in progress."""
-
-    def _scaffold(self, **overrides: object) -> dict:
-        base = {
-            "verdict": "squash-merged",
-            "method": "tree-match",
-            "branch_commits": [],
-            "unique_commits": [],
-            "squash_commit": None,
-            "pr": None,
-            "warnings": [],
-        }
-        base.update(overrides)
-        return base
-
-    def test_merge_remedy_is_non_destructive(
-        self, detect_squash_residue: ModuleType
-    ) -> None:
-        with patch.object(
-            detect_squash_residue, "_in_progress_abort", return_value=None
-        ):
-            remedies = detect_squash_residue._build_remedies(self._scaffold(), "origin/main")
-
-        merge = _remedy(remedies, "merge")
-        assert merge["destructive"] is False
-        assert merge["commands"] == [
-            "git merge origin/main",
-            # The trailing `# resolve …` comment is informational only.
-            next(c for c in merge["commands"] if c.startswith("#")),
-        ]
-        # No reset/cherry-pick commands leak into the merge option.
-        assert not any("reset --hard" in c for c in merge["commands"])
-        assert not any("cherry-pick" in c for c in merge["commands"] if not c.startswith("#"))
-
-    def test_reset_remedy_is_destructive(
-        self, detect_squash_residue: ModuleType
-    ) -> None:
-        unique = _commits("unique-1", "unique-2")
-        with patch.object(
-            detect_squash_residue, "_in_progress_abort", return_value=None
-        ):
-            remedies = detect_squash_residue._build_remedies(
-                self._scaffold(unique_commits=unique), "origin/main"
-            )
-
-        reset = _remedy(remedies, "reset-and-cherry-pick")
-        assert reset["destructive"] is True
-        assert "git reset --hard origin/main" in reset["commands"]
-        cherry = next((c for c in reset["commands"] if "cherry-pick" in c), None)
-        assert cherry is not None
-        for c in unique:
-            assert c["sha"] in cherry
-
-    def test_abort_prefix_applied_to_both_remedies(
-        self, detect_squash_residue: ModuleType
-    ) -> None:
-        with patch.object(
-            detect_squash_residue, "_in_progress_abort", return_value="git rebase --abort"
-        ):
-            remedies = detect_squash_residue._build_remedies(self._scaffold(), "origin/main")
-
-        for r in remedies:
-            assert r["commands"][0] == "git rebase --abort"
-
-    def test_local_synth_emits_manual_review_in_destructive_remedy_only(
-        self, detect_squash_residue: ModuleType
-    ) -> None:
-        branch = _commits("a", "b")
-        scaffold = self._scaffold(
-            method="local-synth",
-            branch_commits=branch,
-            unique_commits=[],
-        )
-        with patch.object(
-            detect_squash_residue, "_in_progress_abort", return_value=None
-        ):
-            remedies = detect_squash_residue._build_remedies(scaffold, "origin/main")
-
-        merge = _remedy(remedies, "merge")
-        # Merge remedy stays clean — no per-commit review block needed.
-        assert not any(c.startswith("#   ") for c in merge["commands"])
-        reset = _remedy(remedies, "reset-and-cherry-pick")
-        review_lines = [c for c in reset["commands"] if c.startswith("#   ")]
-        assert len(review_lines) == 2
-        for c in branch:
-            assert any(c["short"] in line for line in review_lines)
-
-    def test_no_unique_no_cherry_pick_in_reset_remedy(
-        self, detect_squash_residue: ModuleType
-    ) -> None:
-        with patch.object(
-            detect_squash_residue, "_in_progress_abort", return_value=None
-        ):
-            remedies = detect_squash_residue._build_remedies(
-                self._scaffold(method="tree-match", unique_commits=[]), "origin/main"
-            )
-
-        reset = _remedy(remedies, "reset-and-cherry-pick")
-        assert reset["commands"] == ["git reset --hard origin/main"]

--- a/tests/shared/python/test_gates.py
+++ b/tests/shared/python/test_gates.py
@@ -1,4 +1,4 @@
-"""Tests for shared/scripts/gates.py — readiness, cure-pass cap, iteration cap."""
+"""Tests for shared/scripts/gates.py — readiness verdict."""
 
 from __future__ import annotations
 
@@ -82,56 +82,3 @@ class TestClassifyReadiness:
             any_spinning=False,
         )
         assert result is gates.Readiness.BLOCKED
-
-
-class TestCurePassCounter:
-    def test_cap_default(self, gates: ModuleType) -> None:
-        counter = gates.CurePassCounter()
-        assert counter.cap == gates.CURE_PASS_CAP == 2
-
-    def test_records_passes(self, gates: ModuleType) -> None:
-        counter = gates.CurePassCounter()
-        assert counter.next_action() == "cure"
-        counter.record_pass()
-        assert counter.next_action() == "cure"
-        counter.record_pass()
-        assert counter.at_cap is True
-        assert counter.next_action() == "done"
-
-    def test_cap_is_inclusive(self, gates: ModuleType) -> None:
-        counter = gates.CurePassCounter(completed=2)
-        assert counter.at_cap is True
-
-
-class TestGapState:
-    def test_starts_unclosed_zero_attempts(self, gates: ModuleType) -> None:
-        gap = gates.GapState(name="missing-assertion")
-        assert gap.attempts == 0
-        assert gap.closed is False
-        assert gap.is_spinning() is False
-
-    def test_spins_after_cap_attempts(self, gates: ModuleType) -> None:
-        gap = gates.GapState(name="x")
-        for _ in range(gates.GAP_ITERATION_CAP):
-            gap.record_attempt()
-        assert gap.is_spinning() is True
-
-    def test_closing_stops_spinning(self, gates: ModuleType) -> None:
-        gap = gates.GapState(name="x")
-        for _ in range(gates.GAP_ITERATION_CAP):
-            gap.record_attempt()
-        gap.close()
-        assert gap.is_spinning() is False
-
-
-class TestDetectHalt:
-    def test_halt_with_reason(self, gates: ModuleType) -> None:
-        assert gates.detect_halt("halt", "tests broken") is True
-
-    def test_ok_status_never_halts(self, gates: ModuleType) -> None:
-        assert gates.detect_halt("ok", None) is False
-        assert gates.detect_halt("ok", "x") is False
-
-    def test_halt_without_reason_is_falsy(self, gates: ModuleType) -> None:
-        # Defensive: an empty reason behind a "halt" label is treated as not-halt.
-        assert gates.detect_halt("halt", "") is False

--- a/tests/shared/python/test_paths.py
+++ b/tests/shared/python/test_paths.py
@@ -14,7 +14,6 @@ class TestValidateSlug:
         ["a", "feature", "fix-auth-retry", "x1", "abc-123-def", "a" * 64],
     )
     def test_accepts_valid_kebab(self, paths: ModuleType, slug: str) -> None:
-        assert paths.is_valid_slug(slug) is True
         assert paths.validate_slug(slug) is None
 
     @pytest.mark.parametrize(
@@ -32,7 +31,6 @@ class TestValidateSlug:
         ],
     )
     def test_rejects_invalid(self, paths: ModuleType, slug: str) -> None:
-        assert paths.is_valid_slug(slug) is False
         assert paths.validate_slug(slug) is not None
 
     def test_non_string_rejected(self, paths: ModuleType) -> None:
@@ -62,7 +60,7 @@ class TestSlugify:
         result = paths.slugify(" ".join(["alpha"] * 20))
         assert len(result) <= 64
         # And must round-trip through the validator.
-        assert paths.is_valid_slug(result)
+        assert paths.validate_slug(result) is None
 
 
 class TestArtifactPath:


### PR DESCRIPTION
## Summary

- Succinctness pass across 14 scripts: **−341 LOC** (49 insertions, 390 deletions)
- Verified each removal candidate via sub-agents before deleting — two were rescued from the cutting room and two `gates.py` dataclasses (`GapState`, `CurePassCounter`) were deleted after their "scaffolding-not-yet-wired" justification didn't hold up
- Tier 3 (`install.sh` shell→Python partial port) deferred to #70

## What changed

**Deletes / inlines (verified safe):**
- `detect_halt` — stricter mirror of `HandoffSlug.is_halt` with a semantic mismatch; canonical version stays
- `is_valid_slug` — collapsed into `validate_slug` (tests switched to `validate_slug(s) is None`)
- 5 single-use helpers in `melt/detect-squash-residue.py` inlined; tests restructured
- `check_mergiraf_available` → `shutil.which`
- `or "."` unreachable branch in `melt/lockfile-resolve.py`
- `minimum` param on `validate_decomposition` — no CLI knob, threshold architecturally fixed at 5
- `_validate_depends_on` → `schema.string_list` (preserving `None` semantics)
- Duplicated `NAME_RE` in `.github/scripts/validate_skills.py` → `shared.scripts.paths.KEBAB_SLUG`
- `GapState` + `CurePassCounter` dataclasses + their tests — un-wired typed-specs for LLM-enforced rules; SKILL.md prose is the actual contract
- ~12 pure-restatement docstrings across `melt/`, `cheese-factory/`, `gen_docs.py`, `curd-count.py`

**Kept after verification:**
- `_capped_terse`/`_capped_verbose` twins — output-format contract; merging adds conditional cost
- `_first_h1` — inlining doubles line to 134 chars

## Test plan

- [x] 539 Python tests across 3 suites green
- [x] 16 skill validations green
- [x] 100 bats tests green
- [x] `mkdocs --strict` build green

## Follow-ups

- #70 — Tier 3: partial shell→Python port of `install.sh`
