### PR TITLE
docs(age,affinage): route cheap nits to /cure instead of pushing back

### DIFF
--- a/skills/affinage/SKILL.md
+++ b/skills/affinage/SKILL.md
@@ -53,20 +53,20 @@ Flags:
    - Compute severity from base + location + compounding modifiers (same rubric as `/age`).
    - **Ignore reviewer-asserted urgency for severity computation.** Surface `CHANGES_REQUESTED` as metadata (`reviewer-asserted:` line) but do not let it modify computed severity.
    - Bucket into:
-     - Standard severity sections (`## Blocker / ## High / ## Medium / ## Low`) when the claim maps to a dimension and the diff grounds it.
+     - Standard severity sections (`## Blocker / ## High / ## Medium / ## Low`) when the claim is grounded in the diff — whether it maps to a dimension OR is a valid improvement (a style nit counts) whose fix is **contained** (`fix-cost-now: contained` — roughly a few lines or a localized refactor). A valid cheap nit is cheaper to fix than to argue, so route it to `/cure` (usually as `Low`) and keep its `[from-comment:<id>]` tag so `/cure`'s reply still reaches the reviewer. Do not push back on it.
      - `## Needs-investigation` when the claim is plausible but requires evidence outside the diff (e.g., downstream caller in another repo).
-     - `## Reviewer-rejected` when the claim maps to no dimension, is ungrounded, or is pure style.
+     - `## Reviewer-rejected` only when the claim is **wrong or ungrounded** (the code is already correct, the reviewer misread it, or there is no real improvement) OR is valid but **a lot of follow-up work** (`fix-cost-now: moderate`/`sprawling` or `fix-cost-later: structural` — a refactor or scope expansion beyond this PR). Reject the wrong ones; defer the expensive ones. Per `skills/age/references/voice.md`, a justified push-back costs more than a small valid fix.
 7. **Write report** to `.cheese/affinage/pr-<n>.md` with the four-line handoff slug at the top, then the age-format body plus the two extra sections. See `## Output` below.
 8. **Selection gate** (interactive mode). Branch on what graded out:
-   - **At least one `Blocker` / `High` / `Medium` finding.** Render the cure-selection table inline using `/cure`'s verbs (`skills/cure/references/selection.md`). Ask via `shared/handoff-gate.md`. On non-empty selection, **first run step 9** to post any drafted push-backs / investigating notes — they don't depend on cure's outcome, so they must reach GitHub even if `/cure` later halts or the session is interrupted — then dispatch `/cure <slug>` with locked `handoff_context:` and post the cure-dependent replies (step 10) when `/cure` returns. On `none` / `Stop`, run step 9 for any drafted push-backs / investigating notes, then exit with the report path.
-   - **No medium-or-above findings, but `Reviewer-rejected` or `Needs-investigation` has items.** Skip `/cure` dispatch entirely — there is nothing to apply. Render a small gate that lets the user pick `post all`, `post pushbacks only`, `skip posting`, or per-finding choices. On the selection, run step 9 to post the chosen replies. Exit with `status: ok / next: done`. This mirrors the documented auto-mode "no findings meet the floor" branch (see `### Auto mode`) so interactive and auto behave the same.
+   - **At least one finding in a severity section (`Blocker` / `High` / `Medium` / `Low`).** Render the cure-selection table inline using `/cure`'s verbs (`skills/cure/references/selection.md`). Ask via `shared/handoff-gate.md`. On non-empty selection, **first run step 9** to post any drafted push-backs / investigating notes — they don't depend on cure's outcome, so they must reach GitHub even if `/cure` later halts or the session is interrupted — then dispatch `/cure <slug>` with locked `handoff_context:` and post the cure-dependent replies (step 10) when `/cure` returns. On `none` / `Stop`, run step 9 for any drafted push-backs / investigating notes, then exit with the report path.
+   - **No severity-section findings, but `Reviewer-rejected` or `Needs-investigation` has items.** Skip `/cure` dispatch entirely — there is nothing to apply. Render a small gate that lets the user pick `post all`, `post pushbacks only`, `skip posting`, or per-finding choices. On the selection, run step 9 to post the chosen replies. Exit with `status: ok / next: done`. This mirrors the documented auto-mode "no findings meet the floor" branch (see `### Auto mode`) so interactive and auto behave the same.
    - **Nothing graded into any section.** Exit cleanly with the report path; there is nothing to post or cure.
 9. **Post non-cure replies** (runs whenever grading produced these items, with or without `/cure`). Post via `shared/post-reply.sh`:
    - **Reviewer-rejected items** → post the pre-drafted push-back text from the affinage report.
    - **Needs-investigation items** → post `"Human investigating — will follow up."`
    - **CI-sourced findings** (`from-check:<job>` tag) and **fresh-review findings** (`from-age:<dimension>` tag) → no reply (no reviewer to notify).
 
-   Decoupling this from `/cure` is deliberate: drafted push-backs and investigating notes must reach GitHub even when no medium-or-above finding exists and `/cure` never runs — otherwise the drafted reply is write-only, useful to the human reading the report but invisible to the reviewer waiting on GitHub.
+   Decoupling this from `/cure` is deliberate: drafted push-backs and investigating notes must reach GitHub even when no severity-section finding exists and `/cure` never runs — otherwise the drafted reply is write-only, useful to the human reading the report but invisible to the reviewer waiting on GitHub.
 10. **Post-cure reply posting** (only when `/cure` ran). When `/cure` returns, read `.cheese/cure/pr-<n>.md`'s `### Applied` / `### Deferred` sections and post per-finding replies via `shared/post-reply.sh`:
     - **Applied** (with `from-comment:<id>` tag) → `"Fixed — <applied summary>."`
     - **Deferred** (with `from-comment:<id>` tag) → `"Attempted fix reverted — <reason>."`
