### PR TITLE
fix(release): ship built .pyz by tagging a release branch, not main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,32 +44,41 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh skill publish --dry-run
 
-      - name: Drop trigger tag so skill publish can recreate it
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          git push origin ":refs/tags/$TAG"
-          git tag -d "$TAG" || true
+      - name: Stage shippable release tree
+        run: python3 scripts/stage_release.py --out "$RUNNER_TEMP/release"
 
-      - name: Build and stage skill bundles
-        run: |
-          set -euo pipefail
-          python3 scripts/build_pyz.py
-          shopt -s nullglob
-          bundles=(skills/*/scripts/*.pyz)
-          # Fail loudly if nothing was built rather than publishing broken skills.
-          test ${#bundles[@]} -gt 0 || { echo "::error::no skill bundles were built"; exit 1; }
-          git add -f "${bundles[@]}"
-          # Confirm every built bundle is actually staged before publish.
-          staged="$(git diff --cached --name-only)"
-          for pyz in "${bundles[@]}"; do
-            printf '%s\n' "$staged" | grep -qxF "$pyz" || { echo "::error::bundle not staged for publish: $pyz"; exit 1; }
-          done
-          git -c user.email=actions@github.com -c user.name="github-actions[bot]" commit -m "build: bundle skill .pyz for release"
-
-      - name: Publish agent skills
+      # `gh skill install` reads the git tree at the resolved tag, so the tag must
+      # point at a commit that actually contains the built .pyz. We commit the
+      # staged tree to the `release` branch and force the version tag onto THAT
+      # commit — never main, which keeps its .pyz gitignored. Pushes use
+      # GITHUB_TOKEN, which by design does not re-trigger this tag-push workflow.
+      - name: Publish release branch and retarget tag
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
-        run: gh skill publish --tag "$TAG"
+        run: |
+          set -euo pipefail
+          src_sha="$GITHUB_SHA"
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          cd "$RUNNER_TEMP/release"
+          git init -q
+          git checkout -q -b release
+          git add -A
+          git -c user.email=actions@github.com -c user.name="github-actions[bot]" \
+            commit -qm "release: $TAG from main@${src_sha}"
+          git push -f "$remote" "release:refs/heads/release"
+          git tag -f "$TAG"
+          git push -f "$remote" "refs/tags/$TAG"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |-
+          set -euo pipefail
+          gh repo edit "$GITHUB_REPOSITORY" --add-topic agent-skills || true
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" --verify-tag
+          else
+            gh release create "$TAG" --verify-tag --generate-notes --title "$TAG"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ site/
 
 # Built skill bundles (built on publish; never committed to main)
 skills/*/scripts/*.pyz
+
+# `just release-preview` staging output (hidden so validate_skills.py skips it)
+.release-preview/

--- a/justfile
+++ b/justfile
@@ -19,6 +19,11 @@ test:
 bundle:
     python3 scripts/build_pyz.py
 
+# Preview the exact tree a release ships (skills + .pyz only, no sources)
+release-preview:
+    python3 scripts/stage_release.py --out .release-preview
+    @echo "Staged release tree at .release-preview — inspect with: find .release-preview -type f"
+
 # Lint shell scripts
 lint-sh:
     shellcheck scripts/install.sh shared/post-reply.sh

--- a/scripts/stage_release.py
+++ b/scripts/stage_release.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Assemble the shippable release tree: SKILL.md + one built <skill>.pyz per skill,
+plus top-level project metadata. Everything a consumer does NOT need — raw script
+sources (src/, shared/), build/test tooling, docs, CI config — is left behind.
+
+The release workflow commits this tree to the `release` branch and points the
+version tag at it, so `gh skill install` (which reads the git tree at the tag)
+pulls a minimal, self-contained skill: the dispatching .pyz, never the loose .py.
+
+Bundles are built straight into the staged tree via build_pyz.build_bundle, so
+neither this script nor its test mutates the repo's working copy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import build_pyz  # noqa: E402  (sibling module in scripts/)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Allowlist, not denylist: new dev scaffolding added to the repo stays out of
+# releases by default. `skills` ships wholesale (post-build); metadata files
+# ship if present.
+SHIP = [
+    "skills",
+    "README.md",
+    "LICENSE",
+    "SECURITY.md",
+    "CODE_OF_CONDUCT.md",
+    ".claude-plugin",
+]
+
+
+def _copy(src: Path, dst: Path) -> None:
+    if src.is_dir():
+        shutil.copytree(src, dst)
+    else:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+
+
+def stage(out: Path, repo: Path = REPO_ROOT) -> Path:
+    """Build the release tree at ``out`` (wiped first). Returns ``out``."""
+    if out.exists():
+        shutil.rmtree(out)
+    out.mkdir(parents=True)
+
+    for rel in SHIP:
+        src = repo / rel
+        if src.exists():
+            _copy(src, out / rel)
+
+    # Build each bundle directly into the staged skill dir — the only scripts a
+    # released skill ships. Sources stay in the repo's src/ + shared/, unshipped.
+    for skill in build_pyz.SKILLS:
+        target = out / "skills" / skill / "scripts" / f"{skill}.pyz"
+        build_pyz.build_bundle(skill, target)
+
+    _verify(out)
+    return out
+
+
+def _verify(out: Path) -> None:
+    """Fail loud if the staged tree is wrong — a broken release should never get
+    silently published (the v0.5.1 failure mode)."""
+    skills = out / "skills"
+    if not any(skills.glob("*/SKILL.md")):
+        raise SystemExit(f"stage_release: no skills found under {skills}")
+
+    for skill in build_pyz.SKILLS:
+        pyz = skills / skill / "scripts" / f"{skill}.pyz"
+        if not pyz.is_file():
+            raise SystemExit(f"stage_release: missing bundle {pyz}")
+
+    stray = sorted(str(p.relative_to(out)) for p in skills.rglob("*.py"))
+    if stray:
+        raise SystemExit(
+            "stage_release: raw .py sources must not ship under skills/; found: "
+            + ", ".join(stray)
+        )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Stage the shippable release tree.")
+    parser.add_argument("--out", type=Path, required=True, help="Output directory (wiped first).")
+    args = parser.parse_args(argv[1:])
+    out = stage(args.out)
+    print(f"staged release tree at {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/stage_release.py
+++ b/scripts/stage_release.py
@@ -44,14 +44,25 @@ def _copy(src: Path, dst: Path) -> None:
         shutil.copy2(src, dst)
 
 
-def stage(out: Path, repo: Path = REPO_ROOT) -> Path:
+def _guard_out(out: Path) -> None:
+    """``stage`` wipes ``out`` with rmtree — refuse paths whose loss would be
+    catastrophic: the filesystem root, the repo itself, or an ancestor of it."""
+    resolved = out.resolve()
+    if resolved == Path(resolved.anchor):
+        raise SystemExit(f"stage_release: refusing to wipe filesystem root {resolved}")
+    if resolved == REPO_ROOT or resolved in REPO_ROOT.parents:
+        raise SystemExit(f"stage_release: refusing to wipe {resolved} (repo root or ancestor)")
+
+
+def stage(out: Path) -> Path:
     """Build the release tree at ``out`` (wiped first). Returns ``out``."""
+    _guard_out(out)
     if out.exists():
         shutil.rmtree(out)
     out.mkdir(parents=True)
 
     for rel in SHIP:
-        src = repo / rel
+        src = REPO_ROOT / rel
         if src.exists():
             _copy(src, out / rel)
 

--- a/tests/python/test_stage_release.py
+++ b/tests/python/test_stage_release.py
@@ -29,7 +29,8 @@ def test_every_skill_ships_its_bundle(staged: Path) -> None:
         pyz = staged / "skills" / skill / "scripts" / f"{skill}.pyz"
         assert pyz.is_file(), f"missing bundle for {skill}"
         # A real zipapp, not an empty placeholder: it carries the dispatcher.
-        assert "__main__.py" in zipfile.ZipFile(pyz).namelist()
+        with zipfile.ZipFile(pyz) as zf:
+            assert "__main__.py" in zf.namelist()
 
 
 def test_skill_metadata_ships(staged: Path) -> None:
@@ -52,6 +53,14 @@ def test_dev_scaffolding_excluded(staged: Path, dev_dir: str) -> None:
 def test_top_level_metadata_present(staged: Path) -> None:
     assert (staged / "README.md").is_file()
     assert (staged / "LICENSE").is_file()
+
+
+@pytest.mark.parametrize("danger", ["/", str(REPO_ROOT), str(REPO_ROOT.parent)])
+def test_stage_refuses_to_wipe_dangerous_paths(danger: str) -> None:
+    """rmtree on --out must never touch the filesystem root, the repo, or an
+    ancestor — accidental data loss is the irreversible failure mode here."""
+    with pytest.raises(SystemExit, match="refusing to wipe"):
+        stage_release.stage(Path(danger))
 
 
 def test_verify_rejects_missing_bundle(tmp_path: Path) -> None:

--- a/tests/python/test_stage_release.py
+++ b/tests/python/test_stage_release.py
@@ -1,0 +1,63 @@
+"""The staged release tree is exactly the shippable surface: every skill carries
+its built <skill>.pyz and its SKILL.md, no raw .py sources leak in, and dev-only
+scaffolding (src/, shared/, scripts/, tests/, docs/, .github/) is left behind.
+These are the invariants that, when violated silently, shipped the empty v0.5.1.
+"""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import build_pyz  # noqa: E402
+import stage_release  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def staged(tmp_path_factory) -> Path:
+    return stage_release.stage(tmp_path_factory.mktemp("release") / "tree")
+
+
+def test_every_skill_ships_its_bundle(staged: Path) -> None:
+    for skill in build_pyz.SKILLS:
+        pyz = staged / "skills" / skill / "scripts" / f"{skill}.pyz"
+        assert pyz.is_file(), f"missing bundle for {skill}"
+        # A real zipapp, not an empty placeholder: it carries the dispatcher.
+        assert "__main__.py" in zipfile.ZipFile(pyz).namelist()
+
+
+def test_skill_metadata_ships(staged: Path) -> None:
+    for skill in build_pyz.SKILLS:
+        assert (staged / "skills" / skill / "SKILL.md").is_file()
+
+
+def test_no_raw_python_under_skills(staged: Path) -> None:
+    """The release ships the .pyz, never the loose .py — the whole point of the
+    src/ relocation. A stray .py here means a skill leaked its sources."""
+    stray = sorted(p.relative_to(staged) for p in (staged / "skills").rglob("*.py"))
+    assert stray == [], f"raw python leaked into release: {stray}"
+
+
+@pytest.mark.parametrize("dev_dir", ["src", "shared", "scripts", "tests", "docs", ".github"])
+def test_dev_scaffolding_excluded(staged: Path, dev_dir: str) -> None:
+    assert not (staged / dev_dir).exists(), f"{dev_dir}/ must not ship in a release"
+
+
+def test_top_level_metadata_present(staged: Path) -> None:
+    assert (staged / "README.md").is_file()
+    assert (staged / "LICENSE").is_file()
+
+
+def test_verify_rejects_missing_bundle(tmp_path: Path) -> None:
+    """_verify is the publish gate — it must reject a tree whose bundles are absent."""
+    fake = tmp_path / "tree"
+    (fake / "skills" / "affinage").mkdir(parents=True)
+    (fake / "skills" / "affinage" / "SKILL.md").write_text("# affinage\n")
+    with pytest.raises(SystemExit, match="missing bundle"):
+        stage_release._verify(fake)


### PR DESCRIPTION
## Problem

`gh skill install` reads the **git tree at the resolved tag**. The release workflow built the `.pyz` bundles into a CI-local commit that was **never pushed** — then `gh skill publish --tag` created the GitHub Release, and GitHub auto-created the missing tag at the **default branch HEAD (main)**, where `skills/*/scripts/*.pyz` is gitignored.

Result: every tagged release since the `.pyz` restructure (**v0.5.1**) shipped `SKILL.md` files invoking `<skill>.pyz` bundles that were never delivered. `affinage`, `melt`, `cheese-factory`, and `mold` all install **broken** via `gh skill install` (the path `install.sh` and downstream dotfiles use). The release ran green in ~14s while shipping nothing.

## Fix

Build a dedicated **`release` branch** and put the tag on *that* commit:

- **`scripts/stage_release.py`** — assembles the shippable surface from an allowlist: `SKILL.md` + one built `<skill>.pyz` per skill + top-level metadata (`README`, `LICENSE`, `.claude-plugin`, …). Drops `src/`, `shared/`, and all dev scaffolding — the raw `.py` sources never ship, only the `.pyz`. Builds bundles straight into the staged tree (no working-copy mutation). `_verify` **fails loud** on a missing bundle or a leaked raw `.py`.
- **`.github/workflows/release.yml`** — validate (`gh skill publish --dry-run`) → stage → commit to `release` → force-push branch → retarget the version tag onto the release commit → `gh release create`. Pushes use `GITHUB_TOKEN`, which by design does not re-trigger the tag-push workflow.
- **`tests/python/test_stage_release.py`** — every skill ships its `.pyz`, no `.py` leaks under `skills/`, dev dirs excluded, `_verify` rejects a missing bundle.
- **`justfile`** — `release-preview` stages into hidden `.release-preview/` (skipped by `validate_skills.py`) for local inspection.

`main` stays clean — bundles remain gitignored there and live only on `release` + tags.

## Verification

- `just check` green (validators, shellcheck, pytest + bats suites, `mkdocs build --strict`).
- `release-preview` produces exactly `skills/<name>/{SKILL.md, scripts/<name>.pyz}` + metadata; no `src/`/`shared/`, no leaked `.py`.

## Follow-up

This fixes the machinery but does **not** repair v0.5.1 — delivering the bundles needs a fresh **v0.5.2** cut with this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)