### PR TITLE
fix(docs): stop bare cheez-* tokens corrupting Markdown emphasis

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The workflow skills can delegate code search, reading, and editing to these MCP-
 | `skills/cheez-read/SKILL.md` | `/cheez-read` | Smart file/directory reading with hash anchors via tilth MCP. Replaces cat / head / tail / ls. |
 | `skills/cheez-write/SKILL.md` | `/cheez-write` | Hash-anchored, surgical edits via tilth MCP. Never rewrites whole files. |
 
-The cheez-* skills require tilth MCP and hard-fail when it is unavailable rather than fall back to host tools. Workflow skills remain portable by falling back directly to host-native tools when they are not using cheez-*.
+The `cheez-*` skills require tilth MCP and hard-fail when it is unavailable rather than fall back to host tools. Workflow skills remain portable by falling back directly to host-native tools when they are not using `cheez-*`.
 
 #### cheez-* router protocol
 
@@ -112,7 +112,7 @@ If you'd reach for one of these on a code task, route through cheez-* instead:
 | `Edit`, `Write` (host tools, code) | `/cheez-write` | `tilth_edit` is the only edit path with hash-anchor safety. |
 | `sg --rewrite` (codemod across N files) | `/cheez-write` | Sanctioned escape from cheez-write for structural codemods; `tilth_edit` stays the default for single-block edits. |
 
-Outside code work (e.g. `find -mtime`, `ls /tmp`, log inspection with `tail -f`, JSON munging with `jq`) the host tools are still the right call. The redirection rule is: **anything that touches source code goes through cheez-***.
+Outside code work (e.g. `find -mtime`, `ls /tmp`, log inspection with `tail -f`, JSON munging with `jq`) the host tools are still the right call. The redirection rule is: **anything that touches source code goes through `cheez-*`**.
 
 #### Installing tilth MCP
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The `cheez-*` skills require tilth MCP and hard-fail when it is unavailable rath
 
 #### cheez-* router protocol
 
-The three cheez-* skills are designed to chain. The standard sequence:
+The three `cheez-*` skills are designed to chain. The standard sequence:
 
 1. **`/cheez-search`** — locate the symbol, caller, content match, or file. AST-aware; replaces grep/rg/find.
 2. **`/cheez-read`** — read the target file or section to capture hash anchors. Smart-outlines large files; replaces cat/head/tail/ls.
@@ -95,7 +95,7 @@ Workflow skills (`/cook`, `/age`, `/cure`) call into this chain when they need c
 
 ##### Tool redirection map
 
-If you'd reach for one of these on a code task, route through cheez-* instead:
+If you'd reach for one of these on a code task, route through `cheez-*` instead:
 
 | If you'd run... | Use this skill | Why |
 | --- | --- | --- |