@@ -162,6 +162,9 @@ artifact: <path-to-prior-cure-or-press-report-if-any>
 ... (same shape)
 
 ## Low
+- **[from-comment:<id>] [deslop:low]** copilot on `src/utils/format.ts:18` — rename `data` to `lineItems` for clarity.
+  - location: class · fix-cost-now: contained · fix-cost-later: contained
+  - recommendation: rename `data` → `lineItems`. Valid cheap nit — fixed via `/cure`, not pushed back.
 ... (same shape; collapsible per --full rules)
 
 ## Needs-investigation
@@ -170,9 +173,12 @@ artifact: <path-to-prior-cure-or-press-report-if-any>
   - suggested action: human reads `analytics-svc/consumers/users.ts`.
 
 ## Reviewer-rejected
-- **[from-comment:<id>]** copilot on `src/utils/format.ts:18` — "rename `data` to `lineItems`."
-  - reason: pure style; no dimension match.
-  - draft reply: "Thanks — leaving `data` as-is; matches the adjacent format-helper pattern. Open to revisiting if the team standardises."
+- **[from-comment:<id>]** copilot on `src/auth.ts:30` — "missing `await`; this promise is unhandled."
+  - reason: wrong — `parseToken` is synchronous (returns `string`, not a `Promise`, see `src/auth.ts:12`); there is nothing to await.
+  - draft reply: "`parseToken` is synchronous here (returns `string`, `src/auth.ts:12`), so there's no promise to await. Leaving as-is."
+- **[from-comment:<id>]** dana on `src/api/users.ts:60` — "extract this into a generic repository layer."
+  - reason: valid but large — fix-cost-now: sprawling (6 files across 2 slices); scope expansion beyond this PR.
+  - draft reply: "Agreed this would be cleaner, but it's a cross-slice refactor beyond this PR's scope — filing a follow-up rather than growing this change."
 
 ## Confidence
 <certain | speculating | don't know> — <one-line justification>
@@ -183,19 +189,20 @@ Selection prompt rendered inline — pick findings to cure or `none` to stop.
 
 Empty severity sections are omitted entirely. `## Needs-investigation` and `## Reviewer-rejected` are omitted when no items land there.
 
-`status: ok` when grading completed; `status: halt: <reason>` when `gh` or `pr-status.py` failed in a way that blocks honest grading. `next: cure` when at least one medium-or-above severity finding exists; `next: done` when none do.
+`status: ok` when grading completed; `status: halt: <reason>` when `gh` or `pr-status.py` failed in a way that blocks honest grading. `next: cure` when at least one finding meets the `medium+` floor (medium-or-above, or a cheap contained-fix low); `next: done` when none do.
 
 ## Handoff
 
 **Pipeline:** culture → mold → cook → press → age → cure → ship · `/affinage` is parallel to `/age` and feeds the same `/cure`.
 
-After the report lands, the gate depends on whether any medium-or-above finding exists (Flow step 8).
+After the report lands, the gate depends on whether any severity-section finding exists (Flow step 8).
 
-**When at least one `Blocker` / `High` / `Medium` finding exists** — render the cure-selection table inline (per `skills/cure/references/selection.md`) and ask via `shared/handoff-gate.md`. Always present the same four severity-floor options, in the same most-inclusive-to-least order, so the gate is predictable across every run:
+**When at least one severity-section finding exists (any severity, including `Low`)** — render the cure-selection table inline (per `skills/cure/references/selection.md`) and ask via `shared/handoff-gate.md`. Lead with the recommended composite, then present the four severity-floor options below it, in the same most-inclusive-to-least order, so the gate is predictable across every run:
 
+- **Fix mediums-and-above plus cheap lows** *(recommended)* — equivalent to `all-medium, cheap` (floor at medium — blockers + high + medium — unioned with every `Low` whose `fix-cost-now: contained`; the small valid nits cheaper to fix than to defer). Sprawling/structural lows are left out.
 - **Fix everything** — equivalent to `all` (every finding regardless of severity).
 - **Fix medium-severity and above** — equivalent to `all-medium` (floor at medium: blockers + high + medium; the interactive form of the `medium+` auto-floor).
-- **Fix high-severity and blockers** *(recommended when at least one blocker or high-severity finding exists)* — equivalent to `all-high`.
+- **Fix high-severity and blockers** — equivalent to `all-high`.
 - **Fix blockers only** *(strict)* — equivalent to `all-blocker`.
 
 Then offer the non-floor options last:
@@ -204,9 +211,9 @@ Then offer the non-floor options last:
 - **Resolve merge conflicts** *(offered only when the PR has conflicts)* — checkout + `/melt` per `## Merge-conflict resolution`, then re-render this gate.
 - **Stop — leave the report for later** — equivalent to `none`.
 
