### PR TITLE
feat(briesearch): tighten grounding across short-form and forked-agent paths

### DIFF
--- a/skills/briesearch/references/context-isolation.md
+++ b/skills/briesearch/references/context-isolation.md
@@ -40,8 +40,8 @@ Skip it for triage searches (snippets only, ≤10 results) and single-URL extrac
    └── <slug>.md                 # the human-readable report
    ```
 
-5. **Filter inside the sub-agent.** Score threshold, paragraph keyword match, regex on body — whatever the question demands. Build the claim-level rows from `synthesis.md`.
-6. **Return only the synthesis.** The sub-agent's reply to the parent contains: the short-form output (claim table + confidence + path), nothing else. Raw bodies stay on disk for re-extraction in later turns.
+5. **Filter inside the sub-agent.** Score threshold, paragraph keyword match, regex on body — whatever the question demands. Build the claim-level rows from `synthesis.md`. **Bind the Freshness column to `manifest.json`, not free text:** each row's Freshness is the `fetch_date` of the raw file the claim cites (or `"live"` for an unstored live check), so the column can't drift from what was actually fetched.
+6. **Return the synthesis with auditable pointers.** The sub-agent's reply to the parent contains: the short-form output (claim table + confidence + path), nothing else. **Every claim row's Evidence cell must cite an on-disk raw pointer** — `raw/NN-<host>.md#Lstart-end` — so the parent (or a later turn) can spot-check the claim→evidence binding without re-fetching. A row whose evidence is not traceable to a stored raw body does not ship. Raw bodies stay on disk for re-extraction in later turns.
 
 ## Re-extraction in later turns
 

--- a/skills/briesearch/references/routing.md
+++ b/skills/briesearch/references/routing.md
@@ -148,3 +148,5 @@ SOURCE PRIORITY: vendor docs > release notes > repo precedent
 ## Hard rule
 
 If a source was committed in routing, spawn it. If it returns "unavailable", report that — do not silently drop a routed source because it later seems low-value.
+
+Make this mechanical, not honor-system. After gather, diff the emitted `ROUTING DECISION` against what actually ran: for each source marked `YES`, confirm a call executed and produced evidence, an `unavailable` result, or an empty result. Any committed source with no corresponding execution is **committed-but-skipped** — mark it explicitly in the report (a `Searched, empty` line if it ran dry, an UNAVAILABLE note per `unavailable.md` if it failed, or a flagged gap if it was simply not run) and apply the matching confidence cap from `synthesis.md`. A `YES` in the routing block with nothing to show for it is a reconciliation failure, not a silent drop.

--- a/skills/briesearch/references/synthesis.md
+++ b/skills/briesearch/references/synthesis.md
@@ -39,7 +39,7 @@ Canonical failure to avoid: a Tavily snippet says "hybrid retrieval combines spa
 
 ## Link / citation verification
 
-**Short form (always returned) — minimum verification:** before returning any claim, confirm **every URL cited in `## References` resolves** (HTTP 200 or matched-host redirect). Mark unreachable footnote definitions `[unverified]` rather than dropping them — the user can re-check. This runs on the always-returned path; it is not deferred to deep reports.
+**Short form (always returned) — minimum verification:** before returning any claim, confirm **every URL cited in `## References` resolves** (HTTP 200 or matched-host redirect), except the inline-file and user-supplied URLs exempted below. Mark unreachable footnote definitions `[unverified]` rather than dropping them — the user can re-check. This runs on the always-returned path; it is not deferred to deep reports.
 
 Deep reports (anything with a `research/<slug>/<slug>.md` artifact in the durable corpus) add, on top of the above:
 
@@ -53,7 +53,7 @@ Skip verification only for: (a) inline file references (`file:line`), (b) the us
 | Situation | Overall confidence |
 | --- | --- |
 | Critical routed source unavailable and no equivalent fallback exists | `don't know` |
-| Non-critical routed source unavailable, failed, or skipped | cap at `speculating` |
+| Non-critical routed source unavailable, failed, skipped, or searched-but-empty | cap at `speculating` |
 | 3+ independent sources agree per claim | `certain` |
 | 2 independent sources agree per claim | `speculating` |
 | Sources disagree | `don't know` — and surface the disagreement |

--- a/skills/briesearch/references/synthesis.md
+++ b/skills/briesearch/references/synthesis.md
@@ -19,7 +19,7 @@ Rules:
 - **Each "latest" or "current" claim must include an absolute date** ("latest as of 2026-05-04"), not just "latest".
 - **Versioned claims must include the version** ("Next.js 15.3", not "Next.js latest").
 - **Conflicting evidence is its own row pair**, not silently averaged. Surface disagreement explicitly.
