### PR TITLE
feat(skills): add /affinage — grade PR comments + CI failures via /age lens

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,10 +13,11 @@ test:
     python3 -m pytest tests/cheese-factory/python -q
     bats tests/bash/test_install.bats
     bats tests/cheese-factory/bash/test_pr_plan_to_branches.bats
+    bats tests/bash/test_post_reply.bats
 
 # Lint shell scripts
 lint-sh:
-    shellcheck scripts/install.sh
+    shellcheck scripts/install.sh shared/post-reply.sh
 
 # Fix markdown formatting issues
 lint-md-fix:

--- a/shared/post-reply.sh
+++ b/shared/post-reply.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# shared/post-reply.sh — post a reply to a GitHub PR thread or PR conversation
+# with the mandatory "agent on behalf of;" attribution suffix appended.
+#
+# Used by /affinage (this repo) and modelled after the contract in the global
+# /respond skill's scripts/post-reply.sh. Single source of truth for the
+# attribution suffix — never duplicate the literal phrase into callers.
+#
+# Usage:
+#   post-reply.sh --thread --pr <pr> --comment-id <id> --body <body>
+#   post-reply.sh --issue  --pr <pr>                   --body <body>
+#
+# Mode selection:
+#   --thread  Reply to a specific inline review-thread comment.
+#   --issue   Post a top-level PR conversation comment (used for review-body
+#             summary replies that have no anchored comment).
+#
+# Resolves <handle> in this order:
+#   1. RESPOND_GH_HANDLE env var.
+#   2. gh api user --jq .login (the authenticated gh user).
+#   3. git config user.name (final fallback).
+#
+# Exits non-zero on any failure (missing args, gh failure, no handle).
+
+set -euo pipefail
+
+# --- Constants ------------------------------------------------------------
+
+# IMPORTANT: This is the attribution suffix's verbatim prefix. Do not
+# paraphrase, do not change capitalization, do not change punctuation. The
+# single space between the semicolon and the handle is part of the spec —
+# see skills/affinage/SKILL.md, section "Rules".
+readonly ATTRIBUTION_PREFIX="agent on behalf of;"
+
+# Horizontal-rule line that separates the reply from the attribution.
+readonly ATTRIBUTION_SEPARATOR="---"
+
+# --- Helpers --------------------------------------------------------------
+
+die() {
+  printf 'post-reply.sh: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  post-reply.sh --thread --pr <pr> --comment-id <id> --body <body>
+  post-reply.sh --issue  --pr <pr>                   --body <body>
+EOF
+  exit 2
+}
+
+resolve_handle() {
+  if [ -n "${RESPOND_GH_HANDLE:-}" ]; then
+    printf '%s' "$RESPOND_GH_HANDLE"
+    return 0
+  fi
+  local login
+  if login=$(gh api user --jq .login 2>/dev/null) && [ -n "$login" ]; then
+    printf '%s' "$login"
+    return 0
+  fi
+  local name
+  if name=$(git config user.name 2>/dev/null) && [ -n "$name" ]; then
+    printf '%s' "$name"
+    return 0
+  fi
+  die "could not resolve a GitHub handle (set RESPOND_GH_HANDLE, sign in with gh, or set git config user.name)"
+}
+
+# Compose the final reply body: original body + blank line + separator +
+# attribution line. Idempotent — if the body already ends with the exact
+# suffix block (separator + attribution line for this handle, optionally
+# followed by a trailing newline), return it unchanged. A substring match
+# would skip the append when the body merely quotes the attribution
+# elsewhere (e.g. citing the spec), which would post unattributed replies.
+compose_body() {
+  local body="$1"
+  local handle="$2"
+  local attribution_line="${ATTRIBUTION_PREFIX} ${handle}"
+  local suffix
+  printf -v suffix '\n\n%s\n%s' "$ATTRIBUTION_SEPARATOR" "$attribution_line"
+  # Strip a single trailing newline (the form compose_body itself emits)
+  # before comparing, so the check accepts both "...handle" and "...handle\n".
+  local body_trimmed="${body%$'\n'}"
+  if [ "${body_trimmed: -${#suffix}}" = "$suffix" ]; then
+    printf '%s' "$body"
+    return 0
+  fi
+  printf '%s\n\n%s\n%s\n' "$body" "$ATTRIBUTION_SEPARATOR" "$attribution_line"
+}
+
+resolve_repo() {
+  gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null \
+    || die "could not resolve <owner>/<repo> from the current git remote"
+}
+
+post_thread_reply() {
+  local pr="$1" comment_id="$2" full_body="$3"
+  local repo
+  repo=$(resolve_repo)
+  gh api \
+    --method POST \
+    "repos/${repo}/pulls/${pr}/comments/${comment_id}/replies" \
+    -f body="$full_body"
+}
+
+post_issue_comment() {
+  local pr="$1" full_body="$2"
+  local repo
+  repo=$(resolve_repo)
+  gh api \
+    --method POST \
+    "repos/${repo}/issues/${pr}/comments" \
+    -f body="$full_body"
+}
+
+# --- Argument parsing -----------------------------------------------------
+
+mode=""
+pr=""
+comment_id=""
+body=""
+
+set_mode() {
+  local new_mode="$1"
+  if [ -n "$mode" ] && [ "$mode" != "$new_mode" ]; then
+    die "cannot combine --thread and --issue (mode already set to '$mode')"
+  fi
+  if [ -n "$mode" ] && [ "$mode" = "$new_mode" ]; then
+    die "--${new_mode} passed more than once"
+  fi
+  mode="$new_mode"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --thread)     set_mode "thread"; shift ;;
+    --issue)      set_mode "issue"; shift ;;
+    --pr)         pr="${2:-}"; shift 2 ;;
+    --comment-id) comment_id="${2:-}"; shift 2 ;;
+    --body)       body="${2:-}"; shift 2 ;;
+    -h|--help)    usage ;;
+    *)            die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$mode" ] || usage
+[ -n "$pr" ]   || die "missing --pr"
+[ -n "$body" ] || die "missing --body"
+case "$mode" in
+  thread) [ -n "$comment_id" ] || die "missing --comment-id (required for --thread)" ;;
+  issue)  [ -z "$comment_id" ] || die "--comment-id is not valid for --issue mode" ;;
+esac
+
+# --- Compose + post -------------------------------------------------------
+
+handle=$(resolve_handle)
+full_body=$(compose_body "$body" "$handle")
+
+case "$mode" in
+  thread) post_thread_reply "$pr" "$comment_id" "$full_body" ;;
+  issue)  post_issue_comment "$pr" "$full_body" ;;
+esac

--- a/skills/affinage/SKILL.md
+++ b/skills/affinage/SKILL.md
@@ -169,6 +169,8 @@ When invoked with `--auto --stake <floor>`:
 - Needs-investigation items: post the human-investigating reply.
 - Never invoke `/gh`.
 
+The whole cure chain (cure → `/age --scope --auto` → up to the two-cure-pass cap) must run in the parent affinage context so the post-cure reply step still has the original graded findings (slug, ids, `from-comment:<id>` tags, drafted push-back text) in memory. Same in-session-memory contract as `/age --auto`'s two-pass cap. Spawning the cure chain in a sub-agent silently breaks reply posting — do not.
+
 If no findings meet the floor, skip the `/cure` dispatch, post replies for `Reviewer-rejected` + `Needs-investigation` items only, and exit with `status: ok / next: done / "no findings at or above <floor>"`.
 
 ### --hard mode

--- a/skills/affinage/SKILL.md
+++ b/skills/affinage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: affinage
-description: Use this skill to triage external claims about a PR — review comments AND CI failures — by running them through the /age lens. Phrases like "respond to PR comments", "handle review feedback", "affinage the PR", "/affinage <pr>", "address the reviewer comments", "grade the PR comments". Fetches inline + review-body comments via `gh` and CI failures via `scripts/pr-status.py`, grades each through the ten age dimensions, and writes a report at `.cheese/affinage/pr-<n>.md` with extra `## Needs-investigation` and `## Reviewer-rejected` sections. Hands off to `/cure` via `handoff_context`; on return, posts per-finding GitHub replies — fixes confirmed, reverts explained, push-backs delivered. Supports `--auto --stake <floor>` for the autonomous chain. Every reply carries an `agent on behalf of;` attribution. Do NOT use to generate fresh review findings — use `/age` or `/copilot-review`. Before `/cure`; parallel to `/age`.
+description: Use this skill to triage external claims about a PR — review comments AND CI failures — by running them through the /age lens. Phrases like "respond to PR comments", "handle review feedback", "affinage the PR", "/affinage <pr>", "address the reviewer comments", "grade the PR comments". Fetches inline + review-body comments via `gh` and CI failures via `scripts/pr-status.py`, grades each through the ten age dimensions, and writes a report at `.cheese/affinage/pr-<n>.md` with extra `## Needs-investigation` and `## Reviewer-rejected` sections. Hands off to `/cure` via `handoff_context`; on return, posts per-finding GitHub replies — fixes confirmed, reverts explained, push-backs delivered. Supports `--auto --stake <floor>` for the autonomous chain. Every reply carries an `agent on behalf of;` attribution. Do NOT use to generate fresh review findings — use `/age` instead. Before `/cure`; parallel to `/age`.
 license: MIT
 ---
 
