### PR TITLE
WIP: feat(mold): add domain-docs layer (glossary, ADRs, context-map)

### DIFF
--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mold
-description: This skill should be used when the user has a fuzzy idea, half-formed feature, or design direction and wants to converge on a spec — phrases like "let's design X", "I'm thinking about Y", "what should the API for Z look like", "shape this into a spec", "I want to add a feature that…", "/mold". Runs an iterative dialogue (Explore / Ground / Glossary / Shape / Sketch / Grill / Diagnose), grounds every critical claim with cheez-search or briesearch, locks public seams in pseudocode, optionally captures the domain glossary (CONTEXT.md) and architecture decision records, and only writes a spec to `.cheese/specs/<slug>.md` after an explicit approval gate. Use even when the user is "just thinking out loud" if they want the dialogue to leave behind a written artifact — for pure no-write thinking, route to `/culture` instead. After `/culture` (optional); before `/cook`.
+description: This skill should be used when the user has a fuzzy idea, half-formed feature, or design direction and wants to converge on a spec — phrases like "let's design X", "I'm thinking about Y", "what should the API for Z look like", "shape this into a spec", "I want to add a feature that…", "/mold". Runs an iterative dialogue (Explore / Ground / Glossary / Shape / Sketch / Grill / Diagnose), grounds every critical claim with cheez-search or briesearch, locks public seams in pseudocode, optionally captures the domain glossary (CONTEXT.md) and architecture decision records, and only writes a spec to the durable corpus path after an explicit approval gate. Use even when the user is "just thinking out loud" if they want the dialogue to leave behind a written artifact — for pure no-write thinking, route to `/culture` instead. After `/culture` (optional); before `/cook`.
 license: MIT
 ---
 
@@ -71,7 +71,7 @@ Resolve durable artifact locations through the resolver, never hardcode them:
 
 - Spec: `python3 ${CLAUDE_SKILL_DIR}/scripts/mold.pyz artifact-path specs <slug>` (anchored at the per-project durable corpus — see `shared/formatting.md` § Corpus location).
 - Issues: stay repo-local at `.cheese/issues/<slug>-001.md`, `.cheese/issues/<slug>-002.md`, ... — `issues` is a transient phase, not a durable-corpus artifact.
-- Domain docs: repo-local at their literal paths — glossary at `CONTEXT.md` (root or per-context), ADRs at `docs/adr/NNNN-slug.md`. Written at the handshake, lazily, not through the resolver — see `references/domain-docs.md`.
+- Domain docs: repo-local at their literal paths — glossary at `CONTEXT.md` (root or per-context), ADRs at `docs/adr/NNNN-slug.md`. Written at curdle, gated by the handshake, lazily, not through the resolver — see `references/domain-docs.md`.
 
 ## --hard
 

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mold
-description: This skill should be used when the user has a fuzzy idea, half-formed feature, or design direction and wants to converge on a spec — phrases like "let's design X", "I'm thinking about Y", "what should the API for Z look like", "shape this into a spec", "I want to add a feature that…", "/mold". Runs an iterative dialogue (Explore / Ground / Shape / Sketch / Grill / Diagnose), grounds every critical claim with cheez-search or briesearch, locks public seams in pseudocode, and only writes a spec to `.cheese/specs/<slug>.md` after an explicit approval gate. Use even when the user is "just thinking out loud" if they want the dialogue to leave behind a written artifact — for pure no-write thinking, route to `/culture` instead. After `/culture` (optional); before `/cook`.
+description: This skill should be used when the user has a fuzzy idea, half-formed feature, or design direction and wants to converge on a spec — phrases like "let's design X", "I'm thinking about Y", "what should the API for Z look like", "shape this into a spec", "I want to add a feature that…", "/mold". Runs an iterative dialogue (Explore / Ground / Glossary / Shape / Sketch / Grill / Diagnose), grounds every critical claim with cheez-search or briesearch, locks public seams in pseudocode, optionally captures the domain glossary (CONTEXT.md) and architecture decision records, and only writes a spec to `.cheese/specs/<slug>.md` after an explicit approval gate. Use even when the user is "just thinking out loud" if they want the dialogue to leave behind a written artifact — for pure no-write thinking, route to `/culture` instead. After `/culture` (optional); before `/cook`.
 license: MIT
 ---
 