-- **Single-source claims cap at `speculating`** unless the source is authoritative for that claim type (vendor docs for an API; the codebase for a local convention) — only authoritative single sources earn `certain`.
+- **Single-source claims cap at `speculating`** unless the source is authoritative for that claim type (vendor docs for an API; the codebase for a local convention) — only authoritative single sources earn `certain`. A lone Context7 chunk is authoritative *only when its version matches the version in the question*; on a version mismatch (or when the question pins a version the chunk does not state), cap at `speculating` — Context7 IDs can be version-stale (see `routing.md` § Cache library IDs).
 
 The tokens `certain`, `speculating`, and `don't know` are exact label values — write them verbatim, never as synonyms.
 
@@ -39,11 +39,12 @@ Canonical failure to avoid: a Tavily snippet says "hybrid retrieval combines spa
 
 ## Link / citation verification
 
-For deep reports (anything with a `research/<slug>/<slug>.md` artifact in the durable corpus):
+**Short form (always returned) — minimum verification:** before returning any claim, confirm **every URL cited in `## References` resolves** (HTTP 200 or matched-host redirect). Mark unreachable footnote definitions `[unverified]` rather than dropping them — the user can re-check. This runs on the always-returned path; it is not deferred to deep reports.
 
-1. Every URL in `## References` resolves (HTTP 200 or matched-host redirect). Mark unreachable footnote definitions `[unverified]` rather than dropping them — the user can re-check.
-2. Every quoted or paraphrased line traces back to its source (one-click verifiable for the user).
-3. Every "as of <date>" claim has a verified fetch date in the same row.
+Deep reports (anything with a `research/<slug>/<slug>.md` artifact in the durable corpus) add, on top of the above:
+
+1. Quote tracing: every quoted or paraphrased line traces back to its source (one-click verifiable for the user).
+2. Every "as of <date>" claim has a verified fetch date in the same row.
 
 Skip verification only for: (a) inline file references (`file:line`), (b) the user's own supplied URLs.
 
@@ -56,9 +57,9 @@ Skip verification only for: (a) inline file references (`file:line`), (b) the us
 | 3+ independent sources agree per claim | `certain` |
 | 2 independent sources agree per claim | `speculating` |
 | Sources disagree | `don't know` — and surface the disagreement |
-| Single source per claim | inherit that source's authority, cap at `speculating` unless authoritative |
+| Single source per claim | inherit that source's authority, cap at `speculating` unless authoritative (see lone-Context7 caveat above) |
 
-Criticality depends on the question. Context7 is critical for version-specific API claims, Tavily is critical for freshness-sensitive facts, Codebase is critical for local precedent questions, and GitHub is usually supporting evidence unless the user asked for real-world examples.
+**"Independent" means distinct origin, not distinct URL.** Before counting sources toward the cap, dedup by origin: collapse to one source any that share a root domain, or that quote/paraphrase the same upstream (three blogs reprinting one vendor post are one source, not three). Count only the surviving distinct origins. Criticality depends on the question. Context7 is critical for version-specific API claims, Tavily is critical for freshness-sensitive facts, Codebase is critical for local precedent questions, and GitHub is usually supporting evidence unless the user asked for real-world examples.
 
 ## Output shape
 
@@ -83,6 +84,9 @@ Short form (always returned to the caller):
 
 ### Next step
 <recommended skill or action — limited to which skill should run next (`/mold`, `/cook`, etc.), never which design knob to expose.>
+
+### Searched, empty
+<one line per routed source that ran and returned nothing usable, naming the query/filters that came up dry (e.g. "Tavily `basic`, time_range=month, \"<query>\" → 0 results above score 0.5"). This is the provenance for any `don't know` or lowered cap — proof the search ran. Omit the section only when no routed source came back empty.>
 
 ## References
 [^source-1]: <absolute URL or `.cheese/...` path> (fetched <YYYY-MM-DD>).


### PR DESCRIPTION
Closes #102

Addresses all 7 grounding findings. Edits land in `skills/briesearch/references/{synthesis,context-isolation,routing}.md`.

1. **Link verification no longer gated to deep reports** — "every cited URL resolves" is now the short-form (always-returned) minimum; quote-tracing + fetch-date verification layer on top for deep reports.
2. **Cap counts independence, not quantity** — dedup by root domain / shared upstream before counting toward the cap.
3. **Lone Context7 chunk** — `certain` only when its version matches the question; otherwise capped at `speculating`.
4. **Forked sub-agent grounding auditable** — every sub-agent claim row must cite an on-disk raw pointer (`raw/NN-host.md#Lstart-end`).
5. **Freshness derived, not self-reported** — Freshness column bound to `manifest.json` `fetch_date`.
6. **Negative results grounded** — new `### Searched, empty` provenance section in the short-form output shape.
7. **Routing block mechanical** — post-gather routed-vs-executed reconciliation marks committed-but-skipped sources explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)