-Present all four severity options on every run even when a severity band is empty: a floor that resolves to an empty set is a valid, predictable no-op — do not drop or reorder options based on which bands happen to be populated. If the user selects a floor that resolves to an empty set, treat the selection as `none`: report that no findings match and do not dispatch `/cure` with empty `resolved_ids` (the non-empty-selection dispatch rule below still holds).
+Present all four severity options on every run even when a severity band is empty: a floor that resolves to an empty set is a valid, predictable no-op — do not drop or reorder options based on which bands happen to be populated. If the user selects a floor (or the recommended composite) that resolves to an empty set, treat the selection as `none`: report that no findings match and do not dispatch `/cure` with empty `resolved_ids` (the non-empty-selection dispatch rule below still holds).
 
-**When no medium-or-above finding exists but `Reviewer-rejected` or `Needs-investigation` has items** — `/cure` has nothing to act on, so skip it and render a reply-only gate instead:
+**When no severity-section finding exists but `Reviewer-rejected` or `Needs-investigation` has items** — `/cure` has nothing to act on, so skip it and render a reply-only gate instead:
 
 - **Post all** *(recommended)* — post every drafted push-back and human-investigating note.
 - **Post pushbacks only** — post `Reviewer-rejected` drafts; skip `Needs-investigation` notices.
@@ -234,7 +241,7 @@ When invoked with `--auto --stake <floor>`:
 - Skip the selection gate.
 - If the PR has merge conflicts, resolve them via `/melt` first (see `## Merge-conflict resolution`). If `/melt` cannot resolve, halt with `status: halt: merge-conflicts-need-human` before any `/cure` dispatch.
 - If standalone (and `--no-age` not passed), run the fresh `/age` pass so `[from-age:…]` findings join the floor-based auto-selection.
-- Auto-select every finding (comment-sourced, CI-sourced, OR fresh-`/age`-sourced) whose severity meets the floor.
+- Auto-select every finding (comment-sourced, CI-sourced, OR fresh-`/age`-sourced) that meets the floor — severity at or above the floor, plus cheap contained-fix lows when the floor is `medium+` (same floor semantics as `/cure`).
 - Dispatch `/cure --auto --stake <floor>`.
 - After `/cure --auto` and its downstream `/age --scope --auto` chain settle, post replies for the originally graded items only. Do NOT re-grade for findings discovered by `/age --scope`.
 - Reviewer-rejected items: post the pre-drafted push-back.
@@ -243,7 +250,7 @@ When invoked with `--auto --stake <floor>`:
 
 The whole cure chain (cure → `/age --scope --auto` → up to the two-cure-pass cap) must run in the parent affinage context so the post-cure reply step still has the original graded findings (slug, ids, `from-comment:<id>` tags, drafted push-back text) in memory. Same in-session-memory contract as `/age --auto`'s two-pass cap. Spawning the cure chain in a sub-agent silently breaks reply posting — do not.
 
-If no findings meet the floor, skip the `/cure` dispatch, post replies for `Reviewer-rejected` + `Needs-investigation` items only, and exit with `status: ok / next: done / "no findings at or above <floor>"`.
+If no findings meet the floor, skip the `/cure` dispatch, post replies for `Reviewer-rejected` + `Needs-investigation` items only, and exit with `status: ok / next: done / "no findings meet <floor>"`.
 
 ### --hard mode
 
@@ -252,6 +259,7 @@ If no findings meet the floor, skip the `/cure` dispatch, post replies for `Revi
 ## Rules
 
 - Grading is code-grounded, not reviewer-asserted. `CHANGES_REQUESTED` is metadata, not a severity bump.
+- Prefer fixing over pushing back. A valid, grounded nit whose fix is contained (`fix-cost-now: contained` — a few lines or a localized refactor) goes to `/cure` as a `Low` finding tagged `[from-comment:<id>]`; do not draft a push-back for it. Reserve `## Reviewer-rejected` for claims that are wrong/ungrounded or whose fix is a lot of work (`moderate`/`sprawling`/`structural`). See `skills/age/references/voice.md`.
 - Never auto-apply fixes from `/affinage` itself. Code fixes go through `/cure`; merge conflicts go through `/melt`.
 - Fresh `/age` runs only on standalone invocations (no upstream `handoff_context`) and only when `--no-age` is absent. Chained runs never re-review the diff.
 - Merge conflicts are resolved through `/melt`, not by hand. `gh pr checkout` to materialise conflicts is allowed — it neither opens nor updates the PR. Pushing the resolved merge stays user-triggered (interactive) or follows `/cure`'s push contract (`--auto`).

--- a/skills/affinage/SKILL.md
+++ b/skills/affinage/SKILL.md
@@ -53,7 +53,7 @@ Flags:
    - Compute severity from base + location + compounding modifiers (same rubric as `/age`).
    - **Ignore reviewer-asserted urgency for severity computation.** Surface `CHANGES_REQUESTED` as metadata (`reviewer-asserted:` line) but do not let it modify computed severity.
    - Bucket into:
-     - Standard severity sections (`## Blocker / ## High / ## Medium / ## Low`) when the claim is grounded in the diff — whether it maps to a dimension OR is a valid improvement (a style nit counts) whose fix is **contained** (`fix-cost-now: contained` — roughly a few lines or a localized refactor). A valid cheap nit is cheaper to fix than to argue, so route it to `/cure` (usually as `Low`) and keep its `[from-comment:<id>]` tag so `/cure`'s reply still reaches the reviewer. Do not push back on it.
+     - Standard severity sections (`## Blocker / ## High / ## Medium / ## Low`) when the claim is grounded in the diff and its fix is **contained** (`fix-cost-now: contained` — roughly a few lines or a localized refactor). Every such item still maps to a dimension and carries a `[<dimension>:<severity>]` tag — a style or quality nit maps to `deslop` (e.g. `[deslop:low]`). The new rule is to route these grounded, contained-fix nits to `/cure` (usually as `Low`) instead of `## Reviewer-rejected`, keeping the `[from-comment:<id>]` tag so `/cure`'s reply still reaches the reviewer; a valid cheap nit is cheaper to fix than to argue, so do not push back on it.
      - `## Needs-investigation` when the claim is plausible but requires evidence outside the diff (e.g., downstream caller in another repo).
      - `## Reviewer-rejected` only when the claim is **wrong or ungrounded** (the code is already correct, the reviewer misread it, or there is no real improvement) OR is valid but **a lot of follow-up work** (`fix-cost-now: moderate`/`sprawling` or `fix-cost-later: structural` — a refactor or scope expansion beyond this PR). Reject the wrong ones; defer the expensive ones. Per `skills/age/references/voice.md`, a justified push-back costs more than a small valid fix.
 7. **Write report** to `.cheese/affinage/pr-<n>.md` with the four-line handoff slug at the top, then the age-format body plus the two extra sections. See `## Output` below.
@@ -201,7 +201,7 @@ After the report lands, the gate depends on whether any severity-section finding
 
 - **Fix mediums-and-above plus cheap lows** *(recommended)* — equivalent to `all-medium, cheap` (floor at medium — blockers + high + medium — unioned with every `Low` whose `fix-cost-now: contained`; the small valid nits cheaper to fix than to defer). Sprawling/structural lows are left out.
 - **Fix everything** — equivalent to `all` (every finding regardless of severity).
-- **Fix medium-severity and above** — equivalent to `all-medium` (floor at medium: blockers + high + medium; the interactive form of the `medium+` auto-floor).
+- **Fix medium-severity and above** — equivalent to `all-medium` (floor at medium: blockers + high + medium — the severity-floor portion of the `medium+` auto-floor; add `cheap` to also union the contained-fix lows, i.e. the recommended composite above).
 - **Fix high-severity and blockers** — equivalent to `all-high`.
 - **Fix blockers only** *(strict)* — equivalent to `all-blocker`.
 

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -144,7 +144,7 @@ Empty severity sections are omitted entirely. When ten or more `low` findings ex
 
 Suppressed lows feed the cure-selection table only when `--full` is passed.
 
-`status: ok` when the review completed. `status: halt: <reason>` when evidence was unreachable in a way that blocks honest review. `next: cure` when at least one medium-or-above severity finding exists and the chain has cure passes remaining; `next: done` when no medium-or-above severity findings remain or the two-cure-pass cap has been reached.
+`status: ok` when the review completed. `status: halt: <reason>` when evidence was unreachable in a way that blocks honest review. `next: cure` when at least one finding meets the `medium+` floor (medium-or-above, or a cheap contained-fix low) and the chain has cure passes remaining; `next: done` when no finding meets the `medium+` floor or the two-cure-pass cap has been reached.
 
 Then print:
 
@@ -159,17 +159,18 @@ Age report: .cheese/age/<slug>.md
 After the report is on disk, skip any "should I run /cure?" meta-question and go straight to the selection gate. The user's working memory is on the findings, not on whether a follow-up step exists. Use the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md) for post-selection dispatch.
 
 1. Render the numbered selection table per `../cure/references/selection.md` directly inline (one row per finding, grouped by severity).
-2. Ask via the handoff gate which findings to cure. Lead each option with the verb (what the user wants to *do* next); the underlying selection verb is the backing detail. Always present the same four severity-floor options, in the same most-inclusive-to-least order, so the gate is predictable across every run:
+2. Ask via the handoff gate which findings to cure. Lead each option with the verb (what the user wants to *do* next); the underlying selection verb is the backing detail. Lead with the recommended composite, then present the same four severity-floor options below it, in the same most-inclusive-to-least order, so the gate is predictable across every run:
+   - **Fix mediums-and-above plus cheap lows** *(recommended)* — equivalent to `all-medium, cheap` (floor at medium — blockers + high + medium — unioned with every `Low` whose `fix-cost-now: contained`). The cheap lows are the small valid nits that are cheaper to fix than to defer; sprawling/structural lows are left out.
    - **Fix everything** — equivalent to `all` (every finding regardless of severity).
    - **Fix medium-severity and above** — equivalent to `all-medium` (floor at medium: blockers + high + medium; the interactive form of the `medium+` auto-floor).
-   - **Fix high-severity and blockers** *(recommended when at least one blocker or high-severity finding exists)* — equivalent to `all-high` (floor at high, includes blockers).
+   - **Fix high-severity and blockers** — equivalent to `all-high` (floor at high, includes blockers).
    - **Fix blockers only** *(strict; land only the must-fix blockers and defer the rest to a follow-up)* — equivalent to `all-blocker`.
 
    Then offer the two non-floor options last:
    - **Pick findings to fix** — accept a free-text reply using the verbs from `../cure/references/selection.md` (`1,3,5`, `all-blocker`, `all-medium`, `all-high`, `cheap`, `all`, `none`, `skip N`; comma-compose to union).
    - **Stop — leave the report for later** — equivalent to `none`.
 