@@ -8,7 +8,7 @@ license: MIT
 
 Use this skill when the user wants to act on external claims about a PR — review comments from humans or bots, plus failing CI checks — and wants those claims graded through the same lens `/age` uses for fresh review, then handed to `/cure` for application.
 
-Do not use it to generate fresh review findings. That is `/age` (your code) or `/copilot-review` (asking another reviewer). `/affinage` only refines claims that already exist on the PR.
+Do not use it to generate fresh review findings. That is `/age` (your code). `/affinage` only refines claims that already exist on the PR.
 
 The metaphor: an *affineur* evaluates each wheel of cheese by sight / smell / sound and decides its fate. Here the wheels are review comments and CI failures.
 
@@ -32,7 +32,7 @@ Flags:
 1. **Resolve PR.** From `<pr-ref>` or `gh pr view --json number` on the current branch. Resolve `<owner>/<repo>` from the git remote.
 2. **Fetch PR status.** Call `python3 skills/affinage/scripts/pr-status.py <pr>`. The script returns JSON with build status, per-check failure summaries (last ~10 lines of failed logs + parsed failed-test names), and merge state. If the script exits non-zero, write `status: halt: pr-status-unavailable` and stop.
 3. **Fetch comments.**
-   - Inline threads: `gh api repos/<owner>/<repo>/pulls/<pr>/comments`. Filter to unresolved. Skip outdated (`outdated: true` heuristic via `position == null` for inline comments) unless `--include-outdated`.
+   - Inline threads: `gh api repos/<owner>/<repo>/pulls/<pr>/comments`. This REST endpoint returns individual review comments without thread-level resolution state, so the skill cannot filter on `isResolved` from this surface; it skips comments whose `position` is `null` (the diff has moved past the anchored line) unless `--include-outdated`. For true unresolved-only filtering, switch to the GraphQL `pullRequest.reviewThreads { isResolved }` endpoint — documented as a future enhancement.
    - Review bodies: `gh api repos/<owner>/<repo>/pulls/<pr>/reviews`. Filter to non-empty bodies. Dedupe against inline comments via `pull_request_review_id`.
 4. **Skip already-replied threads.** A thread whose most recent comment is from the resolved GitHub handle (env `RESPOND_GH_HANDLE` → `gh api user --jq .login` → `git config user.name`) has already been responded to; skip it. This keeps re-runs idempotent.
 5. **Grade through the age lens.** For each input (comment OR CI failure):
@@ -180,7 +180,7 @@ If no findings meet the floor, skip the `/cure` dispatch, post replies for `Revi
 - Grading is code-grounded, not reviewer-asserted. `CHANGES_REQUESTED` is metadata, not a severity bump.
 - Never auto-apply fixes from `/affinage` itself. Fixes go through `/cure`.
 - Every posted reply ends with the literal `agent on behalf of;` attribution via `shared/post-reply.sh`. Never call `gh api` directly to post.
-- Idempotent re-runs: skip threads where the latest comment is from the resolved handle; respect `is_resolved` from the API.
+- Idempotent re-runs: skip threads where the latest comment is from the resolved handle. The REST `/comments` endpoint does not expose thread resolution, so honest idempotency relies on the latest-comment-from-self heuristic; switch to GraphQL `reviewThreads` if cross-session resolution-state visibility becomes required.
 - CI-sourced findings get no reply (no reviewer to notify).
 - Do not invoke `/gh`. Opening or updating the PR stays user-triggered.
 - Apply the shared voice kernel (`skills/age/references/voice.md`): name confidence as `certain | speculating | don't know`; agree when no findings warrant grading.