@@ -16,7 +16,7 @@ Do not use it for free-form discussion with no artifact intent (`/culture`), dir
 2. **Dialogue** — build shared understanding through the smallest useful question to the user, but contribute at maximum useful depth between questions (full options, named edge cases, concrete evidence — not gestural sketches). Ground every critical claim with `cheez-search`, `cheez-read`, or a Validate Cycle (`references/validate-cycle.md`). Track contradictions across turns; if turn N contradicts an earlier conclusion, flag and resolve it before continuing.
 3. **Sketch** — for any feature touching >1 module or a new public interface, run the shape check (`references/shape-check.md`) on the touched symbols, then lock seams in pseudocode signatures before talking spec content. Default to full signatures, not hand-waving.
 4. **Two-key handshake** — both the user (explicit verb) and the agent (coherence self-check) must agree before extraction. See `references/handshake.md`.
-5. **Curdle** — resolve the durable spec path with `SPEC=$(python3 ${CLAUDE_SKILL_DIR}/scripts/mold.pyz artifact-path specs <slug>)`, then write the approved spec to `"$SPEC"` (and optional issues alongside). The resolver anchors specs at the per-project durable corpus (see `shared/formatting.md` § Corpus location); never hardcode a `.cheese/specs/` path. Format and slug rules in `references/curdle.md`.
+5. **Curdle** — resolve the durable spec path with `SPEC=$(python3 ${CLAUDE_SKILL_DIR}/scripts/mold.pyz artifact-path specs <slug>)`, then write the approved spec to `"$SPEC"` (and optional issues alongside). The resolver anchors specs at the per-project durable corpus (see `shared/formatting.md` § Corpus location); never hardcode a `.cheese/specs/` path. Format and slug rules in `references/curdle.md`. If the dialogue pinned domain terms or surfaced ADR-worthy decisions, flush them to `CONTEXT.md` / `docs/adr/` at the same gate — see `references/domain-docs.md`.
 6. **Hand off** — once the spec is on disk, run `python3 ${CLAUDE_SKILL_DIR}/scripts/mold.pyz curd-count "$SPEC" --blast-radius <low|medium|high>` to compute the recommended downstream skill (full procedure in `references/curd-count.md`). Omit `--blast-radius` when the shape-check verdict is `[?]` or shape-check was skipped — the script degrades to `/cook` for sub-threshold specs in that case. Then prompt the next step via the shared handoff gate in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md). Never dispatch before the user selects; after a non-stop selection, run the selected downstream skill immediately.
 
 ## Modes
@@ -25,6 +25,7 @@ Do not use it for free-form discussion with no artifact intent (`/culture`), dir
 | --- | --- | --- |
 | Explore | The idea is vague | Identify the real problem and pain point |
 | Ground | A file, bug, or existing doc is named | Verify facts against evidence |
+| Glossary | Domain terms are fuzzy, conflicting, or a `CONTEXT.md` exists to challenge against | Pin the ubiquitous language; resolve term conflicts |
 | Shape | The goal is known but approach is open | Compare viable options (Do Nothing always included) |
 | Sketch | Interfaces or module boundaries matter | Lock responsibilities and seams |
 | Grill | A favoured approach needs stress-testing | Steelman the rejected option, find weak assumptions and edge cases |
@@ -70,6 +71,7 @@ Resolve durable artifact locations through the resolver, never hardcode them:
 
 - Spec: `python3 ${CLAUDE_SKILL_DIR}/scripts/mold.pyz artifact-path specs <slug>` (anchored at the per-project durable corpus — see `shared/formatting.md` § Corpus location).
 - Issues: stay repo-local at `.cheese/issues/<slug>-001.md`, `.cheese/issues/<slug>-002.md`, ... — `issues` is a transient phase, not a durable-corpus artifact.
+- Domain docs: repo-local at their literal paths — glossary at `CONTEXT.md` (root or per-context), ADRs at `docs/adr/NNNN-slug.md`. Written at the handshake, lazily, not through the resolver — see `references/domain-docs.md`.
 
 ## --hard
 
@@ -121,6 +123,10 @@ The spec is large enough that per-phase context contamination becomes a real con
 
 - Dialogue first; artifacts are the by-product.
 - Do not implement code.
