### PR TITLE
fix(release): generate notes from main history, not the orphan tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,16 @@ jobs:
         run: |-
           set -euo pipefail
           gh repo edit "$GITHUB_REPOSITORY" --add-topic agent-skills || true
+          # `gh --generate-notes` is useless once the tag is retargeted onto the
+          # orphan release snapshot (no main history to diff). Build notes from
+          # main directly, anchored on GITHUB_SHA — the commit the tag was pushed
+          # to before the retarget.
+          git fetch --tags --force origin
+          python3 scripts/release_notes.py \
+            --tag "$TAG" --to "$GITHUB_SHA" --repo "$GITHUB_REPOSITORY" \
+            > "$RUNNER_TEMP/notes.md"
           if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release edit "$TAG" --verify-tag
+            gh release edit "$TAG" --verify-tag --notes-file "$RUNNER_TEMP/notes.md"
           else
-            gh release create "$TAG" --verify-tag --generate-notes --title "$TAG"
+            gh release create "$TAG" --verify-tag --notes-file "$RUNNER_TEMP/notes.md" --title "$TAG"
           fi

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -25,7 +25,7 @@ _CONVENTIONAL = re.compile(
 )
 _PR_SUFFIX = re.compile(r"\s*\(#(?P<num>\d+)\)\s*$")
 _SOURCE_SHA = re.compile(r"main@(?P<sha>[0-9a-f]{7,40})")