--- a/skills/affinage/SKILL.md
+++ b/skills/affinage/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: affinage
+description: Use this skill to triage external claims about a PR — review comments AND CI failures — by running them through the /age lens. Phrases like "respond to PR comments", "handle review feedback", "affinage the PR", "/affinage <pr>", "address the reviewer comments", "grade the PR comments". Fetches inline + review-body comments via `gh` and CI failures via `scripts/pr-status.py`, grades each through the ten age dimensions, and writes a report at `.cheese/affinage/pr-<n>.md` with extra `## Needs-investigation` and `## Reviewer-rejected` sections. Hands off to `/cure` via `handoff_context`; on return, posts per-finding GitHub replies — fixes confirmed, reverts explained, push-backs delivered. Supports `--auto --stake <floor>` for the autonomous chain. Every reply carries an `agent on behalf of;` attribution. Do NOT use to generate fresh review findings — use `/age` or `/copilot-review`. Before `/cure`; parallel to `/age`.
+license: MIT
+---
+
+# /affinage
+
+Use this skill when the user wants to act on external claims about a PR — review comments from humans or bots, plus failing CI checks — and wants those claims graded through the same lens `/age` uses for fresh review, then handed to `/cure` for application.
+
+Do not use it to generate fresh review findings. That is `/age` (your code) or `/copilot-review` (asking another reviewer). `/affinage` only refines claims that already exist on the PR.
+
+The metaphor: an *affineur* evaluates each wheel of cheese by sight / smell / sound and decides its fate. Here the wheels are review comments and CI failures.
+
+## Inputs
+
+```text
+/affinage [<pr-ref>] [--auto --stake <floor>] [--hard] [--full] [--include-outdated]
+```
+
+`<pr-ref>` accepts a PR number, a full GitHub PR URL, or nothing (auto-detect via `gh pr view --json number` on the current branch).
+
+Flags:
+
+- `--auto --stake <floor>` — autonomous mode. `<floor>` is `blocker`, `high`, `medium+`, or `all` (same semantics as `/cure`). Skips the selection gate, dispatches `/cure --auto --stake <floor>`, posts all replies without prompting.
+- `--hard` — propagated metacognitive-gate flag. `/affinage` does not fire the gate; passes `--hard` forward to `/cure` at handoff.
+- `--full` — un-collapses `## Low` when ≥10 low-severity findings exist (mirrors `/age --full`).
+- `--include-outdated` — include outdated review threads. Default skips them.
+
+## Flow
+
+1. **Resolve PR.** From `<pr-ref>` or `gh pr view --json number` on the current branch. Resolve `<owner>/<repo>` from the git remote.
+2. **Fetch PR status.** Call `python3 skills/affinage/scripts/pr-status.py <pr>`. The script returns JSON with build status, per-check failure summaries (last ~10 lines of failed logs + parsed failed-test names), and merge state. If the script exits non-zero, write `status: halt: pr-status-unavailable` and stop.
+3. **Fetch comments.**
+   - Inline threads: `gh api repos/<owner>/<repo>/pulls/<pr>/comments`. Filter to unresolved. Skip outdated (`outdated: true` heuristic via `position == null` for inline comments) unless `--include-outdated`.
+   - Review bodies: `gh api repos/<owner>/<repo>/pulls/<pr>/reviews`. Filter to non-empty bodies. Dedupe against inline comments via `pull_request_review_id`.
+4. **Skip already-replied threads.** A thread whose most recent comment is from the resolved GitHub handle (env `RESPOND_GH_HANDLE` → `gh api user --jq .login` → `git config user.name`) has already been responded to; skip it. This keeps re-runs idempotent.
+5. **Grade through the age lens.** For each input (comment OR CI failure):
+   - Classify dimension from the **code + claim** (or check type + failure summary, for CI items). See `skills/age/references/dimensions.md` for the dimension rubric.
+   - Compute severity from base + location + compounding modifiers (same rubric as `/age`).
+   - **Ignore reviewer-asserted urgency for severity computation.** Surface `CHANGES_REQUESTED` as metadata (`reviewer-asserted:` line) but do not let it modify computed severity.
+   - Bucket into:
+     - Standard severity sections (`## Blocker / ## High / ## Medium / ## Low`) when the claim maps to a dimension and the diff grounds it.
+     - `## Needs-investigation` when the claim is plausible but requires evidence outside the diff (e.g., downstream caller in another repo).
+     - `## Reviewer-rejected` when the claim maps to no dimension, is ungrounded, or is pure style.
+6. **Write report** to `.cheese/affinage/pr-<n>.md` with the four-line handoff slug at the top, then the age-format body plus the two extra sections. See `## Output` below.
+7. **Selection gate** (interactive mode). Render the cure-selection table inline using `/cure`'s verbs (`skills/cure/references/selection.md`). Ask via `shared/handoff-gate.md`. On non-empty selection, dispatch `/cure <slug>` with locked `handoff_context:`. On `none` / `Stop`, exit cleanly with the report path.
+8. **Post-cure reply posting.** When `/cure` returns, read `.cheese/cure/pr-<n>.md`'s `### Applied` / `### Deferred` sections and post per-finding replies via `shared/post-reply.sh`:
+   - **Applied** (with `from-comment:<id>` tag) → `"Fixed — <applied summary>."`
+   - **Deferred** (with `from-comment:<id>` tag) → `"Attempted fix reverted — <reason>."`
+   - **Reviewer-rejected items** → post the pre-drafted push-back text from the affinage report.
+   - **Needs-investigation items** → post `"Human investigating — will follow up."`
+   - **CI-sourced findings** (`from-check:<job>` tag) → no reply.
+
+## Sub-agent context gate
+
+`/affinage` keeps dialogue, selection, approval state, and reply posting in the parent context. Spawn a read-only grading sub-agent only when the parent context would balloon:
+
+- Total input count (comments + CI failures) exceeds 10.
+- Diff exceeds ~25 KB.
+- Threads span more than 5 files.
+
+The sub-agent returns a digest: graded findings table with dimension, severity, grounded-evidence cite, and pre-drafted push-back text for any `Reviewer-rejected` items. The parent owns the report write, selection gate, `/cure` dispatch, and reply posting.
+
+Digest size, parent-vs-sub-agent split, and harness-agnostic sub-agent selection live in `skills/age/references/sub-agent-gate.md`.
+
+## Preferred tools and fallbacks
+
+Code search and reading go through cheez-* skills (`/cheez-search`, `/cheez-read`). Beyond cheez-* there are affinage-specific tools:
+
+| Need | Prefer | Fallback |
+| --- | --- | --- |
+| PR status (build + merge) | `skills/affinage/scripts/pr-status.py` | manual `gh pr checks` + `gh pr view` |
+| GitHub fetch | `gh api` | none (skill halts) |
+| Reply posting | `shared/post-reply.sh` | none — direct `gh api` calls bypass the `agent on behalf of;` attribution |
+| Diff inspection | `delta` | `git diff --unified=3` |
+
+## Output
+
+Write to `.cheese/affinage/pr-<n>.md` with the four-line handoff slug at the top, then the age-style body with two extra sections:
+
+```markdown
+status: ok | halt: <one-line reason>
+next: cure | done
+artifact: <path-to-prior-cure-or-press-report-if-any>
+<one-line orientation: what the PR does and what was graded>
+
+# Affinage Report — PR #<n>
+
+## Orientation
+<one or two factual sentences about the PR and what was graded>
+
+## PR status
+- Build: passing | failing (N jobs)
+- Merge: clean | conflicts
+- Comments: K unresolved (M skipped as outdated)
+
+## Blocker
+- **[from-comment:<id>] [security:blocker]** alice on `src/auth.ts:42` — token parsed without validation.
+  - location: contract · fix-cost-now: contained · fix-cost-later: structural
+  - reviewer-asserted: changes-requested
+  - recommendation: validate `authorization` header; reject with 401 on missing.
+- **[from-check:test-suite] [correctness:blocker]** CI job `test-suite` — 3 tests failing in `tests/auth.test.ts`.
+  - location: contract · fix-cost-now: contained · fix-cost-later: structural
+  - recommendation: re-run after fixing the missing null check.
+
+## High
+... (same shape)
+
+## Medium
+... (same shape)
+
+## Low
+... (same shape; collapsible per --full rules)
+
+## Needs-investigation
+- **[from-comment:<id>]** bob on `src/api/users.ts:108` — "might break analytics pipeline."
+  - reason: claim plausible but pipeline lives in a different repo; diff cannot confirm.
+  - suggested action: human reads `analytics-svc/consumers/users.ts`.
+
+## Reviewer-rejected
+- **[from-comment:<id>]** copilot on `src/utils/format.ts:18` — "rename `data` to `lineItems`."
+  - reason: pure style; no dimension match.
+  - draft reply: "Thanks — leaving `data` as-is; matches the adjacent format-helper pattern. Open to revisiting if the team standardises."
+
+## Confidence
+<certain | speculating | don't know> — <one-line justification>
+
+## Next step
+Selection prompt rendered inline — pick findings to cure or `none` to stop.
+```
+
+Empty severity sections are omitted entirely. `## Needs-investigation` and `## Reviewer-rejected` are omitted when no items land there.
+
+`status: ok` when grading completed; `status: halt: <reason>` when `gh` or `pr-status.py` failed in a way that blocks honest grading. `next: cure` when at least one medium-or-above severity finding exists; `next: done` when none do.
+
+## Handoff
+
+**Pipeline:** culture → mold → cook → press → age → cure → ship · `/affinage` is parallel to `/age` and feeds the same `/cure`.
+
+After the report lands, render the cure-selection table inline (per `skills/cure/references/selection.md`) and ask via `shared/handoff-gate.md`. Options:
+
+- **Pick findings to fix** — free-text reply using `/age`/`/cure` verbs (`1,3,5`, `all-blocker`, `all-high`, `cheap`, `all`, `none`, `skip N`).
+- **Fix every blocker** — equivalent to `all-blocker`.
+- **Fix blockers and high-severity findings** *(recommended when at least one blocker or high-severity finding exists)* — equivalent to `all-high`.
+- **Stop — leave the report for later** — equivalent to `none`.
+
+On non-empty selection, immediately dispatch `/cure <slug>` with locked context:
+
+```yaml
+handoff_context:
+  source_skill: /affinage
+  source_report: .cheese/affinage/pr-<n>.md
+  selection: "<verb or explicit ids>"
+  resolved_ids: [<expanded ids>]
+```
+
+`/cure` re-confirms cited ids and goes straight to apply. `/affinage` resumes when `/cure` returns to post replies.
+
+### Auto mode
+
+When invoked with `--auto --stake <floor>`:
+
+- Skip the selection gate.
+- Auto-select every finding (comment-sourced OR CI-sourced) whose severity meets the floor.
+- Dispatch `/cure --auto --stake <floor>`.
+- After `/cure --auto` and its downstream `/age --scope --auto` chain settle, post replies for the originally graded items only. Do NOT re-grade for findings discovered by `/age --scope`.
+- Reviewer-rejected items: post the pre-drafted push-back.
+- Needs-investigation items: post the human-investigating reply.
+- Never invoke `/gh`.
+
+If no findings meet the floor, skip the `/cure` dispatch, post replies for `Reviewer-rejected` + `Needs-investigation` items only, and exit with `status: ok / next: done / "no findings at or above <floor>"`.
+
+### --hard mode
+
+`/affinage` does not fire the `/hard-cheese` gate. It propagates `--hard` forward to `/cure` so the gate can fire at the share-for-review boundary inside `/cure --hard`. See `skills/cure/SKILL.md` `--hard mode`.
+
+## Rules
+
+- Grading is code-grounded, not reviewer-asserted. `CHANGES_REQUESTED` is metadata, not a severity bump.
+- Never auto-apply fixes from `/affinage` itself. Fixes go through `/cure`.
+- Every posted reply ends with the literal `agent on behalf of;` attribution via `shared/post-reply.sh`. Never call `gh api` directly to post.
+- Idempotent re-runs: skip threads where the latest comment is from the resolved handle; respect `is_resolved` from the API.
+- CI-sourced findings get no reply (no reviewer to notify).
+- Do not invoke `/gh`. Opening or updating the PR stays user-triggered.
+- Apply the shared voice kernel (`skills/age/references/voice.md`): name confidence as `certain | speculating | don't know`; agree when no findings warrant grading.
+
+## References
+
+- `skills/age/SKILL.md` — review pipeline, dimensions, sub-agent gate, report shape.
+- `skills/age/references/dimensions.md` — per-dimension rubrics and severity computation.
+- `skills/cure/SKILL.md` — apply pipeline, `--auto --stake` floors, handoff context shape.
+- `skills/cure/references/selection.md` — selection verbs and composition.
+- `shared/handoff-gate.md` — gate primitives.
+- `shared/post-reply.sh` — reply posting with `agent on behalf of;` attribution.
+- `skills/affinage/scripts/pr-status.py` — PR status fetcher.