-- Do not write production files before the approval gate.
+- Do not write production files — including domain docs (CONTEXT.md, CONTEXT-MAP.md, ADRs) — before the approval gate. Accumulate them in the state ledger and flush at curdle (`references/domain-docs.md`).
 - Do not silently settle uncertain claims.
 - Apply the shared voice kernel (lives at `skills/age/references/voice.md` in this repo): correct false premises, flag confidence as `certain | speculating | don't know` on each critical claim, steelman before dismissing, ask the smallest useful question while contributing at maximum useful depth.
+
+## Credits
+
+The domain-documentation layer — the Glossary mode, `CONTEXT.md` as a ubiquitous-language glossary, lazy `CONTEXT-MAP.md` for bounded contexts, and the sparingly-offered ADR with its three-part test — is adapted from Matt Pocock's **grill-with-docs** skill (MIT): <https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs>. mold integrates it behind the two-key handshake rather than writing docs inline.

--- a/skills/mold/references/adr-format.md
+++ b/skills/mold/references/adr-format.md
@@ -1,0 +1,47 @@
+# ADR format
+
+An Architecture Decision Record captures one durable decision and *why* it was made. ADRs live in `docs/adr/` (or a context-specific `docs/adr/` in multi-context repos) with sequential numbering: `0001-slug.md`, `0002-slug.md`. Create the directory lazily — only when the first ADR is needed.
+
+Adapted from Matt Pocock's grill-with-docs skill (MIT) — see [`domain-docs.md`](domain-docs.md) § Attribution.
+
+## When to offer an ADR
+
+Offer one **only when all three are true**:
+
+1. **Hard to reverse** — changing your mind later carries meaningful cost.
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons.
+
+Miss any one and skip it: an easy-to-reverse decision you'll just reverse; an unsurprising one nobody questions; a no-alternative one records only "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape** — "monorepo"; "event-sourced write model, Postgres read model".
+- **Integration patterns between contexts** — "Ordering and Billing talk via domain events, not synchronous HTTP".
+- **Technology choices with lock-in** — database, message bus, auth provider, deployment target. Not every library — the ones that would take a quarter to swap.
+- **Boundary and scope decisions** — "Customer data is owned by the Customer context; others reference it by ID only." The explicit no's matter as much as the yes's.
+- **Deliberate deviations from the obvious path** — "manual SQL instead of an ORM because X." Stops the next engineer from "fixing" something deliberate.
+- **Constraints invisible in the code** — "no AWS, for compliance"; "responses under 200ms because of the partner API contract".
+- **Rejected alternatives when the rejection is non-obvious** — picked REST over GraphQL for subtle reasons? Record it, or it gets re-proposed in six months.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1–3 sentences: the context, what was decided, and why.}
+```
+
+That's the whole thing. An ADR can be one paragraph. The value is recording *that* a decision was made and *why* — not filling out sections.
+
+### Optional sections
+
+Include only when they earn their place; most ADRs need none.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — when decisions get revisited.
+- **Considered Options** — when the rejected alternatives are worth remembering.
+- **Consequences** — when non-obvious downstream effects need calling out.
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one. In multi-context repos, number within the relevant context's `docs/adr/`.

--- a/skills/mold/references/context-format.md
+++ b/skills/mold/references/context-format.md
@@ -1,0 +1,68 @@
+# CONTEXT.md format
+
+`CONTEXT.md` is a glossary and nothing else — the project's ubiquitous language. It is devoid of implementation detail: define what a term **is**, not what it does. Not a spec, not a scratch pad.
+
+Adapted from Matt Pocock's grill-with-docs skill (MIT) — see [`domain-docs.md`](domain-docs.md) § Attribution.
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentences: what this context is and why it exists.}
+
+## Language
+
+**Order**:
+A customer's request to purchase, before fulfillment.
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+
+## Flagged ambiguities
+
+- **Cancellation** — used for both order-level and line-level voids. Resolved: order-level only; a line-level void is a **Return**.
+
+## Example dialogue
+
+> **Dev:** If a Customer voids one line of a three-line Order, is the Order cancelled?
+> **Domain expert:** No — that's a Return against the Order. Cancellation voids the whole Order before fulfillment.
+```
+
+## Rules
+
+- **Be opinionated.** When several words mean one concept, pick the best and list the rest under `_Avoid_`.
+- **Flag conflicts explicitly.** Ambiguous usage goes under "Flagged ambiguities" with a resolution — the durable form of the `[CONFLICT <id>]` mold tracks inline during the dialogue.
+- **Keep definitions tight.** One or two sentences. Define what it IS.
+- **Show relationships.** Bold term names; express cardinality where obvious.
+- **Project-specific terms only.** General programming concepts (timeouts, retries, error types, utility patterns) do not belong, even if used heavily. Ask: unique to this domain, or general? Only the former.
+- **Group under subheadings** when natural clusters emerge; a flat list is fine otherwise.
+- **Write an example dialogue** — a dev / domain-expert exchange that shows the terms interacting and clarifies the boundaries between related concepts.
+
+## CONTEXT-MAP.md (multi-context repos)
+
+A root `CONTEXT-MAP.md` lists the bounded contexts, where each lives, and how they relate:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced`; Fulfillment consumes it to start picking.
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched`; Billing consumes it to invoice.
+- **Ordering ↔ Billing**: share `CustomerId` and `Money` types.
+```
+
+Detection rules live in [`domain-docs.md`](domain-docs.md) § Multi-context detection.

--- a/skills/mold/references/curdle.md
+++ b/skills/mold/references/curdle.md
@@ -11,8 +11,9 @@ Resolve the spec path with `SPEC=$(python3 ${CLAUDE_SKILL_DIR}/scripts/mold.pyz 
 | **Spec** | Any meaningful design discussion | `$SPEC` (resolver output) |
 | **Spec + Issues** | Side-channel actionables surfaced (out-of-scope bugs, follow-ups) | spec at `$SPEC`; issues at `.cheese/issues/<slug>-001.md`, `-002.md`, … |
 | **Issues only** | Pure standalone bug tickets, no design | `.cheese/issues/<slug>-001.md`, … |
+| **Domain docs** | Glossary terms or ADR-worthy decisions surfaced during the dialogue | `CONTEXT.md` (root or per-context); ADRs at `docs/adr/NNNN-slug.md` — see `domain-docs.md` |
 
-A spec is the rich container; absorbs problem framing, requirements, approach, decisions, interface sketches, risks, gates. An issue is a separate, GitHub-flavoured item the user can paste into a tracker.
+A spec is the rich container; absorbs problem framing, requirements, approach, decisions, interface sketches, risks, gates. An issue is a separate, GitHub-flavoured item the user can paste into a tracker. Domain docs are durable, repo-local, and accompany a spec rather than replacing it.
 
 ## Slug rules
 
@@ -103,9 +104,19 @@ parent_spec: <slug>
 - <optional caveat or pointer>
 ```
 
+## Domain docs
+
+If the dialogue accumulated `glossary_terms` or `adr_candidates` in the state ledger (see `domain-docs.md`), flush them here — at curdle, after the handshake, never mid-dialogue.
+
+- **CONTEXT.md** — write resolved terms to the glossary. Single-context: root `CONTEXT.md`. Multi-context (`CONTEXT-MAP.md` present): the matching context's `CONTEXT.md`. Create lazily — only the file the first approved term needs. Format in `context-format.md`.
+- **CONTEXT-MAP.md** — scaffold only when the user is genuinely working across multiple bounded contexts. Format in `context-format.md`.
+- **ADRs** — one file per candidate that cleared all three criteria, at `docs/adr/NNNN-slug.md` (number = highest existing + 1; per-context `docs/adr/` in multi-context repos). Format in `adr-format.md`.
+
+These are durable repo artifacts but not part of the durable-corpus resolver — write them at their literal repo paths, not through `artifact-path`. They are not pre-formed curds: a glossary update accompanies a spec, it does not split it, so they do not count toward `candidate_curds` in the handoff.
+
 ## Atomic write
 
-Stage to a temp directory under `${TMPDIR}` first, then move into place. Never leave partial files on a write failure.
+Stage to a temp directory under `${TMPDIR}` first, then move into place. Never leave partial files on a write failure. The same applies to domain docs — an interrupted glossary write must not corrupt an existing `CONTEXT.md`.
 
 ## Hand-off
 

--- a/skills/mold/references/domain-docs.md
+++ b/skills/mold/references/domain-docs.md
@@ -1,0 +1,57 @@
+# Domain documentation
+
+mold's spec captures *this change*. Domain docs capture *the project's shared language and durable decisions* — knowledge that outlives any one spec. mold accumulates both during the dialogue and writes them at the same two-key handshake that gates the spec.
+
+Three artifacts, all optional, all lazy (created only when there is something to write):
+
+| Artifact | What it is | Path |
+| --- | --- | --- |
+| **CONTEXT.md** | Domain glossary — the ubiquitous language. Terms, canonical names, aliases to avoid, flagged ambiguities. No implementation detail. | repo root, or per-context (see multi-context) |
+| **CONTEXT-MAP.md** | Bounded-context map for multi-context repos — where each context lives and how they relate. | repo root |
+| **ADR** | Architecture Decision Record — one durable, hard-to-reverse decision and its rationale. | `docs/adr/NNNN-slug.md` (or a per-context `docs/adr/`) |
+
+Formats: glossary + map in [`context-format.md`](context-format.md); ADRs in [`adr-format.md`](adr-format.md).
+
+## Live tracking, gated writes
+
+The glossary and ADR candidates are **in-session state first, files second** — same discipline as validate cycles (`validate-cycle.md`). mold does not write domain docs mid-dialogue; it accumulates them in the state ledger and flushes them at curdle, after the handshake. This keeps mold's cardinal rule intact — no production files before the approval gate — while preserving the "capture terms as they resolve, don't reconstruct them from memory" benefit.
+
+Track in the mold state file alongside `validate_cycles`:
+
+```yaml
+glossary_terms:
+  - term: Order
+    definition: A customer's request to purchase, before fulfillment.
+    avoid: [Purchase, transaction]
+    context: ordering          # omit for single-context repos
+    status: resolved           # resolved | flagged
+adr_candidates:
+  - title: Event-sourced write model
+    criteria: [hard-to-reverse, surprising, real-tradeoff]   # all three required
+    decision: "Write model is event-sourced; read model projected to Postgres."
+```
+
+Surface the running ledger when a term resolves or an ADR-worthy decision lands — e.g. `📓 glossary: Order ≠ Purchase (logged)` — so the user watches it accrue. Write nothing yet.
+
+## Behaviours during the dialogue
+
+These extend existing modes; they do not replace mold's grounding discipline.
+
+- **Sharpen fuzzy language (Glossary / Ground).** When the user uses a vague or overloaded term, propose a precise canonical name plus the aliases to avoid. "You said *account* — do you mean **Customer** or **User**? Those are different things." Log the resolution.
+- **Challenge against the glossary (Glossary / Ground).** If a `CONTEXT.md` exists and a term conflicts with it, flag it immediately as `[CONFLICT <id>]`: "Your glossary defines *cancellation* as X; you seem to mean Y — which is it?" This is the same contradiction-tracking mold already runs against code, pointed at the lexicon.
+- **Stress-test boundaries with concrete scenarios (Grill).** Invent specific scenarios that probe the edges between concepts and force precision: "A customer voids one line of a three-line order — partial Cancellation, Return, or neither?" See Grill mode in `modes.md`.
+- **Offer ADRs sparingly (handshake).** Only when all three criteria hold — hard to reverse, surprising without context, the result of a real trade-off. Miss any one, skip it. Full test in `adr-format.md`.
+
+## Multi-context detection
+
+Most repos are single-context: one `CONTEXT.md` at the root. Before writing glossary terms, detect the shape:
+
+1. `CONTEXT-MAP.md` at the repo root → multi-context. Read it to find each context's `CONTEXT.md`; route each term to the context it belongs to (ask if unclear).
+2. Only a root `CONTEXT.md` → single context.
+3. Neither → single context; create the root `CONTEXT.md` lazily when the first term is approved.
+
+Do not scaffold a `CONTEXT-MAP.md` unless the user is genuinely working across multiple bounded contexts.
+
+## Attribution
+
+The domain-documentation model — `CONTEXT.md` as a ubiquitous-language glossary, lazy `CONTEXT-MAP.md` for bounded contexts, and the sparingly-offered ADR with its three-part test — is adapted from Matt Pocock's **grill-with-docs** skill (MIT): <https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs>. mold integrates it behind the two-key handshake rather than writing inline.

--- a/skills/mold/references/domain-docs.md
+++ b/skills/mold/references/domain-docs.md
@@ -1,6 +1,6 @@
 # Domain documentation
 
-mold's spec captures *this change*. Domain docs capture *the project's shared language and durable decisions* — knowledge that outlives any one spec. mold accumulates both during the dialogue and writes them at the same two-key handshake that gates the spec.
+mold's spec captures *this change*. Domain docs capture *the project's shared language and durable decisions* — knowledge that outlives any one spec. mold accumulates both during the dialogue and writes them at curdle, gated by the same two-key handshake that gates the spec.
 
 Three artifacts, all optional, all lazy (created only when there is something to write):
 

--- a/skills/mold/references/handshake.md
+++ b/skills/mold/references/handshake.md
@@ -24,7 +24,11 @@ Coherence self-check before curdle:
 - [ ] Open questions all marked [TBD] / [BLOCKED] / [?] (none silent)
 - [ ] Quality gates specified (≥1 runnable command)
 - [ ] Reproduction loop captured if Diagnose ran (or [BLOCKED] if no loop is possible)
+- [ ] Glossary terms: if any domain language was pinned, every term is logged with a canonical name; conflicts resolved or [TBD] (n/a if no glossary work)
+- [ ] ADRs: every ADR candidate meets all three criteria or is dropped (n/a if none offered)
 ```
+
+Domain docs (CONTEXT.md, CONTEXT-MAP.md, ADRs) ride the same gate as the spec — they are written at curdle, never mid-dialogue. The two rows above are no-ops when no glossary or ADR work happened; they exist so accumulated `glossary_terms` / `adr_candidates` cannot be flushed to disk without passing the check. See `domain-docs.md`.
 
 If any box is unchecked, name it and propose the smallest move to fill it. The user can override with `curdle anyway`.
 

--- a/skills/mold/references/modes.md
+++ b/skills/mold/references/modes.md
@@ -1,4 +1,4 @@
-# The six modes of mold
+# The seven modes of mold
 
 Mold has no fixed entry point. Inspect the input shape and pick a starting mode. Announce the mode in one line. Low-confidence classifications default to **Explore**.
 
@@ -8,6 +8,7 @@ Mold has no fixed entry point. Inspect the input shape and pick a starting mode.
 | --- | --- | --- |
 | Stack trace, "X is broken/slow/flaky" | Diagnose | error markers, `file:line` refs, symptom verbs |
 | File path, PR ref, existing spec under `.cheese/specs/` | Ground | concrete artifact exists; read it first |
+| Fuzzy/overloaded domain terms, "what do we call X", a `CONTEXT.md` to challenge against | Glossary | naming and definition questions, term conflicts |
 | Half-baked design doc with signatures or schemas | Sketch | already has interfaces; refine them |
 | "I want to add X" with concrete nouns | Shape | named the thing → jump to options |
 | "Should we do X? thinking about Y" | Grill | tentative plan exists → stress-test it |
@@ -29,6 +30,14 @@ Mold has no fixed entry point. Inspect the input shape and pick a starting mode.
 
 **Exit when:** every critical claim has a citation.
 
+### Glossary — ubiquitous language
+
+**Job:** pin the project's domain language. Sharpen fuzzy or overloaded terms into canonical names with aliases-to-avoid, challenge new usage against an existing `CONTEXT.md`, and resolve term conflicts as `[CONFLICT <id>]`. Accumulate resolved terms in the state ledger (`glossary_terms`); they flush to `CONTEXT.md` at curdle, gated by the handshake — never written mid-dialogue. Full discipline, formats, and multi-context routing in `domain-docs.md`.
+
+**Relation to Ground:** Ground resolves a single overloaded term in the moment to unblock a claim; Glossary owns the durable lexicon and the challenge-against-`CONTEXT.md` loop.
+
+**Exit when:** every domain term in scope has a canonical name (or is logged `[CONFLICT]` / `[TBD]`), and the example-dialogue boundary cases hold.
+
 ### Shape — option generation
 
 **Job:** turn a grounded problem into 2+ candidate approaches with trade-offs. Always include **Do Nothing**. Recommend with one-line rationale. Validate Cycle any critical assumption behind a recommendation.
@@ -43,7 +52,7 @@ Mold has no fixed entry point. Inspect the input shape and pick a starting mode.
 
 ### Grill — adversarial clarification
 
-**Job:** stress-test the chosen approach plus sketched interfaces. **One question at a time**, paired with the agent's recommended answer (recommendation is non-optional). Traverse decision branches and contract corners. Pause for a Validate Cycle when an unverified assumption surfaces.
+**Job:** stress-test the chosen approach plus sketched interfaces. **One question at a time**, paired with the agent's recommended answer (recommendation is non-optional). Traverse decision branches and contract corners. When domain boundaries are in play, stress-test them with invented concrete scenarios that force precision on where one concept ends and another begins (see `domain-docs.md`). Pause for a Validate Cycle when an unverified assumption surfaces.
 
 **Exit when:** every branch and contract corner is touched and agent confidence ≥ user confidence.
 
@@ -58,7 +67,7 @@ Diagnose is **diagnostic-only** — hand off to Shape ("what's the fix?") then C
 
 ## User knobs (free-form interrupts)
 
-`explore`, `ground`, `shape`, `sketch`, `grill`, `diagnose`, `validate <hypothesis>`, `curdle`, `pause`, `enough`. Honour these immediately.
+`explore`, `ground`, `glossary`, `shape`, `sketch`, `grill`, `diagnose`, `validate <hypothesis>`, `curdle`, `pause`, `enough`. Honour these immediately.
 
 ## Uncertainty markers
 


### PR DESCRIPTION
> **🚧 WIP — opening as a draft so the design conversation that produced this PR is captured in one place, and so the validation steps below get done before merging.**

## The conversation that led here

I asked `/mold` to shape this as a spec rather than implementing blind. mold ran a **Ground** pass against both the canonical `grill-with-docs` source on GitHub and mold's own reference files, then produced this gap table:

| `grill-with-docs` feature | mold today | Verdict |
|---|---|---|
| Codebase exploration over asking | Ground + cheez-search | ✅ already had it |
| Cross-reference stated behavior vs code, surface contradictions | "tracks contradictions" + Ground | ✅ already had it |
| Concrete-scenario stress-testing of boundaries | Grill (steelman/edge cases) | ◐ partial overlap |
| One-question-at-a-time, each with a recommended answer | Grill already mandates "recommendation is non-optional" | ✅ already had it |
| **`CONTEXT.md`** — domain glossary (ubiquitous language) | none | ✗ **net-new** |
| **`CONTEXT-MAP.md`** — bounded-context map | none | ✗ **net-new** |
| **ADRs** (`docs/adr/NNNN-slug.md`), offered sparingly via 3 criteria | decisions only in spec frontmatter | ✗ **net-new** |
| Challenge a term against the glossary | no glossary to challenge | ✗ depends on glossary |
| Sharpen fuzzy term → canonical name + aliases-to-avoid | sharpens in dialogue, doesn't persist | ◐ partial |
| **Update docs inline as decisions crystallize** | writes nothing before the approval gate | ⚠️ **philosophical conflict** |

### The central tension I surfaced

mold's cardinal rule is *"Dialogue first; do not write production files before the two-key handshake."* `grill-with-docs` does the **opposite** — it writes `CONTEXT.md` and ADRs eagerly, mid-session, ungated. "Full parity" can't honor both silently.

### Framing forks I proposed (and the defaults I took)

The user opted to skip the question round and have me swing. The defaults I applied:

1. **Write discipline → Gated + live tracking.** Glossary terms and ADR candidates accumulate as visible in-session state, flush to disk at the handshake. Preserves mold's cardinal rule; still captures grill's "don't reconstruct from memory" benefit.
2. **Feature scope → Net-new, deduped.** Fold in what mold lacks; don't restate behaviours mold already has.
3. **ADR ownership → Fold into mold** (the ask was "add to mold," not "build a new skill").
4. **Multi-context → Include, lazy.** Cheap `CONTEXT-MAP.md` detection; the ask was "full parity."

All four are flippable in review.

---

## What's implemented

| Feature | Where |
|---|---|
| **Glossary mode** (7th mode) — pin ubiquitous language, sharpen terms, challenge against `CONTEXT.md` | `references/modes.md`, `SKILL.md` |
| **`CONTEXT.md`** glossary format | new `references/context-format.md` |
| **`CONTEXT-MAP.md`** lazy multi-context routing | new `references/context-format.md` + `references/domain-docs.md` |
| **ADRs** via the 3-part sparingly test | new `references/adr-format.md` |
| **Grill** extended with concrete-scenario boundary stress-testing | `references/modes.md` |
| Integration spine — live-tracking + gated-flush discipline | new `references/domain-docs.md` |
| Handshake checklist rows for glossary terms and ADR candidates | `references/handshake.md` |
| Curdle artifact-table row + Domain docs flush section + atomic-write note | `references/curdle.md` |
| Attribution to Matt Pocock's `grill-with-docs` (MIT) | `SKILL.md` § Credits + each ported file |

What I deliberately **did not** add (per dedup): codebase cross-reference, contradiction tracking, one-question-with-recommendation Grill — mold already does these.

## Mechanical validation done

- `markdownlint-cli2 skills/mold/**/*.md` → 0 errors
- `mkdocs build --strict` → passes (every new cross-reference resolves cleanly)
- mattpocock/skills license verified MIT, attribution recorded per terms

---

## Next steps to validate before this leaves WIP

These are the things mechanical validation can't answer. Marked with what we're trying to find out.

### 1. Behavioural smoke test — drive `/mold` against a real fuzzy idea (does the Glossary mode pull its weight?)
Pick a small ambiguous feature request with at least one overloaded domain term ("account", "session", "order", whatever fits the test repo). Run `/mold` end-to-end. Observe:
- Does it route into Glossary or Ground when terms are fuzzy?
- Do `glossary_terms` actually accrue in the in-session ledger and surface to the user as they resolve?
- Does the handshake correctly block on unresolved glossary terms?
- Does the curdle flush write `CONTEXT.md` to the right path (root vs per-context)?

### 2. Trigger the ADR path
Force a decision that meets all three criteria (hard to reverse + surprising + real trade-off) — e.g. picking between two databases for a write model. Confirm:
- mold offers an ADR (not silently writes one).
- The candidate is logged in `adr_candidates`.
- ADR file is written under `docs/adr/NNNN-slug.md` with correct numbering at curdle.
- mold does **not** offer ADRs for easy-to-reverse / unsurprising / no-alternative decisions.

### 3. Multi-context detection
Create a throwaway repo with a stub `CONTEXT-MAP.md` pointing at two `src/<ctx>/CONTEXT.md` files. Confirm Glossary mode reads the map, asks which context a term belongs to when ambiguous, and writes to the right per-context file.

### 4. Re-litigate the four defaults (the design forks I closed without asking)
- **Inline vs gated writes** — is the gated-with-live-tracking integration the right call, or should some artifacts (glossary in particular) write inline like grill does?
- **Glossary as a full 7th mode** — does it earn its place, or should it fold into Ground? Folding is a small reverse if we change our minds.
- **ADRs in mold vs separate `/adr` skill** — does ADR offering belong here, or should mold detect ADR-worthy decisions and hand off?
- **Multi-context** — keep the `CONTEXT-MAP.md` support, or strip it as YAGNI?

### 5. Downstream awareness
mold now produces `CONTEXT.md`. Does `/cook` know to read it as authoritative project language? Same question for `/age` and `/cure`. May need a small follow-up to teach the implementer skills about the glossary.

### 6. Worked example in the docs (optional)
Consider adding a short worked-example file under `references/` showing a sample dialogue with glossary accrual → handshake → flush. Would lower the bar for users encountering the new mode for the first time.

### 7. Re-read for parity drift
After hands-on use, re-read `grill-with-docs` SKILL.md and confirm nothing meaningful slipped through the gap analysis. The dedup judgments were made from text alone — running both side-by-side may surface subtleties.

### 8. Decide handling of `glossary_terms` / `adr_candidates` in the state file
Right now the docs describe the YAML schema for these in `domain-docs.md` and `validate-cycle.md` mentions a "mold state file" — but the on-disk shape of that state file isn't fully specified anywhere I can find. If we're treating it as in-conversation state only (most consistent with mold's no-writes rule), the docs should say so explicitly. If we're treating it as a real transient file, we need to nail down the path and lifecycle.

---

## Attribution

Adapted from [`grill-with-docs`](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs) by Matt Pocock (MIT). Credit recorded in `SKILL.md` § Credits and in each ported reference file.