-   Present all four severity options on every run even when a severity band is empty (e.g. no blockers): a floor that resolves to an empty set is a valid, predictable no-op — do not drop or reorder options based on which bands happen to be populated. If the user selects a floor that resolves to an empty set, treat the selection as `none`: report that no findings match and do not dispatch `/cure` with empty `resolved_ids` (the non-empty-selection contract in step 3 still holds).
+   Present all four severity options on every run even when a severity band is empty (e.g. no blockers): a floor that resolves to an empty set is a valid, predictable no-op — do not drop or reorder options based on which bands happen to be populated. If the user selects a floor (or the recommended composite) that resolves to an empty set, treat the selection as `none`: report that no findings match and do not dispatch `/cure` with empty `resolved_ids` (the non-empty-selection contract in step 3 still holds).
 3. On a non-empty selection, immediately dispatch `/cure <slug> [--hard]` with the selection locked in via context, not a CLI flag:
 
 ```yaml
@@ -191,15 +192,15 @@ When invoked with `--auto`:
 
 - Skip the handoff gate.
 - If two cure passes have already completed (cap reached), stop and surface the final report — do not invoke `/cure` again even if findings remain.
-- Otherwise, if any medium-or-above severity finding exists, invoke `/cure <slug> --auto --stake medium+` and increment the cure-pass count when it returns.
-- If no medium-or-above severity findings remain, stop the chain with a one-line "auto chain clean" note and the report path.
+- Otherwise, if any finding meets the `medium+` floor (medium-or-above, or a `Low` whose `fix-cost-now: contained`), invoke `/cure <slug> --auto --stake medium+` and increment the cure-pass count when it returns.
+- If no finding meets the `medium+` floor (no medium-or-above and no cheap lows remain), stop the chain with a one-line "auto chain clean" note and the report path.
 
 ### When invoked from /ultracook
 
 `/ultracook` spawns age as a fresh-context sub-agent and owns the chain itself. Honour the no-chain override:
 
 - Write `.cheese/age/<slug>.md` (with the handoff slug at the top) and stop. Do not invoke `/cure <slug> --auto --stake medium+` from inside the sub-agent.
-- Set `next:` from what you observe on this run, not from any guess about chain position. `next: cure` when at least one medium-or-above severity finding exists; `next: done` when none do.
+- Set `next:` from what you observe on this run, not from any guess about chain position. `next: cure` when at least one finding meets the `medium+` floor (medium-or-above, or a cheap contained-fix low); `next: done` when none do.
 - The two-cure-pass cap is enforced by ultracook's fixed chain length, not by age's `next:` field. Fresh-context age cannot count prior cure passes anyway, so this is the only honest contract. The orchestrator uses `next: done` for early-stop signalling; the natural terminal stop is the chain table running out of entries.
 
 ### Inline-degrade mode (invoked from a sub-agent, e.g. /cheese-factory curd worker)

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -162,7 +162,7 @@ After the report is on disk, skip any "should I run /cure?" meta-question and go
 2. Ask via the handoff gate which findings to cure. Lead each option with the verb (what the user wants to *do* next); the underlying selection verb is the backing detail. Lead with the recommended composite, then present the same four severity-floor options below it, in the same most-inclusive-to-least order, so the gate is predictable across every run:
    - **Fix mediums-and-above plus cheap lows** *(recommended)* — equivalent to `all-medium, cheap` (floor at medium — blockers + high + medium — unioned with every `Low` whose `fix-cost-now: contained`). The cheap lows are the small valid nits that are cheaper to fix than to defer; sprawling/structural lows are left out.
    - **Fix everything** — equivalent to `all` (every finding regardless of severity).
-   - **Fix medium-severity and above** — equivalent to `all-medium` (floor at medium: blockers + high + medium; the interactive form of the `medium+` auto-floor).
+   - **Fix medium-severity and above** — equivalent to `all-medium` (floor at medium: blockers + high + medium — the severity-floor portion of the `medium+` auto-floor; add `cheap` to also union the contained-fix lows, i.e. the recommended composite above).
    - **Fix high-severity and blockers** — equivalent to `all-high` (floor at high, includes blockers).
    - **Fix blockers only** *(strict; land only the must-fix blockers and defer the rest to a follow-up)* — equivalent to `all-blocker`.
 

--- a/skills/age/references/voice.md
+++ b/skills/age/references/voice.md
@@ -21,6 +21,7 @@ Phrased as positive guardrails — "do X" rather than "don't do Y". Prohibition 
 - **Steelman the rejected option.** When proposing one approach, state the strongest case for the alternative before dismissing it. Applies to design choices, library picks, and review recommendations.
 - **Track contradictions across the dialogue.** If turn N contradicts turn N-3, flag it and resolve before moving on. The model is responsible for noticing — the user should not have to be the consistency check.
 - **Agree when agreement is warranted.** Do not manufacture counterpoints to seem balanced. A correct PR with no findings is a fine `/age` outcome; a spec the user already got right does not need re-litigation.
+- **Prefer satisfying a valid critique over arguing it.** When a review comment or self-review nit is correct and the fix is cheap — a contained change, roughly a few lines or a localized refactor — make the change rather than draft a defense for leaving it. Push back only when the critique is *wrong* (the code is already correct, or the claim is ungrounded) or when satisfying it costs far more than it returns (a sprawling or structural change beyond the current scope). A justified push-back usually costs more than a small valid fix.
 - **Name the exact step that breaks** when reasoning is invalid — not "this seems off", but "the X assumption fails when Y because Z".
 
 ## Depth and questions

--- a/skills/cheese-factory/references/curd-prompt.md
+++ b/skills/cheese-factory/references/curd-prompt.md
@@ -33,7 +33,7 @@ Do NOT run the full test suite.
 1. /cook --auto {hard_flag}                  — implement the behaviour against the acceptance criterion
 2. /press --auto                             — adversarial test hardening (single pass)
 3. /age --auto                               — ten-dimension review of YOUR diff only, inline-degrade
-4. /cure --auto --stake medium+ {hard_flag}  — fix every medium-or-above severity finding
+4. /cure --auto --stake medium+ {hard_flag}  — fix every medium-or-above finding + cheap (contained-fix) lows
 5. /commit (or git commit direct)            — single commit with conventional message
 6. Write pr-metadata.json: {{title, body}} for the slicer to pick up later
 

--- a/skills/cook/SKILL.md
+++ b/skills/cook/SKILL.md
@@ -22,7 +22,7 @@ Accept one of:
 
 Optional flags:
 
-- `--auto` — autonomous mode. Skip every handoff gate, propagate the flag through `/press → /age → /cure`, and fix every medium-or-above finding across up to two cure passes. See `## Auto mode` below.
+- `--auto` — autonomous mode. Skip every handoff gate, propagate the flag through `/press → /age → /cure`, and fix every medium-or-above finding plus cheap (contained-fix) lows across up to two cure passes. See `## Auto mode` below.
 - `--hard` — propagate the `/hard-cheese` metacognitive gate flag through `/press → /age → /cure`. Cook does not fire the gate itself; it only passes the flag along. The gate fires at `/cure`'s share-for-review handoff or, under `--auto --hard`, at the end of cure's final auto pass. See `skills/hard-cheese/SKILL.md` and `skills/hard-cheese/references/composition.md`.
 
 ### Standalone fast-path