--- a/skills/affinage/scripts/pr-status.py
+++ b/skills/affinage/scripts/pr-status.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Fetch PR status (build + merge) for /affinage grading.
+
+Returns JSON on stdout:
+
+    {
+      "pr": <number>,
+      "build": {
+        "status": "passing" | "failing" | "pending",
+        "checks": [
+          {
+            "name": str,
+            "conclusion": str,
+            "url": str,
+            "failure_summary": str,   # last ~10 lines of the failing log
+            "failed_tests": [str]      # heuristic parse of FAILED test names
+          }
+        ]
+      },
+      "merge": {"mergeable": str, "state": str}
+    }
+
+Wraps `gh pr checks`, `gh pr view`, and `gh run view --log-failed`. Exits
+non-zero (1 on PR/gh API error, 2 on missing gh binary) so the caller can
+halt cleanly with `status: halt: pr-status-unavailable`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Any
+
+FAILURE_TAIL_LINES = 10
+
+# Heuristic patterns for extracting failed-test names from log output.
+# Conservative — false positives are noise but not incorrect grading.
+_FAILED_TEST_PATTERNS = (
+    # pytest:  FAILED tests/auth.py::test_name
+    re.compile(r"FAILED\s+(\S+(?:::\S+)+)"),
+    # rust:    test foo::bar ... FAILED
+    re.compile(r"test\s+(\S+)\s+\.\.\.\s+FAILED"),
+    # jest:    ✗ test name
+    re.compile(r"^\s*[✗×]\s+(.+?)$", re.MULTILINE),
+)
+
+
+def _run_gh(args: list[str], *, allow_fail: bool = False) -> str:
+    """Invoke gh and return stdout. Exits the process on failure unless allow_fail."""
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        sys.stderr.write("pr-status.py: gh CLI not found in PATH\n")
+        sys.exit(2)
+    if result.returncode != 0:
+        if allow_fail:
+            return ""
+        sys.stderr.write(
+            f"pr-status.py: gh {' '.join(args)} failed (exit {result.returncode}): "
+            f"{result.stderr.strip()}\n"
+        )
+        sys.exit(1)
+    return result.stdout
+
+
+def fetch_checks(pr: int) -> list[dict[str, Any]]:
+    """Return raw check entries from `gh pr checks --json`."""
+    raw = _run_gh(["pr", "checks", str(pr), "--json", "name,state,conclusion,link"])
+    if not raw.strip():
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"pr-status.py: could not parse gh pr checks JSON: {exc}\n")
+        sys.exit(1)
+    if not isinstance(data, list):
+        return []
+    return data
+
+
+def fetch_merge_state(pr: int) -> dict[str, str]:
+    raw = _run_gh(["pr", "view", str(pr), "--json", "mergeable,mergeStateStatus"])
+    if not raw.strip():
+        return {"mergeable": "UNKNOWN", "state": "UNKNOWN"}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"mergeable": "UNKNOWN", "state": "UNKNOWN"}
+    return {
+        "mergeable": data.get("mergeable", "UNKNOWN") or "UNKNOWN",
+        "state": data.get("mergeStateStatus", "UNKNOWN") or "UNKNOWN",
+    }
+
+
+def extract_run_id(link: str) -> str | None:
+    """Parse a github actions URL to extract the run id."""
+    if not link:
+        return None
+    match = re.search(r"/runs/(\d+)", link)
+    return match.group(1) if match else None
+
+
+def extract_failed_tests(log: str) -> list[str]:
+    """Heuristically pull failed-test names from a log."""
+    seen: list[str] = []
+    for pattern in _FAILED_TEST_PATTERNS:
+        for match in pattern.finditer(log):
+            name = match.group(1).strip()
+            if name and name not in seen:
+                seen.append(name)
+    return seen
+
+
+def fetch_failure_summary(link: str) -> tuple[str, list[str]]:
+    """Return (tail-summary, failed_tests) for a failing check link."""
+    run_id = extract_run_id(link)
+    if not run_id:
+        return "", []
+    raw = _run_gh(["run", "view", run_id, "--log-failed"], allow_fail=True)
+    if not raw.strip():
+        return "", []
+    lines = raw.rstrip().splitlines()
+    tail = "\n".join(lines[-FAILURE_TAIL_LINES:])
+    failed_tests = extract_failed_tests(raw)
+    return tail, failed_tests
+
+
+def classify_status(checks: list[dict[str, Any]]) -> str:
+    if not checks:
+        return "passing"
+    conclusions = {(c.get("conclusion") or "").lower() for c in checks}
+    if {"failure", "timed_out", "cancelled"} & conclusions:
+        return "failing"
+    states = {(c.get("state") or "").lower() for c in checks}
+    if states & {"pending", "in_progress", "queued"}:
+        return "pending"
+    return "passing"
+
+
+def build_output(pr: int) -> dict[str, Any]:
+    raw_checks = fetch_checks(pr)
+    merge = fetch_merge_state(pr)
+    status = classify_status(raw_checks)
+
+    enriched: list[dict[str, Any]] = []
+    for check in raw_checks:
+        entry: dict[str, Any] = {
+            "name": check.get("name", ""),
+            "conclusion": check.get("conclusion", "") or "",
+            "url": check.get("link", "") or "",
+            "failure_summary": "",
+            "failed_tests": [],
+        }
+        if entry["conclusion"].lower() == "failure":
+            summary, failed = fetch_failure_summary(entry["url"])
+            entry["failure_summary"] = summary
+            entry["failed_tests"] = failed
+        enriched.append(entry)
+
+    return {
+        "pr": pr,
+        "build": {"status": status, "checks": enriched},
+        "merge": merge,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch PR status (build + merge) for /affinage grading.",
+    )
+    parser.add_argument("pr", type=int, help="PR number")
+    args = parser.parse_args(argv)
+
+    output = build_output(args.pr)
+    json.dump(output, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/affinage/scripts/pr-status.py
+++ b/skills/affinage/scripts/pr-status.py
@@ -73,7 +73,7 @@ def _run_gh(args: list[str], *, allow_fail: bool = False) -> str:
 
 def fetch_checks(pr: int) -> list[dict[str, Any]]:
     """Return raw check entries from `gh pr checks --json`."""
-    raw = _run_gh(["pr", "checks", str(pr), "--json", "name,state,conclusion,link"])
+    raw = _run_gh(["pr", "checks", str(pr), "--json", "name,state,bucket,link"])
     if not raw.strip():
         return []
     try:
@@ -82,7 +82,11 @@ def fetch_checks(pr: int) -> list[dict[str, Any]]:
         sys.stderr.write(f"pr-status.py: could not parse gh pr checks JSON: {exc}\n")
         sys.exit(1)
     if not isinstance(data, list):
-        return []
+        sys.stderr.write(
+            f"pr-status.py: gh pr checks returned non-list JSON (got {type(data).__name__}); "
+            "the CLI schema may have changed\n"
+        )
+        sys.exit(1)
     return data
 
 
@@ -134,13 +138,18 @@ def fetch_failure_summary(link: str) -> tuple[str, list[str]]:
 
 
 def classify_status(checks: list[dict[str, Any]]) -> str:
+    """Classify overall build state from per-check `bucket` values.
+
+    `gh pr checks` exposes a pre-classified `bucket` field (pass / fail /
+    pending / skipping) which is more stable than enumerating raw `state`
+    values across event types. Skipping counts as passing.
+    """
     if not checks:
         return "passing"
-    conclusions = {(c.get("conclusion") or "").lower() for c in checks}
-    if {"failure", "timed_out", "cancelled"} & conclusions:
+    buckets = {(c.get("bucket") or "").lower() for c in checks}
+    if "fail" in buckets:
         return "failing"
-    states = {(c.get("state") or "").lower() for c in checks}
-    if states & {"pending", "in_progress", "queued"}:
+    if "pending" in buckets:
         return "pending"
     return "passing"
 
@@ -152,14 +161,22 @@ def build_output(pr: int) -> dict[str, Any]:
 
     enriched: list[dict[str, Any]] = []
     for check in raw_checks:
+        bucket = (check.get("bucket") or "").lower()
+        state = (check.get("state") or "")
         entry: dict[str, Any] = {
             "name": check.get("name", ""),
-            "conclusion": check.get("conclusion", "") or "",
+            # Output key stays `conclusion` per spec; we derive it from gh's
+            # canonical `state` (SUCCESS / FAILURE / CANCELLED / TIMED_OUT /
+            # SKIPPED / IN_PROGRESS / QUEUED / ...) lowercased.
+            "conclusion": state.lower(),
             "url": check.get("link", "") or "",
             "failure_summary": "",
             "failed_tests": [],
         }
-        if entry["conclusion"].lower() == "failure":
+        # Enrich for the whole failure family (failure, cancelled, timed_out)
+        # via gh's pre-classified `bucket` so classification and enrichment
+        # stay in lockstep.
+        if bucket == "fail":
             summary, failed = fetch_failure_summary(entry["url"])
             entry["failure_summary"] = summary
             entry["failed_tests"] = failed

--- a/skills/affinage/scripts/pr-status.py
+++ b/skills/affinage/scripts/pr-status.py
@@ -44,7 +44,7 @@ _FAILED_TEST_PATTERNS = (
     # rust:    test foo::bar ... FAILED
     re.compile(r"test\s+(\S+)\s+\.\.\.\s+FAILED"),
     # jest:    ✗ test name
-    re.compile(r"^\s*[✗×]\s+(.+?)$", re.MULTILINE),
+    re.compile(r"^\s*[✗×]\s+(.+)$", re.MULTILINE),
 )
 
 
@@ -62,6 +62,10 @@ def _run_gh(args: list[str], *, allow_fail: bool = False) -> str:
         sys.exit(2)
     if result.returncode != 0:
         if allow_fail:
+            sys.stderr.write(
+                f"pr-status.py: gh {' '.join(args)} failed (exit {result.returncode}); "
+                "continuing with empty result\n"
+            )
             return ""
         sys.stderr.write(
             f"pr-status.py: gh {' '.join(args)} failed (exit {result.returncode}): "
@@ -96,7 +100,11 @@ def fetch_merge_state(pr: int) -> dict[str, str]:
         return {"mergeable": "UNKNOWN", "state": "UNKNOWN"}
     try:
         data = json.loads(raw)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(
+            f"pr-status.py: could not parse gh pr view JSON ({exc}); "
+            "treating merge state as UNKNOWN\n"
+        )
         return {"mergeable": "UNKNOWN", "state": "UNKNOWN"}
     return {
         "mergeable": data.get("mergeable", "UNKNOWN") or "UNKNOWN",

--- a/skills/cheese/SKILL.md
+++ b/skills/cheese/SKILL.md
@@ -61,7 +61,7 @@ The full classification table — including disambiguation rules, edge cases, an
 
 Flow:
 
-1. Scan for the most recently modified handoff slug across `.cheese/{cook,press,age,cure,notes}/<slug>.md`.
+1. Scan for the most recently modified handoff slug across `.cheese/{cook,press,age,cure,affinage,notes}/<slug>.md`.
 2. If none exist, offer to start the pipeline from scratch — `/mold` for fuzzy specs, `/cook` for clear asks, `/ultracook` for high-blast-radius specs — and stop.
 3. If at least one exists, read the latest one and use its `next:` field to decide the recommended action. Surface the orientation line so the user knows where they are.
 4. Confirm the resumption via the handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). The recommended option depends on the slug's `next:` value:

--- a/tests/bash/test_post_reply.bats
+++ b/tests/bash/test_post_reply.bats
@@ -12,6 +12,8 @@ setup() {
     FAKE_BIN="$BATS_TEST_TMPDIR/bin"
     GH_LOG="$BATS_TEST_TMPDIR/gh.log"
     export GH_LOG
+    : > "$GH_LOG"
+    ORIG_PATH="$PATH"
 
     mkdir -p "$FAKE_BIN"
 
@@ -37,6 +39,11 @@ EOF
 
     export PATH="$FAKE_BIN:$PATH"
     unset RESPOND_GH_HANDLE
+}
+
+teardown() {
+    export PATH="${ORIG_PATH:-$PATH}"
+    unset ORIG_PATH
 }
 
 @test "--thread mode hits the pulls comments replies endpoint" {

--- a/tests/bash/test_post_reply.bats
+++ b/tests/bash/test_post_reply.bats
@@ -1,0 +1,192 @@
+#!/usr/bin/env bats
+#
+# Tests for shared/post-reply.sh.
+#
+# Stubs `gh` in PATH so the script's invocations are logged to a temp file.
+# Verifies endpoint routing, attribution, handle resolution, idempotency,
+# and argument validation.
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    SCRIPT="$REPO_ROOT/shared/post-reply.sh"
+    FAKE_BIN="$BATS_TEST_TMPDIR/bin"
+    GH_LOG="$BATS_TEST_TMPDIR/gh.log"
+    export GH_LOG
+
+    mkdir -p "$FAKE_BIN"
+
+    # Stub gh: log every invocation arg-by-arg, return canned responses for
+    # the read-only sub-commands.
+    cat > "$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+{
+  printf '=== GH_INVOKE ===\n'
+  for arg in "$@"; do
+    printf 'ARG: %s\n' "$arg"
+  done
+  printf '=== END ===\n'
+} >> "$GH_LOG"
+case "$1 $2" in
+  "api user")   printf 'stub-user\n' ;;
+  "repo view")  printf 'owner/repo\n' ;;
+  *)            : ;;
+esac
+exit 0
+EOF
+    chmod +x "$FAKE_BIN/gh"
+
+    export PATH="$FAKE_BIN:$PATH"
+    unset RESPOND_GH_HANDLE
+}
+
+@test "--thread mode hits the pulls comments replies endpoint" {
+    run "$SCRIPT" --thread --pr 42 --comment-id 999 --body "Fixed."
+    [ "$status" -eq 0 ]
+    grep -F "ARG: repos/owner/repo/pulls/42/comments/999/replies" "$GH_LOG"
+}
+
+@test "--issue mode hits the issues comments endpoint" {
+    run "$SCRIPT" --issue --pr 42 --body "Re: @alice — fixed."
+    [ "$status" -eq 0 ]
+    grep -F "ARG: repos/owner/repo/issues/42/comments" "$GH_LOG"
+}
+
+@test "attribution suffix is appended with the resolved handle" {
+    run "$SCRIPT" --issue --pr 42 --body "Hello world."
+    [ "$status" -eq 0 ]
+    # The body arg passed to gh should contain the attribution line.
+    grep -F "agent on behalf of; stub-user" "$GH_LOG"
+}
+
+@test "RESPOND_GH_HANDLE overrides handle resolution" {
+    export RESPOND_GH_HANDLE="override-handle"
+    run "$SCRIPT" --issue --pr 42 --body "Hello."
+    [ "$status" -eq 0 ]
+    grep -F "agent on behalf of; override-handle" "$GH_LOG"
+    # And gh api user was never called (env var short-circuits).
+    ! grep -F "ARG: user" "$GH_LOG"
+}
+
+@test "idempotent: body already ending with attribution is not double-appended" {
+    body=$'Hello.\n\n---\nagent on behalf of; stub-user'
+    run "$SCRIPT" --issue --pr 42 --body "$body"
+    [ "$status" -eq 0 ]
+    # Exactly one attribution line in the gh body arg.
+    count=$(grep -cF "agent on behalf of; stub-user" "$GH_LOG")
+    [ "$count" -eq 1 ]
+}
+
+@test "missing --pr fails with usage error" {
+    run "$SCRIPT" --thread --comment-id 999 --body "x"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"missing --pr"* ]]
+}
+
+@test "--thread without --comment-id fails" {
+    run "$SCRIPT" --thread --pr 42 --body "x"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"missing --comment-id"* ]]
+}
+
+@test "--issue with --comment-id fails" {
+    run "$SCRIPT" --issue --pr 42 --comment-id 999 --body "x"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--comment-id is not valid for --issue"* ]]
+}
+
+@test "unknown flag fails" {
+    run "$SCRIPT" --issue --pr 42 --body "x" --bogus value
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"unknown argument"* ]]
+}
+
+@test "--thread and --issue together fails" {
+    run "$SCRIPT" --thread --issue --pr 42 --comment-id 1 --body "x"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"cannot combine"* ]]
+}
+
+@test "handle resolution falls through gh failure to git config" {
+    # Override gh to fail on `api user` but still respond to repo view.
+    cat > "$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+{
+  printf '=== GH_INVOKE ===\n'
+  for arg in "$@"; do
+    printf 'ARG: %s\n' "$arg"
+  done
+  printf '=== END ===\n'
+} >> "$GH_LOG"
+case "$1 $2" in
+  "api user")   exit 1 ;;
+  "repo view")  printf 'owner/repo\n' ;;
+  *)            : ;;
+esac
+exit 0
+EOF
+    chmod +x "$FAKE_BIN/gh"
+
+    # Stub git so `git config user.name` returns a known value.
+    cat > "$FAKE_BIN/git" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "config" ] && [ "$2" = "user.name" ]; then
+  printf 'fallback-user\n'
+  exit 0
+fi
+exit 1
+EOF
+    chmod +x "$FAKE_BIN/git"
+
+    run "$SCRIPT" --issue --pr 42 --body "Hello."
+    [ "$status" -eq 0 ]
+    grep -F "agent on behalf of; fallback-user" "$GH_LOG"
+}
+
+@test "handle resolution failure when all sources exhausted exits with clear error" {
+    # gh api user fails; git config user.name also fails.
+    cat > "$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "api user")   exit 1 ;;
+  "repo view")  printf 'owner/repo\n' ;;
+esac
+exit 0
+EOF
+    chmod +x "$FAKE_BIN/gh"
+
+    cat > "$FAKE_BIN/git" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$FAKE_BIN/git"
+
+    run "$SCRIPT" --issue --pr 42 --body "Hello."
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"could not resolve a GitHub handle"* ]]
+}
+
+@test "resolve_repo failure surfaces a clear error" {
+    # gh repo view fails; gh api user still works.
+    cat > "$FAKE_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+case "$1 $2" in
+  "api user")   printf 'stub-user\n' ;;
+  "repo view")  exit 1 ;;
+esac
+exit 0
+EOF
+    chmod +x "$FAKE_BIN/gh"
+
+    run "$SCRIPT" --issue --pr 42 --body "Hello."
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"could not resolve <owner>/<repo>"* ]]
+}
+
+@test "body with shell metacharacters is preserved verbatim" {
+    body='Backticks `code` and $vars and "quotes" and newlines
+still survive.'
+    run "$SCRIPT" --issue --pr 42 --body "$body"
+    [ "$status" -eq 0 ]
+    # The literal backtick-code segment must appear in the gh body arg.
+    grep -F 'Backticks `code` and $vars' "$GH_LOG"
+}

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -15,6 +15,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / "skills" / "melt" / "scripts"
 MOLD_SCRIPTS_DIR = REPO_ROOT / "skills" / "mold" / "scripts"