-_SEMVER = re.compile(r"^v(?P<maj>\d+)\.(?P<min>\d+)\.(?P<patch>\d+)")
+_SEMVER = re.compile(r"^v(?P<maj>\d+)\.(?P<min>\d+)\.(?P<patch>\d+)$")
 
 # Conventional type -> section heading, in render order.
 _SECTIONS = [

--- a/scripts/release_notes.py
+++ b/scripts/release_notes.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Generate categorized release notes from main's git history.
+
+`gh release create --generate-notes` is useless here: the release workflow
+force-retargets each version tag onto a single-commit orphan `release`-branch
+snapshot (so `gh skill install` can read the built .pyz from the tag tree).
+That orphan has no main history, so GitHub has nothing to diff and emits empty
+notes.
+
+Instead we walk main directly. The previous version tag records its main commit
+in its subject (`release: vX.Y.Z from main@<sha>`); we recover that, then group
+`git log <prev_source>..<curr_source>` by conventional-commit type.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+
+# type/scope: description (optional ! before the colon marks a breaking change)
+_CONVENTIONAL = re.compile(
+    r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]*)\))?(?P<bang>!)?:\s*(?P<desc>.+)$"
+)
+_PR_SUFFIX = re.compile(r"\s*\(#(?P<num>\d+)\)\s*$")
+_SOURCE_SHA = re.compile(r"main@(?P<sha>[0-9a-f]{7,40})")
+_SEMVER = re.compile(r"^v(?P<maj>\d+)\.(?P<min>\d+)\.(?P<patch>\d+)")
+
+# Conventional type -> section heading, in render order.
+_SECTIONS = [
+    ("breaking", "Breaking changes"),
+    ("feat", "Features"),
+    ("fix", "Fixes"),
+    ("perf", "Performance"),
+    ("docs", "Documentation"),
+    ("deps", "Dependencies"),
+    ("maint", "Maintenance"),
+    ("other", "Other"),
+]
+_MAINT_TYPES = {"chore", "build", "ci", "refactor", "test", "style", "revert"}
+
+
+def _git(*args: str, cwd: str | None = None) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _semver_key(tag: str) -> tuple[int, int, int] | None:
+    m = _SEMVER.match(tag)
+    if not m:
+        return None
+    return int(m["maj"]), int(m["min"]), int(m["patch"])
+
+
+def find_previous_tag(tag: str, cwd: str | None = None) -> str | None:
+    """The version tag with the highest semver strictly below `tag`."""
+    current = _semver_key(tag)
+    if current is None:
+        return None
+    candidates = []
+    for line in _git("tag", "--list", "v[0-9]*", cwd=cwd).splitlines():
+        key = _semver_key(line.strip())
+        if key is not None and key < current:
+            candidates.append((key, line.strip()))
+    if not candidates:
+        return None
+    return max(candidates)[1]
+
+
+def resolve_source_sha(ref: str, cwd: str | None = None) -> str:
+    """Recover the main commit a release tag was built from.
+
+    Tags from the orphan-retarget era carry `release: vX from main@<sha>` in
+    their subject. Older tags point straight at a main commit, so the ref itself
+    is the source.
+    """
+    subject = _git("log", "-1", "--format=%s", ref, cwd=cwd)
+    m = _SOURCE_SHA.search(subject)
+    return m["sha"] if m else ref
+
+
+def collect_commits(from_ref: str | None, to_ref: str, cwd: str | None = None) -> list[str]:
+    rng = to_ref if from_ref is None else f"{from_ref}..{to_ref}"
+    out = _git("log", "--no-merges", "--format=%s", rng, cwd=cwd)
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def _classify(subject: str) -> tuple[str, str, str | None]:
+    """(section_key, cleaned_description, pr_number)."""
+    pr = None
+    pr_match = _PR_SUFFIX.search(subject)
+    if pr_match:
+        pr = pr_match["num"]
+        subject = subject[: pr_match.start()].rstrip()
+
+    m = _CONVENTIONAL.match(subject)
+    if not m:
+        return "other", subject, pr
+
+    ctype, scope, bang, desc = m["type"], m["scope"] or "", m["bang"], m["desc"]
+    if bang:
+        return "breaking", desc, pr
+    if (ctype in {"chore", "build"} and "deps" in scope) or desc.lower().startswith("bump "):
+        return "deps", desc, pr
+    if ctype in {"feat", "fix", "perf", "docs"}:
+        return ctype, desc, pr
+    if ctype in _MAINT_TYPES:
+        return "maint", desc, pr
+    return "other", desc, pr
+
+
+def _bullet(desc: str, pr: str | None) -> str:
+    desc = desc[0].upper() + desc[1:] if desc else desc
+    return f"- {desc} (#{pr})" if pr else f"- {desc}"
+
+
+def categorize(subjects: list[str]) -> dict[str, list[str]]:
+    buckets: dict[str, list[str]] = {key: [] for key, _ in _SECTIONS}
+    for subject in subjects:
+        key, desc, pr = _classify(subject)
+        buckets[key].append(_bullet(desc, pr))
+    return buckets
+
+
+def render(
+    tag: str,
+    subjects: list[str],
+    repo: str,
+    prev_source: str | None,
+    to_sha: str,
+) -> str:
+    buckets = categorize(subjects)
+    lines: list[str] = ["## What's Changed", ""]
+    for key, heading in _SECTIONS:
+        if buckets[key]:
+            lines.append(f"### {heading}")
+            lines.extend(buckets[key])
+            lines.append("")
+    if len(lines) == 2:  # nothing categorized
+        lines.append("_No notable changes._")
+        lines.append("")
+    if prev_source:
+        link = f"https://github.com/{repo}/compare/{prev_source}...{to_sha}"
+        lines.append(f"**Full Changelog**: {link}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def generate(tag: str, to_sha: str, repo: str, cwd: str | None = None) -> str:
+    prev_tag = find_previous_tag(tag, cwd=cwd)
+    prev_source = resolve_source_sha(prev_tag, cwd=cwd) if prev_tag else None
+    subjects = collect_commits(prev_source, to_sha, cwd=cwd)
+    return render(tag, subjects, repo, prev_source, to_sha)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="version tag being released, e.g. v0.5.3")
+    parser.add_argument("--to", default="HEAD", help="end of the commit range (the main SHA)")
+    parser.add_argument("--repo", required=True, help="owner/repo for the changelog link")
+    args = parser.parse_args()
+    sys.stdout.write(generate(args.tag, args.to, args.repo))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/test_release_notes.py
+++ b/tests/python/test_release_notes.py
@@ -1,0 +1,98 @@
+"""Release notes are generated from main's real history, not the orphan release
+tag. These tests pin the invariants that the empty-notes bug violated: the
+previous tag's source SHA is recovered from its `main@<sha>` subject, the commit
+range is the main range (not the single-commit orphan), and conventional-commit
+types land in the right sections.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import release_notes  # noqa: E402
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _commit(repo: Path, subject: str) -> str:
+    (repo / "f").write_text(subject)
+    _git(repo, "add", "f")
+    _git(repo, "commit", "-m", subject)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q")
+    _git(r, "config", "user.email", "t@t")
+    _git(r, "config", "user.name", "t")
+    return r
+
+
+def test_recovers_prev_source_and_categorizes(repo: Path) -> None:
+    prev_source = _commit(repo, "feat(old): shipped in last release (#1)")
+    # The orphan release snapshot: a commit whose subject records its main SHA.
+    release_commit = _commit(repo, f"release: v0.1.0 from main@{prev_source}")
+    _git(repo, "tag", "v0.1.0", release_commit)
+
+    _commit(repo, "feat(paths): anchor durable corpus (#84)")
+    _commit(repo, "fix(docs): stop token corruption (#89)")
+    _commit(repo, "docs(readme): add badges (#91)")
+    _commit(repo, "chore(deps): bump github/codeql-action from 4.35.5 to 4.36.0 (#87)")
+    _commit(repo, "refactor: tidy internals (#92)")
+    to_sha = _git(repo, "rev-parse", "HEAD")
+
+    notes = release_notes.generate("v0.2.0", to_sha, "owner/repo", cwd=str(repo))
+
+    # The prior-release feat must NOT appear — it predates prev_source.
+    assert "shipped in last release" not in notes
+    # Each type lands under its heading.
+    assert "### Features\n- Anchor durable corpus (#84)" in notes
+    assert "### Fixes\n- Stop token corruption (#89)" in notes
+    assert "### Documentation\n- Add badges (#91)" in notes
+    assert "### Dependencies\n- Bump github/codeql-action from 4.35.5 to 4.36.0 (#87)" in notes
+    assert "### Maintenance\n- Tidy internals (#92)" in notes
+    # Changelog link spans the real main range, not the orphan tag.
+    assert f"compare/{prev_source}...{to_sha}" in notes
+
+
+def test_breaking_change_promoted(repo: Path) -> None:
+    _commit(repo, "feat(api)!: drop legacy flag (#5)")
+    to_sha = _git(repo, "rev-parse", "HEAD")
+    notes = release_notes.generate("v0.1.0", to_sha, "owner/repo", cwd=str(repo))
+    assert "### Breaking changes\n- Drop legacy flag (#5)" in notes
+    # A bang feat is breaking, not a plain feature.
+    assert "### Features" not in notes
+
+
+def test_no_previous_tag_lists_all_history(repo: Path) -> None:
+    _commit(repo, "feat: first ever (#1)")
+    to_sha = _git(repo, "rev-parse", "HEAD")
+    notes = release_notes.generate("v0.1.0", to_sha, "owner/repo", cwd=str(repo))
+    assert "- First ever (#1)" in notes
+    # No prior tag means no changelog compare link.
+    assert "Full Changelog" not in notes
+
+
+def test_non_conventional_subject_falls_to_other(repo: Path) -> None:
+    _commit(repo, "random uncategorized commit")
+    to_sha = _git(repo, "rev-parse", "HEAD")
+    notes = release_notes.generate("v0.1.0", to_sha, "owner/repo", cwd=str(repo))
+    assert "### Other\n- Random uncategorized commit" in notes


### PR DESCRIPTION
## Problem

`gh release create --generate-notes` produces empty notes (v0.5.3 shipped with just a bare `**Full Changelog**` link). The release workflow force-retargets each version tag onto a **single-commit orphan** `release`-branch snapshot — required so `gh skill install` can read the built `.pyz` from the tag tree. That orphan has no main history, so GitHub has nothing to diff.

## Fix

`scripts/release_notes.py` builds the changelog from main directly:

- Finds the previous version tag and recovers its main commit from the `release: vX.Y.Z from main@<sha>` subject (falls back to the tag itself for the pre-retarget era).
- Renders a conventional-commit changelog over `git log <prev_source>..<curr_source>`, anchored on `GITHUB_SHA` (the commit the tag pointed at before the retarget).
- Groups into Breaking / Features / Fixes / Performance / Documentation / Dependencies / Maintenance / Other; non-conventional subjects fall to Other.

`release.yml` now feeds the rendered file via `--notes-file` (both the create and edit paths, so re-runs refresh notes).

## Verification

- `tests/python/test_release_notes.py` — 4 tests over real temp git repos: source-SHA recovery, range exclusion of prior-release commits, type→section mapping, breaking-change promotion, no-previous-tag, and non-conventional fallthrough.
- Full suite: 380 passed. ruff + yamllint clean.
- Generated v0.5.3's notes from real history and confirmed they match the hand-curated set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)