@@ -107,7 +107,7 @@ When invoked with `--auto`, skip this gate entirely and proceed straight into th
 1. After cook's package-ready report, invoke `/press <slug> --auto`.
 2. `/press --auto` runs its hardening pass and, if readiness is `ready for /age` or `follow-up recommended`, invokes `/age <slug> --auto`. Both states mean the cooked contract is sound and every changed behaviour has a hardening test; documented follow-ups are review-safe. Only `blocked` stops auto — false premise, unfixable level-1/2 gap, a changed behaviour with no stable hardening test, or spinning wheels (three attempts at one gap without green).
 3. `/age <slug> --auto` writes the report and invokes `/cure <slug> --auto --stake medium+`.
-4. `/cure --auto --stake medium+` bypasses the selection gate, applies every finding of `blocker`, `high`, or `medium` severity, then invokes `/age --scope <touched-paths> --auto` for verification.
+4. `/cure --auto --stake medium+` bypasses the selection gate, applies every finding of `blocker`, `high`, or `medium` severity plus every cheap (contained-fix) `Low`, then invokes `/age --scope <touched-paths> --auto` for verification.
 5. The age → cure cycle is capped at **two cure passes total**. Pass 1 fixes the initial findings. Pass 2 fixes anything the re-age surfaces. After pass 2 the chain stops with a final summary, regardless of whether new findings remain.
 6. Auto mode never invokes `/gh`. Opening or updating a PR stays user-triggered.
 

--- a/skills/culture/SKILL.md
+++ b/skills/culture/SKILL.md
@@ -78,7 +78,7 @@ Default options (pick at most three of these plus a stop):
 
 - **Shape this into a written spec** *(recommended when the idea is still fuzzy)* — `/mold` with the context packet, or `/mold .cheese/notes/<slug>.md` when a notes slug exists.
 - **Implement it directly** *(recommended when the ask is clear and unambiguous)* — `/cook` with the context packet as the accepted contract.
-- **Implement and auto-review** — `/cook --auto` with the context packet, chains through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Stops at the final cure pass; opening or updating the PR stays a manual step. Offer this when the conversation reached an unambiguous contract *and* the user signalled they want the whole pipeline to run forward without per-step approval ("just do it", "ship it", "auto", "fix it all the way through"). Never pre-select; auto mode opts the user out of the gates that exist for their protection.
+- **Implement and auto-review** — `/cook --auto` with the context packet, chains through `/press → /age → /cure` autonomously, fixing every medium-or-above finding plus cheap (contained-fix) lows across up to two cure passes. Stops at the final cure pass; opening or updating the PR stays a manual step. Offer this when the conversation reached an unambiguous contract *and* the user signalled they want the whole pipeline to run forward without per-step approval ("just do it", "ship it", "auto", "fix it all the way through"). Never pre-select; auto mode opts the user out of the gates that exist for their protection.
 - **Research more first** *(when the conversation hit a factual gap external docs could close)* — `/briesearch`.
 - **Pause** — dispatch none; keep the dialogue in head.
 

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -21,7 +21,7 @@ If selection is ambiguous *and* not pre-locked from `/age`, render a numbered se
 Optional flags:
 
 - `--auto` — autonomous mode (propagated from `/cook --auto`). Bypasses the user-selection step. Must be paired with `--stake <floor>` to set the inclusion threshold; `/cook --auto` always passes `--stake medium+`. See `references/selection.md` for the auto-selection rules and `## Auto mode` below for the pass-cap and revert behaviour.