+AFFINAGE_SCRIPTS_DIR = REPO_ROOT / "skills" / "affinage" / "scripts"
 SHARED_SCRIPTS = REPO_ROOT / "shared" / "scripts"
 
 
@@ -55,3 +56,8 @@ def detect_squash_residue() -> ModuleType:
 @pytest.fixture(scope="session")
 def curd_count() -> ModuleType:
     return _load("curd_count", MOLD_SCRIPTS_DIR / "curd-count.py")
+
+
+@pytest.fixture(scope="session")
+def pr_status() -> ModuleType:
+    return _load("pr_status", AFFINAGE_SCRIPTS_DIR / "pr-status.py")

--- a/tests/python/test_pr_status.py
+++ b/tests/python/test_pr_status.py
@@ -1,0 +1,379 @@
+"""Tests for skills/affinage/scripts/pr-status.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Callable, Iterable
+
+import pytest
+
+
+class _FakeCompletedProcess:
+    def __init__(self, stdout: str = "", returncode: int = 0, stderr: str = ""):
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+def _matcher(prefix: Iterable[str]) -> Callable[[list[str]], bool]:
+    needle = list(prefix)
+    return lambda cmd: cmd[: len(needle)] == needle
+
+
+def _fake_run(responses: list[tuple[Callable[[list[str]], bool], str, int]]):
+    """Return a fake subprocess.run that dispatches by argv prefix.
+
+    Each response is (matcher, stdout, returncode). First match wins.
+    """
+
+    def runner(cmd, **kwargs):
+        for matcher, stdout, rc in responses:
+            if matcher(cmd):
+                return _FakeCompletedProcess(stdout=stdout, returncode=rc)
+        raise AssertionError(f"unmocked subprocess call: {cmd}")
+
+    return runner
+
+
+def test_passing_build_no_checks(pr_status, monkeypatch):
+    """Empty check list classifies as passing."""
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_run(
+            [
+                (_matcher(["gh", "pr", "checks"]), "[]", 0),
+                (
+                    _matcher(["gh", "pr", "view"]),
+                    json.dumps({"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}),
+                    0,
+                ),
+            ]
+        ),
+    )
+    output = pr_status.build_output(42)
+    assert output["pr"] == 42
+    assert output["build"]["status"] == "passing"
+    assert output["build"]["checks"] == []
+    assert output["merge"] == {"mergeable": "MERGEABLE", "state": "CLEAN"}
+
+
+def test_failing_build_extracts_summary_and_tests(pr_status, monkeypatch):
+    """A failing check enriches the entry with summary + failed tests."""
+    checks_json = json.dumps(
+        [
+            {
+                "name": "test-suite",
+                "state": "completed",
+                "conclusion": "failure",
+                "link": "https://github.com/foo/bar/actions/runs/12345/job/67890",
+            }
+        ]
+    )
+    log_lines = [
+        "Running tests...",
+        "PASS tests/format.test.ts",
+        "FAIL tests/auth.test.ts",
+        "FAILED tests/auth.test.ts::rejects_invalid_token",
+        "FAILED tests/auth.test.ts::rejects_missing_header",
+        "FAILED tests/auth.test.ts::rejects_expired_token",
+        "",
+        "3 failed, 8 passed (11)",
+        "",
+        "::error::Tests failed",
+        "##[error]Process completed with exit code 1",
+    ]
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_run(
+            [
+                (_matcher(["gh", "pr", "checks"]), checks_json, 0),
+                (
+                    _matcher(["gh", "pr", "view"]),
+                    json.dumps({"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}),
+                    0,
+                ),
+                (_matcher(["gh", "run", "view"]), "\n".join(log_lines), 0),
+            ]
+        ),
+    )
+    output = pr_status.build_output(42)
+    assert output["build"]["status"] == "failing"
+    assert len(output["build"]["checks"]) == 1
+    check = output["build"]["checks"][0]
+    assert check["name"] == "test-suite"
+    assert check["conclusion"] == "failure"
+    # tail summary contains the closing lines from the log
+    assert "Process completed with exit code 1" in check["failure_summary"]
+    # failed-test extraction finds the three test names
+    assert "tests/auth.test.ts::rejects_invalid_token" in check["failed_tests"]
+    assert "tests/auth.test.ts::rejects_missing_header" in check["failed_tests"]
+    assert "tests/auth.test.ts::rejects_expired_token" in check["failed_tests"]
+
+
+def test_pending_check_classified_pending(pr_status, monkeypatch):
+    """A check still in_progress reports pending."""
+    checks_json = json.dumps(
+        [{"name": "slow-job", "state": "in_progress", "conclusion": "", "link": ""}]
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_run(
+            [
+                (_matcher(["gh", "pr", "checks"]), checks_json, 0),
+                (
+                    _matcher(["gh", "pr", "view"]),
+                    json.dumps({"mergeable": "MERGEABLE", "mergeStateStatus": "UNSTABLE"}),
+                    0,
+                ),
+            ]
+        ),
+    )
+    output = pr_status.build_output(42)
+    assert output["build"]["status"] == "pending"
+
+
+def test_merge_conflict_surfaced(pr_status, monkeypatch):
+    """CONFLICTING / DIRTY merge state surfaces in the output."""
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_run(
+            [
+                (_matcher(["gh", "pr", "checks"]), "[]", 0),
+                (
+                    _matcher(["gh", "pr", "view"]),
+                    json.dumps({"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY"}),
+                    0,
+                ),
+            ]
+        ),
+    )
+    output = pr_status.build_output(42)
+    assert output["merge"]["mergeable"] == "CONFLICTING"
+    assert output["merge"]["state"] == "DIRTY"
+
+
+def test_missing_gh_exits_two(pr_status, monkeypatch):
+    """FileNotFoundError on subprocess.run → exit 2 (gh not installed)."""
+
+    def raise_fnfe(*args, **kwargs):
+        raise FileNotFoundError("gh not found")
+
+    monkeypatch.setattr(subprocess, "run", raise_fnfe)
+    with pytest.raises(SystemExit) as exc:
+        pr_status.fetch_checks(42)
+    assert exc.value.code == 2
+
+
+def test_gh_failure_exits_one(pr_status, monkeypatch):
+    """gh exits non-zero (e.g. PR not found) → exit 1."""
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_run([(_matcher(["gh", "pr", "checks"]), "", 1)]),
+    )
+    with pytest.raises(SystemExit) as exc:
+        pr_status.fetch_checks(42)
+    assert exc.value.code == 1
+
+
+def test_extract_run_id_from_actions_url(pr_status):
+    url = "https://github.com/foo/bar/actions/runs/123456789/job/987654"
+    assert pr_status.extract_run_id(url) == "123456789"
+
+
+def test_extract_run_id_returns_none_on_empty(pr_status):
+    assert pr_status.extract_run_id("") is None
+    assert pr_status.extract_run_id("https://example.com/no/run/here") is None
+
+
+def test_extract_failed_tests_pytest_style(pr_status):
+    log = "FAILED tests/auth.py::test_foo\nFAILED tests/auth.py::test_bar\nrandom line\n"
+    assert pr_status.extract_failed_tests(log) == [
+        "tests/auth.py::test_foo",
+        "tests/auth.py::test_bar",
+    ]
+
+
+def test_extract_failed_tests_rust_style(pr_status):
+    log = "running 3 tests\ntest foo::bar ... FAILED\ntest foo::baz ... ok\n"
+    assert pr_status.extract_failed_tests(log) == ["foo::bar"]
+
+
+def test_extract_failed_tests_dedups(pr_status):
+    log = "FAILED tests/x::a\nFAILED tests/x::a\n"
+    assert pr_status.extract_failed_tests(log) == ["tests/x::a"]
+
+
+def test_classify_status_with_cancelled_is_failing(pr_status):
+    checks = [{"name": "lint", "state": "completed", "conclusion": "cancelled", "link": ""}]
+    assert pr_status.classify_status(checks) == "failing"
+
+
+def test_main_writes_json_to_stdout(pr_status, monkeypatch, capsys):
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_run(
+            [
+                (_matcher(["gh", "pr", "checks"]), "[]", 0),
+                (
+                    _matcher(["gh", "pr", "view"]),
+                    json.dumps({"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}),
+                    0,
+                ),
+            ]
+        ),
+    )
+    rc = pr_status.main(["42"])
+    assert rc == 0
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["pr"] == 42
+    assert payload["build"]["status"] == "passing"
+
+
+def test_classify_status_with_timed_out_is_failing(pr_status):
+    """timed_out conclusion classifies as failing (sibling of failure/cancelled)."""
+    checks = [{"name": "slow", "state": "completed", "conclusion": "timed_out", "link": ""}]
+    assert pr_status.classify_status(checks) == "failing"
+
+
+def test_multiple_failing_checks_get_independent_summaries(pr_status, monkeypatch):
+    """Each failing check fetches its own log; summaries don't bleed across checks."""
+    checks_json = json.dumps(
+        [
+            {
+                "name": "unit-tests",
+                "state": "completed",
+                "conclusion": "failure",
+                "link": "https://github.com/foo/bar/actions/runs/111/job/1",
+            },
+            {
+                "name": "e2e",
+                "state": "completed",
+                "conclusion": "failure",
+                "link": "https://github.com/foo/bar/actions/runs/222/job/2",
+            },
+        ]
+    )
+
+    def runner(cmd, **kwargs):
+        if cmd[:3] == ["gh", "pr", "checks"]:
+            return _FakeCompletedProcess(stdout=checks_json)
+        if cmd[:3] == ["gh", "pr", "view"]:
+            return _FakeCompletedProcess(
+                stdout=json.dumps({"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"})
+            )
+        if cmd[:3] == ["gh", "run", "view"]:
+            # Dispatch by run id in argv.
+            run_id = cmd[3]
+            if run_id == "111":
+                return _FakeCompletedProcess(stdout="FAILED tests/unit.py::test_a\n")
+            if run_id == "222":
+                return _FakeCompletedProcess(stdout="FAILED tests/e2e.py::test_b\n")
+        raise AssertionError(f"unmocked: {cmd}")
+
+    monkeypatch.setattr(subprocess, "run", runner)
+    output = pr_status.build_output(42)
+    checks = output["build"]["checks"]
+    assert len(checks) == 2
+    unit = next(c for c in checks if c["name"] == "unit-tests")
+    e2e = next(c for c in checks if c["name"] == "e2e")
+    assert "tests/unit.py::test_a" in unit["failed_tests"]
+    assert "tests/unit.py::test_a" not in e2e["failed_tests"]
+    assert "tests/e2e.py::test_b" in e2e["failed_tests"]
+    assert "tests/e2e.py::test_b" not in unit["failed_tests"]
+
+
+def test_malformed_json_from_gh_checks_exits_one(pr_status, monkeypatch):
+    """Non-JSON output from gh pr checks exits 1 (defensive parse)."""
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_run([(_matcher(["gh", "pr", "checks"]), "not json at all", 0)]),
+    )
+    with pytest.raises(SystemExit) as exc:
+        pr_status.fetch_checks(42)
+    assert exc.value.code == 1
+
+
+def test_malformed_json_from_gh_pr_view_falls_back_to_unknown(pr_status, monkeypatch):
+    """Malformed JSON from gh pr view falls back to UNKNOWN/UNKNOWN (less critical than checks)."""
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_run([(_matcher(["gh", "pr", "view"]), "garbage", 0)]),
+    )
+    merge = pr_status.fetch_merge_state(42)
+    assert merge == {"mergeable": "UNKNOWN", "state": "UNKNOWN"}
+
+
+def test_failing_check_with_empty_log_yields_empty_summary(pr_status, monkeypatch):
+    """gh run view returning empty produces empty summary, not a crash."""
+    checks_json = json.dumps(
+        [
+            {
+                "name": "slow",
+                "state": "completed",
+                "conclusion": "failure",
+                "link": "https://github.com/foo/bar/actions/runs/999/job/1",
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_run(
+            [
+                (_matcher(["gh", "pr", "checks"]), checks_json, 0),
+                (
+                    _matcher(["gh", "pr", "view"]),
+                    json.dumps({"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}),
+                    0,
+                ),
+                (_matcher(["gh", "run", "view"]), "", 1),
+            ]
+        ),
+    )
+    output = pr_status.build_output(42)
+    check = output["build"]["checks"][0]
+    assert check["failure_summary"] == ""
+    assert check["failed_tests"] == []
+    # status still classifies as failing
+    assert output["build"]["status"] == "failing"
+
+
+def test_failing_check_with_no_run_id_in_link_yields_empty_summary(pr_status, monkeypatch):
+    """A failing check whose link has no /runs/<id> segment skips log fetch gracefully."""
+    checks_json = json.dumps(
+        [
+            {
+                "name": "weird",
+                "state": "completed",
+                "conclusion": "failure",
+                "link": "https://example.com/no-run-id-here",
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_run(
+            [
+                (_matcher(["gh", "pr", "checks"]), checks_json, 0),
+                (
+                    _matcher(["gh", "pr", "view"]),
+                    json.dumps({"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}),
+                    0,
+                ),
+            ]
+        ),
+    )
+    output = pr_status.build_output(42)
+    assert output["build"]["checks"][0]["failure_summary"] == ""
+    assert output["build"]["checks"][0]["failed_tests"] == []

--- a/tests/python/test_pr_status.py
+++ b/tests/python/test_pr_status.py
@@ -65,8 +65,8 @@ def test_failing_build_extracts_summary_and_tests(pr_status, monkeypatch):
         [
             {
                 "name": "test-suite",
-                "state": "completed",
-                "conclusion": "failure",
+                "state": "FAILURE",
+                "bucket": "fail",
                 "link": "https://github.com/foo/bar/actions/runs/12345/job/67890",
             }
         ]
@@ -116,7 +116,7 @@ def test_failing_build_extracts_summary_and_tests(pr_status, monkeypatch):
 def test_pending_check_classified_pending(pr_status, monkeypatch):
     """A check still in_progress reports pending."""
     checks_json = json.dumps(
-        [{"name": "slow-job", "state": "in_progress", "conclusion": "", "link": ""}]
+        [{"name": "slow-job", "state": "IN_PROGRESS", "bucket": "pending", "link": ""}]
     )
     monkeypatch.setattr(
         subprocess,
@@ -210,7 +210,7 @@ def test_extract_failed_tests_dedups(pr_status):
 
 
 def test_classify_status_with_cancelled_is_failing(pr_status):
-    checks = [{"name": "lint", "state": "completed", "conclusion": "cancelled", "link": ""}]
+    checks = [{"name": "lint", "state": "CANCELLED", "bucket": "fail", "link": ""}]
     assert pr_status.classify_status(checks) == "failing"
 
 
@@ -239,7 +239,7 @@ def test_main_writes_json_to_stdout(pr_status, monkeypatch, capsys):
 
 def test_classify_status_with_timed_out_is_failing(pr_status):
     """timed_out conclusion classifies as failing (sibling of failure/cancelled)."""
-    checks = [{"name": "slow", "state": "completed", "conclusion": "timed_out", "link": ""}]
+    checks = [{"name": "slow", "state": "TIMED_OUT", "bucket": "fail", "link": ""}]
     assert pr_status.classify_status(checks) == "failing"
 
 
@@ -249,14 +249,14 @@ def test_multiple_failing_checks_get_independent_summaries(pr_status, monkeypatc
         [
             {
                 "name": "unit-tests",
-                "state": "completed",
-                "conclusion": "failure",
+                "state": "FAILURE",
+                "bucket": "fail",
                 "link": "https://github.com/foo/bar/actions/runs/111/job/1",
             },
             {
                 "name": "e2e",
-                "state": "completed",
-                "conclusion": "failure",
+                "state": "FAILURE",
+                "bucket": "fail",
                 "link": "https://github.com/foo/bar/actions/runs/222/job/2",
             },
         ]
@@ -319,8 +319,8 @@ def test_failing_check_with_empty_log_yields_empty_summary(pr_status, monkeypatc
         [
             {
                 "name": "slow",
-                "state": "completed",
-                "conclusion": "failure",
+                "state": "FAILURE",
+                "bucket": "fail",
                 "link": "https://github.com/foo/bar/actions/runs/999/job/1",
             }
         ]
@@ -354,8 +354,8 @@ def test_failing_check_with_no_run_id_in_link_yields_empty_summary(pr_status, mo
         [
             {
                 "name": "weird",
-                "state": "completed",
-                "conclusion": "failure",
+                "state": "FAILURE",
+                "bucket": "fail",
                 "link": "https://example.com/no-run-id-here",
             }
         ]
@@ -377,3 +377,89 @@ def test_failing_check_with_no_run_id_in_link_yields_empty_summary(pr_status, mo
     output = pr_status.build_output(42)
     assert output["build"]["checks"][0]["failure_summary"] == ""
     assert output["build"]["checks"][0]["failed_tests"] == []
+
+
+def test_non_list_json_from_gh_checks_exits_one(pr_status, monkeypatch):
+    """Regression for cure #3: valid JSON that isn't a list now exits 1
+    (was silently returning []), so a future schema flip is loud not silent."""
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_run([(_matcher(["gh", "pr", "checks"]), '{"error": "unexpected shape"}', 0)]),
+    )
+    with pytest.raises(SystemExit) as exc:
+        pr_status.fetch_checks(42)
+    assert exc.value.code == 1
+
+
+def test_gh_pr_checks_uses_real_schema_fields(pr_status, monkeypatch):
+    """Regression for cure #1: the --json arg passed to `gh pr checks` must use
+    fields that the CLI actually returns. The original implementation requested
+    `conclusion` (which does not exist on `gh pr checks`) and died on every real
+    invocation; only the recursive integration test caught it because the unit
+    mocks lied. Lock in the correct shape so future edits stay honest."""
+    captured: list[list[str]] = []
+
+    def runner(cmd, **kwargs):
+        captured.append(list(cmd))
+        if cmd[:3] == ["gh", "pr", "checks"]:
+            return _FakeCompletedProcess(stdout="[]")
+        return _FakeCompletedProcess(stdout="")
+
+    monkeypatch.setattr(subprocess, "run", runner)
+    pr_status.fetch_checks(42)
+
+    check_call = next(c for c in captured if c[:3] == ["gh", "pr", "checks"])
+    json_arg_idx = check_call.index("--json") + 1
+    fields = check_call[json_arg_idx].split(",")
+    # `conclusion` does NOT exist on `gh pr checks --json`; `bucket` is the real
+    # pre-classified field. The original bug landed exactly here.
+    assert "conclusion" not in fields, (
+        "gh pr checks has no `conclusion` field; use `bucket` (pass/fail/pending/skipping)"
+    )
+    assert "bucket" in fields, "must request `bucket` so classify_status has its input"
+    # `state` is also a real field and is used to derive the per-check `conclusion`
+    # output value, so it must be requested too.
+    assert "state" in fields
+
+
+def test_failing_state_with_cancelled_bucket_fail_enriches(pr_status, monkeypatch):
+    """Regression for cure #4: enrichment runs on bucket==fail, so cancelled
+    and timed_out states (which gh classifies as bucket=fail) now get summary
+    + failed_tests population, not just classification."""
+    checks_json = json.dumps(
+        [
+            {
+                "name": "slow",
+                "state": "CANCELLED",
+                "bucket": "fail",
+                "link": "https://github.com/foo/bar/actions/runs/555/job/1",
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        _fake_run(
+            [
+                (_matcher(["gh", "pr", "checks"]), checks_json, 0),
+                (
+                    _matcher(["gh", "pr", "view"]),
+                    json.dumps({"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}),
+                    0,
+                ),
+                (
+                    _matcher(["gh", "run", "view"]),
+                    "job cancelled by user at step 3\nFAILED tests/cancel.py::test_x",
+                    0,
+                ),
+            ]
+        ),
+    )
+    output = pr_status.build_output(42)
+    check = output["build"]["checks"][0]
+    # state lowercased into conclusion (spec output contract preserved).
+    assert check["conclusion"] == "cancelled"
+    # bucket==fail triggers enrichment for non-failure states too — the cure #4 fix.
+    assert "tests/cancel.py::test_x" in check["failed_tests"]
+    assert "cancelled by user" in check["failure_summary"]


### PR DESCRIPTION
## Summary

Implements [`.cheese/specs/affinage.md`](../tree/paulnsorensen/age-review-comments/.cheese/specs/affinage.md) (spec is gitignored — see the cook report below for the contract): a new `/affinage` skill that triages external claims about a PR — review comments AND CI failures — by running them through the same ten-dimension `/age` lens, then hands selected findings to `/cure` and posts per-finding GitHub replies on return.

Position in the cave:
- `/age` reviews **your** code.
- `/affinage` reviews the **reviewer's** claims about your code.
- `/cure` applies the resulting decisions.

## Three new artifacts

- **`skills/affinage/SKILL.md`** — the skill prose: input shape, eight-step flow (resolve PR → fetch status → fetch comments → skip-already-replied → grade through age lens → write report → selection gate → post-cure reply posting), sub-agent context gate, auto-mode chain, `--hard` propagation, report shape with new `## Needs-investigation` and `## Reviewer-rejected` sections.
- **`skills/affinage/scripts/pr-status.py`** — Python helper wrapping `gh pr checks`, `gh pr view`, and `gh run view --log-failed`. Returns structured JSON with build status, per-check failure summaries (last ~10 lines of failed logs), heuristic failed-test extraction (pytest / rust / jest patterns), and merge state. Exits `2` on missing `gh`, `1` on PR/gh-api error.
- **`shared/post-reply.sh`** — ported from global `/respond`'s contract. Single source of truth for the literal `agent on behalf of;` attribution suffix. Idempotent body composition; handle resolution falls through `RESPOND_GH_HANDLE` → `gh api user --jq .login` → `git config user.name`.

## Locked design decisions

These resolve the agent-introduced items flagged during the `/mold` dialogue. Documented in the spec so downstream skills don't re-litigate:

1. CI failures are graded as findings (not fixed inline). `pr-status.py` extracts the data; the skill grades it through the age lens like any other finding.
2. Reviewer-asserted urgency (`CHANGES_REQUESTED`) is **metadata only**, not a severity bump. Sandbagged blockers stop being inflated by reviewer framing.
3. `shared/post-reply.sh` is the single source of truth for `agent on behalf of;` — never paraphrase, never duplicate the literal into callers.
4. Slug is `pr-<number>`; re-runs overwrite. Idempotency comes from skipping threads where the latest comment is from the resolved handle.
5. Outdated review threads skipped by default; opt-in via `--include-outdated`.

## Test plan

- [x] `python3 -m pytest tests/python/test_pr_status.py -q` → 19 passed (passing/failing builds, multi-check independence, malformed JSON defensive parse, empty/no-run-id logs, all conclusion variants, three failed-test extraction styles).
- [x] `bats tests/bash/test_post_reply.bats` → 14/14 ok (endpoint routing, attribution, RESPOND_GH_HANDLE override, idempotency, handle fallback chain through git config, resolve_repo failure, shell-metachar passthrough, arg validation).
- [x] `just test` (full suite: skill validators + melt + shared + cheese-factory + bash install + cheese-factory bats + new bats) → all green.
- [x] `just lint-md` → 0 errors across 54 files.
- [x] `uvx ruff check skills/affinage tests/python/test_pr_status.py` → clean.
- [x] `shellcheck shared/post-reply.sh` → clean.
- [ ] **Integration test (planned):** running `/affinage` on **this PR** after CI has had ~10 minutes to settle. This is the deliberate end-to-end test — the skill graded against itself, real `gh` API, real CI failure surface if any.

## Note on `.serena/project.yml`

There is a pre-existing `yamllint` failure in `.serena/project.yml:35` (indentation). Verified pre-existing on `origin/main` (reproduces after `git stash` of this branch's changes). Not touched per surgical-scope rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)