@@ -118,7 +118,7 @@ Outside code work (e.g. `find -mtime`, `ls /tmp`, log inspection with `tail -f`,
 
 See [Installing MCP servers](#installing-mcp-servers) below — expand the tilth section for full instructions.
 
-If those tools don't show up after install, the cheez-* skills will hard-fail with "tilth MCP server is not loaded" instead of silently falling back to host tools.
+If those tools don't show up after install, the `cheez-*` skills will hard-fail with "tilth MCP server is not loaded" instead of silently falling back to host tools.
 
 ### Suggested flow
 
@@ -150,7 +150,7 @@ discussion stays in `/culture`. `/melt` cuts in whenever a merge step blocks
 Easy-cheese is intentionally a small surface. What that means in practice:
 
 - **Skills only.** No agents, commands, eta templates, or compiled harness bundles. Each capability is a single `SKILL.md`.
-- **No repo-wide MCP requirement.** Workflow skills suggest tools (tilth, Context7, Tavily, code-review-graph) but have host-native fallbacks. The cheez-* tool skills are the exception: they require tilth MCP by design.
+- **No repo-wide MCP requirement.** Workflow skills suggest tools (tilth, Context7, Tavily, code-review-graph) but have host-native fallbacks. The `cheez-*` tool skills are the exception: they require tilth MCP by design.
 - **One orchestrator skill, narrowly scoped.** `/ultracook` is the only orchestrator — it spawns full-peer sub-agents for the fixed `cook → press → age → cure → age → cure → age` chain on high-blast-radius specs. There is no large-feature decomposition, no PR-rescue convoy, no whole-repo NIH audit. Every other skill remains a single, scoped step a human can drive.
 - **No automatic re-age loop in `/cure`.** The skill describes the protocol; the human runs the next `/age` when ready.
 
@@ -165,7 +165,7 @@ Workflow skills name preferred tools when they help, with fallbacks for portabil
 | Context7 (MCP) | Library and API documentation | repo docs, package docs, vendor pages, web search |
 | Tavily (MCP) | Current web/vendor research | host web search or user-supplied sources |
 | code-review-graph (MCP) | Review impact radius, architecture framing, and embeddings-backed semantic / cross-repo search | import searches, caller searches, tests |
-| LSP / [Serena](https://github.com/oraios/serena) (MCP) | Type-aware xrefs (`find_referencing_symbols`, `find_implementations`), symbol-bounded edits (`rename_symbol`, `replace_symbol_body`, `safe_delete_symbol`), and LSP diagnostics — concrete tools for the abstract "if your harness has an LSP" sections in cheez-* skills | `sg`, `tilth_search`, targeted reads via tilth |
+| LSP / [Serena](https://github.com/oraios/serena) (MCP) | Type-aware xrefs (`find_referencing_symbols`, `find_implementations`), symbol-bounded edits (`rename_symbol`, `replace_symbol_body`, `safe_delete_symbol`), and LSP diagnostics — concrete tools for the abstract "if your harness has an LSP" sections in `cheez-*` skills | `sg`, `tilth_search`, targeted reads via tilth |
 | `ripgrep` | Fast text search | `grep`, `find`, editor search |
 | `gh` | GitHub issues, PRs, checks, examples | local git commands or user-provided links/logs |
 | `delta` | Readable diffs | plain `git diff` |
@@ -174,7 +174,7 @@ Workflow skills name preferred tools when they help, with fallbacks for portabil
 | `fd` | Fast file discovery | `find` |
 | `just` | Project task discovery | package scripts or documented commands |
 
-When a preferred tool is unavailable, workflow skills say so once, fall back, and lower confidence only if evidence quality suffers. The cheez-* skills stop instead because tilth is their compatibility requirement.
+When a preferred tool is unavailable, workflow skills say so once, fall back, and lower confidence only if evidence quality suffers. The `cheez-*` skills stop instead because tilth is their compatibility requirement.
 
 ## Install
 
@@ -279,10 +279,10 @@ Each `SKILL.md` must have YAML frontmatter with at least `name` and `description
 
 ## Installing MCP servers
 
-The cheez-* tool skills and several workflow skills benefit from MCP servers. Install the ones you need.
+The `cheez-*` tool skills and several workflow skills benefit from MCP servers. Install the ones you need.
 
 <details>
-<summary><strong>tilth</strong> (required for cheez-* skills) — AST-aware code search, smart reading, hash-anchored edits</summary>
+<summary><strong>tilth</strong> (required for `cheez-*` skills) — AST-aware code search, smart reading, hash-anchored edits</summary>
 
 [tilth](https://github.com/jahala/tilth) provides AST-aware code search, smart file reading, and hash-anchored edits. Required by `/cheez-search`, `/cheez-read`, and `/cheez-write`.
 
@@ -580,4 +580,4 @@ winget install Casey.Just      # Windows
 
 The shared voice kernel at [`skills/age/references/voice.md`](skills/age/references/voice.md) — output discipline, reasoning posture, the `certain | speculating | don't know` confidence vocabulary, and the depth-vs-question split — adapts a [Claude Opus 4.7 system-prompt experiment by Reebz](https://gist.github.com/Reebz/b81ad99409d5b5de3045bebde71d4471), narrowed to the parts that earn their keep in a portable skills toolkit. Cross-referenced from `briesearch`, `culture`, `mold`, `cook`, and `cure`.
 
-The `/pasteurize` skill — the six-phase diagnosis loop (feedback loop → reproduce → hypothesise → instrument → fix + regression test → cleanup) and the "build a feedback loop first" insight — adapts [Matt Pocock's `diagnose` skill](https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md). Easy-cheese-specific adaptations (cheez-* tooling, handoff slug schema, `--auto` chain, `/cook` handoff for Phase 5) are layered on top.
+The `/pasteurize` skill — the six-phase diagnosis loop (feedback loop → reproduce → hypothesise → instrument → fix + regression test → cleanup) and the "build a feedback loop first" insight — adapts [Matt Pocock's `diagnose` skill](https://github.com/mattpocock/skills/blob/main/skills/engineering/diagnose/SKILL.md). Easy-cheese-specific adaptations (`cheez-*` tooling, handoff slug schema, `--auto` chain, `/cook` handoff for Phase 5) are layered on top.

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -21,6 +21,7 @@ Also emits:
 from __future__ import annotations
 
 import re
+from functools import lru_cache
 from pathlib import Path
 
 import mkdocs_gen_files
@@ -30,6 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILLS_DIR = REPO_ROOT / "skills"
 SHARED_DIR = REPO_ROOT / "shared"
 REPO_URL = "https://github.com/paulnsorensen/easy-cheese"
+LICENSE_URL = f"{REPO_URL}/blob/main/LICENSE"
 
 LINK_RE = re.compile(r"(?<!\!)\[([^\]]+)\]\(([^)\s]+)(\s+\"[^\"]*\")?\)")
 NESTED_IMAGE_LINK_RE = re.compile(r"(\[!\[[^\]]*\]\([^)]+\)\]\()([^)\s]+)(\))")
@@ -70,8 +72,24 @@ def _split_anchor(path: str) -> tuple[str, str]:
     return path, ""
 
 
+def _is_external(url: str) -> bool:
+    return url.startswith(("http://", "https://", "mailto:", "#"))
+
+
+@lru_cache(maxsize=None)
+def _read_text_cached(path: Path, _mtime: float) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _read_text(path: Path) -> str:
+    # README.md is consumed by both emit_install_page and emit_root_passthrough;
+    # cache so each repo file is read from disk once per build. Keyed on mtime so a
+    # changed file is never served stale if these are ever re-driven in-process.
+    return _read_text_cached(path, path.stat().st_mtime)
+
+
 def rewrite_skill_link(url: str, skill_name: str) -> str:
-    if url.startswith(("http://", "https://", "mailto:", "#")):
+    if _is_external(url):
         return url
     path, anchor = _split_anchor(url)
 
@@ -98,13 +116,13 @@ def rewrite_skill_link(url: str, skill_name: str) -> str:
         return f"../shared/{m.group(1)}{anchor}"
 
     if path == "../../LICENSE":
-        return f"{REPO_URL}/blob/main/LICENSE"
+        return LICENSE_URL
 
     return url
 
 
 def rewrite_ref_link(url: str, skill_name: str) -> str:
-    if url.startswith(("http://", "https://", "mailto:", "#")):
+    if _is_external(url):
         return url
     path, anchor = _split_anchor(url)
 
@@ -124,13 +142,13 @@ def rewrite_ref_link(url: str, skill_name: str) -> str:
         return f"../../../{ROOT_DOC_MAP[m.group(1)]}{anchor}"
 
     if path == "../../../LICENSE":
-        return f"{REPO_URL}/blob/main/LICENSE"
+        return LICENSE_URL
 
     return url
 
 
 def rewrite_root_passthrough_link(url: str) -> str:
-    if url.startswith(("http://", "https://", "mailto:", "#")):
+    if _is_external(url):
         return url
     path, anchor = _split_anchor(url)
     stripped = path[2:] if path.startswith("./") else path
@@ -138,7 +156,7 @@ def rewrite_root_passthrough_link(url: str) -> str:
     if stripped in ROOT_DOC_MAP:
         return f"./{ROOT_DOC_MAP[stripped]}{anchor}"
     if stripped == "LICENSE":
-        return f"{REPO_URL}/blob/main/LICENSE"
+        return LICENSE_URL
     return url
 
 
@@ -257,8 +275,8 @@ def extract_h2_section(
                     out.append(line)
             continue
         if in_section:
-            if bump_headings and line.startswith("### "):
-                line = "## " + line[4:]
+            if bump_headings and re.match(r"^#{3,} ", line):
+                line = line[1:]  # drop one '#' — promote h3+ by a level
             out.append(line)
     return "".join(out)
 
@@ -267,7 +285,7 @@ def emit_install_page() -> bool:
     src = REPO_ROOT / "README.md"
     if not src.exists():
         return False
-    readme = src.read_text(encoding="utf-8")
+    readme = _read_text(src)
 
     sections = {
         "Install": extract_h2_section(readme, "Install", drop_header=True, bump_headings=True),
@@ -305,7 +323,7 @@ def emit_root_passthrough(filename: str, dest: str, title: str) -> bool:
     src = REPO_ROOT / filename
     if not src.exists():
         return False
-    text = src.read_text(encoding="utf-8")
+    text = _read_text(src)
     text = re.sub(r"^#\s+.*\n", "", text, count=1)
     text = apply_link_rewrite(text, rewrite_root_passthrough_link)
     front = "---\n" + yaml.safe_dump(

--- a/skills/affinage/SKILL.md
+++ b/skills/affinage/SKILL.md
@@ -110,7 +110,7 @@ Digest size, parent-vs-sub-agent split, and harness-agnostic sub-agent selection
 
 ## Preferred tools and fallbacks
 
-Code search and reading go through cheez-* skills (`/cheez-search`, `/cheez-read`). Beyond cheez-* there are affinage-specific tools:
+Code search and reading go through `cheez-*` skills (`/cheez-search`, `/cheez-read`). Beyond `cheez-*` there are affinage-specific tools:
 
 | Need | Prefer | Fallback |
 | --- | --- | --- |

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -57,9 +57,9 @@ Per-dimension base-severity tables, location-sensitivity, fix-cost-now / fix-cos
 
 ## Preferred tools and fallbacks
 
-Code search and reading go through the cheez-* skills (`/cheez-search`, `/cheez-read`) — see those skills for tool selection rules. For caller graphs specifically, age uses `cheez-search` with `kind: "callers"` and `tilth_deps` (cheez-search owns the routing).
+Code search and reading go through the `cheez-*` skills (`/cheez-search`, `/cheez-read`) — see those skills for tool selection rules. For caller graphs specifically, age uses `cheez-search` with `kind: "callers"` and `tilth_deps` (cheez-search owns the routing).
 
-Beyond cheez-* there are review-specific tools:
+Beyond `cheez-*` there are review-specific tools:
 
 | Need | Prefer | Fallback |
 | --- | --- | --- |

--- a/skills/briesearch/SKILL.md
+++ b/skills/briesearch/SKILL.md
@@ -39,9 +39,9 @@ When two or more heavy sources are independent, spawn one small sub-agent per so
 
 ## Preferred tools and fallbacks
 
-Local code patterns go through the cheez-* skills (`/cheez-search`, `/cheez-read`) — see those skills for tool selection rules.
+Local code patterns go through the `cheez-*` skills (`/cheez-search`, `/cheez-read`) — see those skills for tool selection rules.
 
-Beyond cheez-* there are research-specific tools:
+Beyond `cheez-*` there are research-specific tools:
 
 | Need | Prefer | Fallback |
 | --- | --- | --- |

--- a/skills/briesearch/references/unavailable.md
+++ b/skills/briesearch/references/unavailable.md
@@ -8,7 +8,7 @@ Optional MCP servers (Context7, Tavily, code-review-graph, tilth) are not always
 | --- | --- | --- |
 | Context7 | Read repo docs, package README, vendor pages, then web search | Cap at `speculating` for version-specific questions |
 | Tavily | Host web search or user-provided links | Cap at `speculating` when freshness matters |
-| Codebase (cheez-*) | Fall back to Serena or LSP, `sg`, `ripgrep`, `find`, and targeted reads | Cap at `speculating` when local precedent is central |
+| Codebase (`cheez-*`) | Fall back to Serena or LSP, `sg`, `ripgrep`, `find`, and targeted reads | Cap at `speculating` when local precedent is central |
 | code-review-graph (full tool list in [README → Optional tools](../../../README.md#optional-tools)) | Use `tilth_deps` + `cheez-search` callers (`tilth_search kind: "callers"`) for blast radius; skip cross-repo, semantic search, and architecture framing | Cap at `speculating` for cross-repo or large-architecture questions |
 | GitHub (`gh`) | Note absence; user-supplied URLs are acceptable | Skip with a confidence note |
 

--- a/skills/cheese-factory/SKILL.md
+++ b/skills/cheese-factory/SKILL.md
@@ -168,7 +168,7 @@ Seed items are minimal — only the shared types / protocols that curds cannot c
 
 For each seed item:
 
-1. Implement the change. Prefer `/cheez-write` when tilth MCP is present; otherwise fall back to the host's native edit tool (per the cheez-* portability rule in `README.md`). The skill must not hard-fail when `/cheez-write` is unavailable.
+1. Implement the change. Prefer `/cheez-write` when tilth MCP is present; otherwise fall back to the host's native edit tool (per the `cheez-*` portability rule in `README.md`). The skill must not hard-fail when `/cheez-write` is unavailable.
 2. Run quality gates (the project's `just check` or equivalent) — if gates fail, STOP.
 3. Commit via `/commit` (if available) or `git commit` direct.
 

--- a/skills/cheese-factory/references/spawn-primitive-reference.md
+++ b/skills/cheese-factory/references/spawn-primitive-reference.md
@@ -34,7 +34,7 @@ Rules:
 
 - **Do not downgrade the model.** Omit the `model` parameter so the sub-agent inherits.
 - **Do not narrow `subagent_type`.** Use `general-purpose` (or the harness equivalent that grants full tool access). Do not pass `Explore`, `lsp-probe`, or any other read-only / scoped worker type.
-- **Do not restrict tools or MCP access.** Each phase needs Bash, Edit, Write, Read, the cheez-* skills, and any MCP servers the parent has.
+- **Do not restrict tools or MCP access.** Each phase needs Bash, Edit, Write, Read, the `cheez-*` skills, and any MCP servers the parent has.
 - **Do pass the slug.** The phase skill resolves its own paths from the slug.
 
 The contract is "inheritance, not diminution" — most sub-agent patterns in this ecosystem (Explore, lsp-probe, whey-drainer, ricotta-reducer) are deliberately scoped down for cheap focused queries. `/cheese-factory` does the opposite: it spawns workers that are full peers of the parent.

--- a/skills/cheese/SKILL.md
+++ b/skills/cheese/SKILL.md
@@ -88,9 +88,9 @@ Never resolve uncertainty by guessing — silent misrouting is worse than asking
 
 ## Preferred tools and fallbacks
 
-When the input is a path or slug, code reading and searching go through the cheez-* skills (`/cheez-read`, `/cheez-search`) — see those skills for tool selection rules.
+When the input is a path or slug, code reading and searching go through the `cheez-*` skills (`/cheez-read`, `/cheez-search`) — see those skills for tool selection rules.
 
-Beyond cheez-* there are router-specific tools:
+Beyond `cheez-*` there are router-specific tools:
 
 | Need | Prefer | Fallback |
 | --- | --- | --- |

--- a/skills/cheez-read/SKILL.md
+++ b/skills/cheez-read/SKILL.md
@@ -95,7 +95,7 @@ The tilth MCP server is launched against **one repository** — whatever directo
 
 ### When NOT to invoke `/cheez-read`
 
-Inside `/cheez-read`, the contract is hard: tilth-only, no host fallback. The reads below are **out of scope** for the skill — don't enter cheez-read for them in the first place. They're listed here so workflow skills know where to route instead, consistent with the README rule "anything that touches source code goes through cheez-*; everything else stays on host tools".
+Inside `/cheez-read`, the contract is hard: tilth-only, no host fallback. The reads below are **out of scope** for the skill — don't enter cheez-read for them in the first place. They're listed here so workflow skills know where to route instead, consistent with the README rule "anything that touches source code goes through `cheez-*`; everything else stays on host tools".
 
 | File (don't use cheez-read) | Route to | Why |
 |-----------------------------|----------|-----|

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -105,7 +105,7 @@ The tilth MCP server is launched against **one repository** — whatever directo
 
 ### When NOT to invoke `/cheez-search`
 
-Inside `/cheez-search`, the contract is hard: tilth-only, no host search fallback. The questions below are **out of scope** for the skill — don't enter cheez-search for them in the first place. They're listed here so workflow skills know where to route instead, consistent with the README rule "anything that touches source code goes through cheez-*; everything else stays on host tools".
+Inside `/cheez-search`, the contract is hard: tilth-only, no host search fallback. The questions below are **out of scope** for the skill — don't enter cheez-search for them in the first place. They're listed here so workflow skills know where to route instead, consistent with the README rule "anything that touches source code goes through `cheez-*`; everything else stays on host tools".
 
 | Question (don't use cheez-search) | Route to | Why |
 |-----------------------------------|----------|-----|
@@ -416,7 +416,7 @@ tilth_deps(path: "src/auth/index.ts")
 ## DO NOT
 
 - **DO NOT use grep / rg / ripgrep / ag / ack** — use `tilth_search`. `sg` (ast-grep) is the *only* sanctioned shell escape, and only for AST-shape patterns with metavariables tilth can't express.
-- **DO NOT use find / fd to locate files by name pattern** — use `tilth_files` (cheez-read). `find` for non-name predicates (size, mtime, perms) is fine outside code work, but redirect anything code-related back through cheez-*.
+- **DO NOT use find / fd to locate files by name pattern** — use `tilth_files` (cheez-read). `find` for non-name predicates (size, mtime, perms) is fine outside code work, but redirect anything code-related back through `cheez-*`.
 - **DO NOT use ast-grep (`sg`) for name-shaped or text queries** — that's `tilth_search` territory. `sg` is for structural patterns with metavars (`$X`, `$$$BODY`) only.
 - **DO NOT blind text search** — use a semantic `kind` (`symbol`, `callers`, `content`, `regex`) before reaching for `sg`.
 - **DO NOT re-read expanded results** — they're already shown.

--- a/skills/cook/SKILL.md
+++ b/skills/cook/SKILL.md
@@ -43,7 +43,7 @@ When the fast-path applies, derive a slug from the task (e.g. `tail-trailing-new
 4. **Taste-test** — check spec drift, readability, and scope creep. Two-round cap; details in `references/tdd-loop.md`.
 5. **Hand off** — produce the package-ready report (`references/package-report.md`), write the handoff slug (`## Handoff slug` below), and prompt the next step via the shared handoff gate (see `## Handoff` below). The default chain is `/press` → `/age` → `/cure`.
 
-Code search, reading, and editing all go through the cheez-* skills (`/cheez-search`, `/cheez-read`, `/cheez-write`) — see those skills for tool selection rules and out-of-scope fallbacks.
+Code search, reading, and editing all go through the `cheez-*` skills (`/cheez-search`, `/cheez-read`, `/cheez-write`) — see those skills for tool selection rules and out-of-scope fallbacks.
 
 ## Preferred tools and fallbacks
 

--- a/skills/culture/SKILL.md
+++ b/skills/culture/SKILL.md
@@ -26,9 +26,9 @@ Default the model's own contribution to maximum useful depth — full pseudocode
 
 ## Preferred tools and fallbacks
 
-Code search and reading go through the cheez-* skills (`/cheez-search`, `/cheez-read`) — see those skills for tool selection rules. Blast-radius reads specifically use `cheez-search` callers (`kind: "callers"`) plus `tilth_deps` (read-only shape check); culture stops at the verdict and never drafts signatures.
+Code search and reading go through the `cheez-*` skills (`/cheez-search`, `/cheez-read`) — see those skills for tool selection rules. Blast-radius reads specifically use `cheez-search` callers (`kind: "callers"`) plus `tilth_deps` (read-only shape check); culture stops at the verdict and never drafts signatures.
 
-Beyond cheez-* there are culture-specific tools:
+Beyond `cheez-*` there are culture-specific tools:
 
 | Need | Prefer | Fallback |
 | --- | --- | --- |

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -36,9 +36,9 @@ Optional flags:
 
 ## Preferred tools and fallbacks
 
-Code search, reading, and editing all go through the cheez-* skills (`/cheez-search`, `/cheez-read`, `/cheez-write`) — see those skills for tool selection rules.
+Code search, reading, and editing all go through the `cheez-*` skills (`/cheez-search`, `/cheez-read`, `/cheez-write`) — see those skills for tool selection rules.
 
-Beyond cheez-* there are cure-specific tools:
+Beyond `cheez-*` there are cure-specific tools:
 
 | Need | Prefer | Fallback |
 | --- | --- | --- |

--- a/skills/melt/SKILL.md
+++ b/skills/melt/SKILL.md
@@ -12,13 +12,13 @@ Do not use it for general git operations without conflicts (those go to a `commi
 
 ## File IO delegation
 
-`melt` orchestrates the resolution chain via bash and the helper scripts. For per-file inspection or manual edits, delegate to the cheez-* skills:
+`melt` orchestrates the resolution chain via bash and the helper scripts. For per-file inspection or manual edits, delegate to the `cheez-*` skills:
 
 - **`/cheez-search`** — locate conflict markers or related symbols across the tree.
 - **`/cheez-read`** — inspect conflicted files, view conflict hunks, list directory contents.
 - **`/cheez-write`** — apply hash-anchored resolutions when bash flows are not enough.
 
-The bash-driven flows below cover the bulk of resolution. Drop into the cheez-* skills only when you need to inspect or rewrite a specific file by hand.
+The bash-driven flows below cover the bulk of resolution. Drop into the `cheez-*` skills only when you need to inspect or rewrite a specific file by hand.
 
 ## Resolution chain
 

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -34,9 +34,9 @@ Full mode definitions, exit criteria, and user knobs in `references/modes.md`.
 
 ## Preferred tools and fallbacks
 
-Code search, reading, and editing (including spec writing) all go through the cheez-* skills (`/cheez-search`, `/cheez-read`, `/cheez-write`) — see those skills for tool selection rules. Shape checks specifically use `cheez-search` callers (`kind: "callers"`) plus `tilth_deps`; the procedure lives in `references/shape-check.md`.
+Code search, reading, and editing (including spec writing) all go through the `cheez-*` skills (`/cheez-search`, `/cheez-read`, `/cheez-write`) — see those skills for tool selection rules. Shape checks specifically use `cheez-search` callers (`kind: "callers"`) plus `tilth_deps`; the procedure lives in `references/shape-check.md`.
 
-Beyond cheez-* there are mold-specific tools:
+Beyond `cheez-*` there are mold-specific tools:
 
 | Need | Prefer | Fallback |
 | --- | --- | --- |

--- a/skills/mold/references/shape-check.md
+++ b/skills/mold/references/shape-check.md
@@ -44,7 +44,7 @@ A `high` verdict (multi-module callers or more than five importers) makes the Gr
 
 ## When tilth / cheez-search is unavailable
 
-Shape-check should not block the dialogue when its preferred tools are missing. Substitute where a sanctioned alternative exists; **for shape-check specifically, do not substitute textual search** — `grep` / `rg` over a symbol name produces a count of string occurrences, not callers or importers, and a guessed blast-radius verdict is worse than an honest unknown. (This is a shape-check rule, not a global cheez-* ban: outside cheez-* skills, mold and other workflow skills may use host tools where they are the right answer — see the README's "host tools are still the right call outside code work" line.)
+Shape-check should not block the dialogue when its preferred tools are missing. Substitute where a sanctioned alternative exists; **for shape-check specifically, do not substitute textual search** — `grep` / `rg` over a symbol name produces a count of string occurrences, not callers or importers, and a guessed blast-radius verdict is worse than an honest unknown. (This is a shape-check rule, not a global `cheez-*` ban: outside `cheez-*` skills, mold and other workflow skills may use host tools where they are the right answer — see the README's "host tools are still the right call outside code work" line.)
 
 - **Callers / callees**: fall back to LSP `textDocument/references` / `textDocument/prepareCallHierarchy` when a language server is reachable. Note the substitution out loud.
 - **Imports / blast radius**: no LSP equivalent. Skip the count, mark the line `unknown`, and lean on the verdict downgrade below.

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -27,9 +27,9 @@ Do not use it to implement broad new behavior. Press may add or strengthen tests
 
 ## Preferred tools and fallbacks
 
-Code search, reading, and editing all go through the cheez-* skills (`/cheez-search`, `/cheez-read`, `/cheez-write`) — see those skills for tool selection rules. For coverage and test discovery, press uses `cheez-search` (callers via `kind: "callers"`) and `tilth_deps` (cheez-search owns the routing).
+Code search, reading, and editing all go through the `cheez-*` skills (`/cheez-search`, `/cheez-read`, `/cheez-write`) — see those skills for tool selection rules. For coverage and test discovery, press uses `cheez-search` (callers via `kind: "callers"`) and `tilth_deps` (cheez-search owns the routing).
 
-Beyond cheez-* there are press-specific tools:
+Beyond `cheez-*` there are press-specific tools:
 
 | Need | Prefer | Fallback |
 | --- | --- | --- |

--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -97,7 +97,7 @@ Rules:
 
 - **Do not downgrade the model.** Omit the model parameter so the sub-agent inherits the parent's model. Never pass a smaller tier (haiku, lighter task workers) for ultracook phases.
 - **Do not narrow `subagent_type`.** Use `general-purpose` (or the harness equivalent that grants full tool access). Do not pass `Explore`, `lsp-probe`, or any other read-only / scoped worker type.
-- **Do not restrict tools or MCP access.** Each phase needs Bash, Edit, Write, Read, the cheez-* skills, and any MCP servers the parent has. Restricting them is the failure mode the contract exists to prevent.
+- **Do not restrict tools or MCP access.** Each phase needs Bash, Edit, Write, Read, the `cheez-*` skills, and any MCP servers the parent has. Restricting them is the failure mode the contract exists to prevent.
 - **Do pass the slug.** The phase skill resolves its own paths from the slug; `/ultracook` does not pre-compute paths for the sub-agent.
 
 The contract is "inheritance, not diminution" because most sub-agent patterns in this ecosystem (Explore, lsp-probe, whey-drainer, ricotta-reducer) are deliberately scoped down for cheap focused queries. `/ultracook` does the opposite: it spawns workers that are full peers of the parent, doing major work in their own context window.

--- a/tests/python/test_docs_emphasis_guard.py
+++ b/tests/python/test_docs_emphasis_guard.py
@@ -1,0 +1,98 @@
+r"""Guard against bare ``cheez-*`` wildcard tokens corrupting Markdown emphasis.
+
+``scripts/gen_docs.py`` mirrors these sources verbatim into the MkDocs site. A
+bare ``cheez-*`` in prose has its ``*`` parsed as an emphasis delimiter by
+Python-Markdown: two in one paragraph italicise the span between them, and one
+immediately before a ``**`` close (``cheez-***``) leaks the ``*`` out of the
+bold. Both render wrong on the docs site (confirmed by building it). The fix is
+to wrap the token in inline code (```` `cheez-*` ````) or escape it
+(``cheez-\*``). This test fails if a regression reintroduces the bare hazard.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+FENCE_RE = re.compile(r"```.*?```", re.S)
+INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+BARE_TOKEN = "cheez-*"
+COLLISION = "cheez-**"  # a cheez-* token abutting a `**`/`***` emphasis run
+
+
+def _mirrored_markdown() -> list[Path]:
+    """The markdown gen_docs.py copies into the docs tree verbatim."""
+    files = [
+        REPO_ROOT / "README.md",
+        REPO_ROOT / "CONTRIBUTING.md",
+        REPO_ROOT / "SECURITY.md",
+        REPO_ROOT / "CODE_OF_CONDUCT.md",
+    ]
+    files += sorted((REPO_ROOT / "skills").glob("*/SKILL.md"))
+    files += sorted((REPO_ROOT / "skills").glob("*/references/*.md"))
+    files += sorted((REPO_ROOT / "shared").glob("*.md"))
+    return [f for f in files if f.exists()]
+
+
+def _strip_code(text: str) -> str:
+    """Blank out code spans (backticked tokens are exempt) but keep line count."""
+    text = FENCE_RE.sub(lambda m: "\n" * m.group(0).count("\n"), text)
+    return INLINE_CODE_RE.sub("", text)
+
+
+def _hazards(text: str) -> list[tuple[int, str]]:
+    """Return (paragraph-start-line, snippet) for each corrupting paragraph."""
+    hazards: list[tuple[int, str]] = []
+    para: list[str] = []
+    start = 0
+
+    def flush() -> None:
+        if not para:
+            return
+        blob = " ".join(para)
+        if blob.count(BARE_TOKEN) >= 2 or COLLISION in blob:
+            hazards.append((start, blob.strip()[:120]))
+
+    for i, line in enumerate(_strip_code(text).splitlines(), 1):
+        if line.strip():
+            if not para:
+                start = i
+            para.append(line)
+        else:
+            flush()
+            para = []
+    flush()
+    return hazards
+
+
+def test_no_bare_cheez_star_emphasis_hazard():
+    offenders: list[str] = []
+    for f in _mirrored_markdown():
+        for line, snippet in _hazards(f.read_text(encoding="utf-8")):
+            offenders.append(f"{f.relative_to(REPO_ROOT)}:{line}  {snippet!r}")
+    assert not offenders, (
+        "Bare `cheez-*` corrupts Markdown emphasis in the docs build; wrap each "
+        "occurrence in backticks (`cheez-*`) or escape it (cheez-\\*):\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_detector_flags_paired_tokens():
+    # Two bare tokens in one paragraph -> italic span between them.
+    assert _hazards("use cheez-* skills, not cheez-* fallbacks\n")
+
+
+def test_detector_flags_bold_collision():
+    # cheez-* immediately before a `**` close -> the `*` leaks out of the bold.
+    assert _hazards("**goes through cheez-***.\n")
+
+
+def test_detector_ignores_single_bare_token():
+    # A lone cheez-* followed by whitespace stays literal in the render.
+    assert not _hazards("the cheez-* skills require tilth.\n")
+
+
+def test_detector_ignores_backticked_tokens():
+    assert not _hazards("use `cheez-*` and `cheez-*` freely\n")

--- a/tests/python/test_docs_emphasis_guard.py
+++ b/tests/python/test_docs_emphasis_guard.py
@@ -19,17 +19,26 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 FENCE_RE = re.compile(r"```.*?```", re.S)
 INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
 BARE_TOKEN = "cheez-*"
-COLLISION = "cheez-**"  # a cheez-* token abutting a `**`/`***` emphasis run
+# The corruptor is the `cheez-*` glob's `*` abutting a closing `**` run, i.e.
+# three asterisks (`cheez-***`). A legit `cheez-**bold**` (two asterisks opening
+# an intended bold) must NOT match.
+COLLISION = "cheez-***"
 
 
-def _mirrored_markdown() -> list[Path]:
-    """The markdown gen_docs.py copies into the docs tree verbatim."""
+def _rendered_markdown() -> list[Path]:
+    """Every markdown source the MkDocs site renders.
+
+    Covers both what gen_docs.py mirrors verbatim (root docs, SKILL.md bodies,
+    references, shared contracts) and the hand-authored ``docs/*.md`` pages that
+    mkdocs renders directly — a bare ``cheez-*`` corrupts emphasis in either.
+    """
     files = [
         REPO_ROOT / "README.md",
         REPO_ROOT / "CONTRIBUTING.md",
         REPO_ROOT / "SECURITY.md",
         REPO_ROOT / "CODE_OF_CONDUCT.md",
     ]
+    files += sorted((REPO_ROOT / "docs").glob("*.md"))
     files += sorted((REPO_ROOT / "skills").glob("*/SKILL.md"))
     files += sorted((REPO_ROOT / "skills").glob("*/references/*.md"))
     files += sorted((REPO_ROOT / "shared").glob("*.md"))
@@ -69,7 +78,7 @@ def _hazards(text: str) -> list[tuple[int, str]]:
 
 def test_no_bare_cheez_star_emphasis_hazard():
     offenders: list[str] = []
-    for f in _mirrored_markdown():
+    for f in _rendered_markdown():
         for line, snippet in _hazards(f.read_text(encoding="utf-8")):
             offenders.append(f"{f.relative_to(REPO_ROOT)}:{line}  {snippet!r}")
     assert not offenders, (
@@ -81,17 +90,24 @@ def test_no_bare_cheez_star_emphasis_hazard():
 
 def test_detector_flags_paired_tokens():
     # Two bare tokens in one paragraph -> italic span between them.
-    assert _hazards("use cheez-* skills, not cheez-* fallbacks\n")
+    assert _hazards("use cheez-* skills, not cheez-* fallbacks\n") == [
+        (1, "use cheez-* skills, not cheez-* fallbacks")
+    ]
 
 
 def test_detector_flags_bold_collision():
     # cheez-* immediately before a `**` close -> the `*` leaks out of the bold.
-    assert _hazards("**goes through cheez-***.\n")
+    assert _hazards("**goes through cheez-***.\n") == [(1, "**goes through cheez-***.")]
 
 
 def test_detector_ignores_single_bare_token():
     # A lone cheez-* followed by whitespace stays literal in the render.
     assert not _hazards("the cheez-* skills require tilth.\n")
+
+
+def test_detector_ignores_legit_bold_after_token():
+    # `cheez-**bold**` is an intended bold run, not the `cheez-***` corruptor.
+    assert not _hazards("use cheez-**bold** here\n")
 
 
 def test_detector_ignores_backticked_tokens():

--- a/tests/python/test_gen_docs.py
+++ b/tests/python/test_gen_docs.py
@@ -233,6 +233,15 @@ class TestExtractH2Section:
         assert "## Sub\n" in out
         assert "### Sub" not in out
 
+    def test_bump_headings_promotes_h4_to_h3(self, gen_docs):
+        # Deeper headings must also bump by one level, otherwise an h4 under a
+        # promoted h3 would skip a level in the rendered install page.
+        text = "## A\n### Sub\n#### Deep\nbody\n\n## B\n"
+        out = gen_docs.extract_h2_section(text, "A", drop_header=True, bump_headings=True)
+        assert "## Sub\n" in out
+        assert "### Deep\n" in out
+        assert "#### Deep" not in out
+
     def test_missing_section_returns_empty(self, gen_docs):
         text = "## A\nbody-a\n\n## B\nbody-b\n"
         assert gen_docs.extract_h2_section(text, "Z") == ""


### PR DESCRIPTION
## Problem

The docs job rendered skill pages with broken **bold**/**emphasis**. Root cause: `scripts/gen_docs.py` mirrors README/SKILL.md bodies verbatim into the MkDocs site, and a bare `cheez-*` in prose has its wildcard `*` parsed by Python-Markdown as an emphasis delimiter:

- **Two per paragraph** → italicises the entire span between them
- **`cheez-***`** (token immediately before a `**` close) → the `*` leaks **out** of the bold

Reproduced by building the site locally (`mkdocs build`) and grepping the rendered HTML. Confirmed **4 breaking spots**:
- `README.md:84` — two bare tokens → italic span
- `README.md:115` — `cheez-***` collision → `*` leaks out of bold (the literal "doesn't fully bold" symptom)
- `skills/affinage/SKILL.md:113` — two bare tokens → italic span
- `skills/mold/references/shape-check.md:47` — two bare tokens → italic span

## Fix

Backticked all four corrupting tokens (`` `cheez-*` ``) so Python-Markdown stops parsing the wildcard as emphasis. Verified by rebuilding: both README spots now render correctly, and a full-site grep for `cheez-<em>` / `</strong>*` / `</em>*` returns nothing.

## Guard

Added `tests/python/test_docs_emphasis_guard.py` — a pure-Python regression guard that scans every mirrored markdown source (README + root docs + `skills/**/SKILL.md` + references + shared), strips code spans/fences, and fails on the corruption signature (≥2 bare `cheez-*` per paragraph, or a `cheez-***` collision). Runs in the existing `pytest tests/python` CI gate — no docs venv needed.

## Cleanups (from the `/age` pass)

1. **De-dup rewriters** — extracted the repeated external-URL guard into `_is_external()` and the LICENSE→absolute-URL literal into a `LICENSE_URL` constant.
2. **Promote all h3+ headings** — `bump_headings` now promotes any `#{3,}` by one level (not just `###`), preventing an h4 in a sliced README section from skipping a level.
3. **Mtime-keyed read cache** — each repo file is read once per build via an `@lru_cache`'d `_read_text(path)` keyed on `path.stat().st_mtime`, so README.md isn't re-read by both `emit_install_page` and `emit_root_passthrough`.

## Verification

- `pytest tests/python -q` → **375 passed** (existing + new h4 case + 5 emphasis-guard tests)
- `mkdocs build` → clean (0 emphasis-corruption hits in rendered HTML)
- `ruff check` → clean
- `markdownlint-cli2` (3 changed markdown files) → 0 errors