-- `--stake <floor>` — used only with `--auto`. Despite the flag name (preserved across callers for stability), the floor is a per-finding **severity** floor, not a dimension-bucket. Accepts `blocker`, `high` (blocker + high), `medium+` (blocker + high + medium), or `all`. Without `--auto` this flag is ignored — interactive selection is the only sanctioned path.
+- `--stake <floor>` — used only with `--auto`. Despite the flag name (preserved across callers for stability), the floor is primarily a per-finding **severity** floor, not a dimension-bucket. Accepts `blocker`, `high` (blocker + high), `medium+` (blocker + high + medium **plus cheap contained-fix lows**), or `all`. The floors are severity thresholds; `medium+` is the one exception — it additionally unions the cheap lows (see `references/selection.md` § Auto-mode selection). Without `--auto` this flag is ignored — interactive selection is the only sanctioned path.
 - `--hard` — propagated metacognitive-gate flag (from `/cook --hard` or `/cheese --hard`). Cure is the *only* pipeline skill that fires the gate: when `--hard` is in scope and the user selects the share-for-review handoff option (the **Open or update the PR** label, which dispatches `/gh`), invoke `/hard-cheese <slug>` first and proceed only on exit `0`. Under `--auto --hard`, see `## --hard mode` and the auto-mode puncture clause below.
 
 ## Flow
@@ -118,7 +118,7 @@ The gate's mechanism (SOLO-graded fresh-context judge, Socratic retry, fail-open
 When invoked with `--auto --stake <floor>`:
 
 - Skip the selection-list rendering and the handoff gate.
-- Auto-select every finding whose severity meets the floor (`blocker` only, `high` for blocker + high, `medium+` for blocker + high + medium, or `all`).
+- Auto-select every finding that meets the floor (`blocker` only; `high` for blocker + high; `medium+` for blocker + high + medium **plus cheap contained-fix lows**; or `all`).
 - Apply findings one at a time. After each fix, run the narrowest test that proves it. If the fix breaks a previously-passing test or any project-wide gate, revert that single finding's edit and record it under `### Deferred` in the cure report with the test name and the failure summary. Continue with the remaining findings.
 - After all selected findings are processed, skip the handoff gate and invoke `/age --scope <touched-paths> --auto` so the chain can re-review.
 - `/age --auto` enforces the two-pass cap. Cure does not need to track passes itself — it just keeps applying when invoked.
@@ -133,7 +133,7 @@ When invoked with `--auto --stake <floor>`:
 - On `ERROR`: chain exits `0` with a warning (the fail-open divergence documented in `skills/hard-cheese/SKILL.md`).
 - A non-TTY environment aborts with `"--hard requires an interactive TTY; remove --hard or run interactively"` — the puncture requires a human in the loop.
 
-If no findings meet the severity floor, write an empty cure report with `### Applied: (none — no findings at or above <floor>)` and skip straight to the auto handoff with a one-line "auto chain clean" note.
+If no findings meet the floor, write an empty cure report with `### Applied: (none — no findings meet <floor>)` and skip straight to the auto handoff with a one-line "auto chain clean" note.
 
 ### When invoked from /ultracook
 

--- a/skills/cure/references/selection.md
+++ b/skills/cure/references/selection.md
@@ -43,14 +43,14 @@ If no slug is supplied, accept any of: a pasted findings list, a `.cheese/age/` 
 1,3,5         # specific item ids
 all-blocker   # every blocker-severity item (strict; no high included)
 all-high      # every blocker- or high-severity item (floor at high; matches --stake high auto-floor)
-all-medium    # every blocker-, high-, or medium-severity item (floor at medium; matches --stake medium+ auto-floor)
+all-medium    # every blocker-, high-, or medium-severity item (floor at medium; compose `all-medium, cheap` to match the --stake medium+ auto-floor, which also sweeps cheap lows)
 cheap         # every finding where fix-cost-now == contained, regardless of severity
 all           # every item (requires explicit type-out, not assumed)
 none          # default; exit cleanly
 skip N        # drop item N from the change-order
 ```
 
-Interactive verbs use **floor** semantics, aligned with auto-mode: `all-blocker` is the only strict selector (because blocker is the top of the ladder, there is nothing above it to include); `all-high` includes blockers + high; `all-medium` includes blockers + high + medium (the interactive equivalent of the `medium+` auto-floor). Use composition (`all-blocker, ...`) when you specifically want strict blocker-only behaviour combined with another verb.
+Interactive verbs use **floor** semantics, aligned with auto-mode: `all-blocker` is the only strict selector (because blocker is the top of the ladder, there is nothing above it to include); `all-high` includes blockers + high; `all-medium` includes blockers + high + medium; compose `all-medium, cheap` to match the `medium+` auto-floor, which also sweeps cheap lows. Use composition (`all-blocker, ...`) when you specifically want strict blocker-only behaviour combined with another verb.
 
 ### Verb composition
 
@@ -89,10 +89,10 @@ When `/cure` is invoked with `--auto --stake <floor>`:
 - **Severity floors:**
   - `blocker` — only `blocker` severity findings.
   - `high` — `blocker` and `high` severity findings.
-  - `medium+` — `blocker`, `high`, and `medium` severity findings. This is what `/cook --auto` always passes.
+  - `medium+` — `blocker`, `high`, and `medium` severity findings, **plus every `Low` whose `fix-cost-now: contained`** (cheap lows — small valid nits cheaper to fix than to defer; `moderate`/`sprawling`/`structural` lows are excluded). This is what `/cook --auto` always passes, so the autonomous chain fixes mediums-and-above and the cheap lows. It is the auto analogue of the recommended interactive selection `all-medium, cheap`.
   - `all` — every finding regardless of severity.
-- **`cheap` has no auto-mode equivalent.** The `cheap` selection verb is interactive-only — there is no `--auto --stake cheap`. To combine `cheap` with severity selection, invoke `/cure <slug>` interactively and type a composite verb like `all-blocker, cheap`. Auto mode operates strictly on the four severity floors above.
-- **Order of application:** blocker first, then high, then medium, in the order they appear in the age report. Within a severity band, group by file to minimise re-reads.
+- **Cheap lows ride the `medium+` floor only.** There is no standalone `--stake cheap`. The `medium+` floor sweeps contained-fix lows automatically (above); the `blocker` and `high` floors do not (they are strict severity thresholds), and `all` already includes every low. To combine `cheap` with a different floor, invoke `/cure <slug>` interactively and type a composite verb like `all-blocker, cheap`.
+- **Order of application:** blocker first, then high, then medium, then — under the `medium+` floor — the cheap lows, in the order they appear in the age report. Within a severity band, group by file to minimise re-reads.
 - **Per-finding flow is the same as interactive:** `cheez-read` to re-confirm, `cheez-write` to apply, narrowest test to verify.
 - **On test breakage:** revert that single finding's edit, log it under the cure report's `### Deferred` section with the test name and one-line failure summary, and continue with the next finding. Do not stop the whole pass for one bad fix.
 - **On a finding that is no longer applicable** (file moved, code already fixed): record under `### Skipped` exactly as in interactive mode.

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -111,7 +111,7 @@ The spec is large enough that per-phase context contamination becomes a real con
 **Non-decomposable, low- or medium-blast-radius specs (`decomposable: false`, verdict `low` or `medium`):**
 
 - **Implement the spec** *(recommended)* — `/cook .cheese/specs/<slug>.md`.
-- **Implement and auto-review** — `/cook --auto .cheese/specs/<slug>.md`, chains straight through `/press → /age → /cure` autonomously, fixing every medium-or-above finding across up to two cure passes. Stops at the final cure pass; opening or updating the PR stays a manual step. Offer when acceptance criteria are explicit *and* the user has signalled they want the pipeline to run forward without per-step approval. Never pre-select; auto mode is opt-in.
+- **Implement and auto-review** — `/cook --auto .cheese/specs/<slug>.md`, chains straight through `/press → /age → /cure` autonomously, fixing every medium-or-above finding plus cheap (contained-fix) lows across up to two cure passes. Stops at the final cure pass; opening or updating the PR stays a manual step. Offer when acceptance criteria are explicit *and* the user has signalled they want the pipeline to run forward without per-step approval. Never pre-select; auto mode is opt-in.
 - **Research more first** — `/briesearch`, gather more external evidence before implementing.
 - **Stop** — dispatch none; leave the spec for later.
 

--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -55,7 +55,7 @@ Every spawn uses the canonical `/<phase> <slug> --auto` form. Cook accepts a bar
 The two-cure-pass cap is enforced by **chain length, not by age**. Each age sub-agent boots in fresh context and cannot count prior cure passes, so the contract cannot rely on age tracking the count. Instead:
 
 - The chain table has exactly seven entries, with two cure spawns (#4 and #6) and three age spawns (#3, #5, #7). After spawn #7 completes, the orchestrator stops because the table is exhausted.
-- Each age spawn writes `next:` from what it observes on its own run: `next: cure` when at least one medium-or-above severity finding exists, `next: done` when none do. The field is **informational** under ultracook — it drives early-stop (when an age reports clean), but it does not gate cap enforcement.
+- Each age spawn writes `next:` from what it observes on its own run: `next: cure` when at least one finding meets the `medium+` floor (medium-or-above, or a cheap contained-fix low), `next: done` when none do. The field is **informational** under ultracook — it drives early-stop (when an age reports clean), but it does not gate cap enforcement.
 - `/ultracook` does not pass a pass-ordinal hint to age. Age has no need to know whether it is age₁, age₂, or age₃; the orchestrator owns the position.
 
 ## No-chain isolation directive


### PR DESCRIPTION
## What changed

Threaded a single behavioural rule through the `/age` → `/affinage` → `/cure` pipeline: valid, grounded nits whose fix is contained (`fix-cost-now: contained`) now route to `/cure` as `Low` findings instead of being pushed back, and the `medium+` auto-floor (plus a new recommended `all-medium, cheap` interactive selection) sweeps those cheap lows automatically.

## Why

A justified push-back usually costs more than a small valid fix. The prior pipeline rejected pure-style/cheap nits into `## Reviewer-rejected`, which meant arguing instead of fixing; `## Reviewer-rejected` is now reserved for claims that are wrong/ungrounded or whose fix is a lot of follow-up work.

## How to verify

Docs-only change to `skills/**/*.md`. Read the diff — confirm the `medium+` floor semantics, the recommended composite selection, and the `voice.md` "prefer satisfying a valid critique over arguing it" principle are consistent across `age`, `affinage`, `cure`, `cook`, `culture`, `mold`, `ultracook`, and `cheese-factory`.

## Risk / rollout notes

Low — no executable code touched; behaviour change is in skill instructions only. Reviewers should sanity-check that the `medium+` floor's new "plus cheap contained-fix lows" semantics are described consistently everywhere it's referenced.

## Checklist

- [x] Conventional Commits PR title (`feat:`, `fix:`, `chore:`, `docs:`, ...)
- [x] Tests added or updated (or N/A) — N/A (docs only)
- [x] Documentation updated (or N/A)
- [x] No secrets or credentials added
