### PR TITLE
feat: scaffold durable-memory boundary (.hallouminate/ wiki + policy)

### DIFF
--- a/.hallouminate/config.toml
+++ b/.hallouminate/config.toml
@@ -1,0 +1,14 @@
+# Repo-layer hallouminate config.
+#
+# Declares this repo as a hallouminate tenant so the wiki under
+# .hallouminate/wiki/ is searchable as the `repo:easy-cheese:wiki` corpus.
+# `path = "."` resolves against the repo root (the parent of .hallouminate/),
+# so this works from any checkout or worktree without per-machine config —
+# the daemon reads the repo layer fresh on every request (no restart needed).
+#
+# Do NOT also declare `[[repository]] name = "easy-cheese"` in the XDG
+# baseline: both layers would derive `repo:easy-cheese:wiki` and collide on
+# the duplicate-name check.
+[[repository]]
+name = "easy-cheese"
+path = "."

--- a/.hallouminate/wiki/architecture.md
+++ b/.hallouminate/wiki/architecture.md
@@ -81,10 +81,13 @@ trade by refusing to run without it (`skills/cheez-search/SKILL.md:3-5`).
 
 ## Why a wiki at all
 
-Transient task output lives in `.cheese/` (gitignored). Durable
-architecture/convention/rationale knowledge needs a git-tracked home
-that survives the task that produced it — that is this wiki. The split
-is enforced as a git-tracking boundary; see
-[wiki-conventions](./wiki-conventions.md) for the classification rule and
+Durable architecture/convention/rationale knowledge needs a home that
+survives the task that produced it and is worth committing into the tree
+— that is this wiki. It is one of three memory lanes: specs and research
+reports are durable too but anchor at the out-of-git XDG project corpus,
+and transient per-task output stays gitignored under `.cheese/`.
+Durability is not the same axis as git-tracking
+(`shared/formatting.md:103`); see [wiki-conventions](./wiki-conventions.md)
+for the classification rule and
 [workflow-invariants](./workflow-invariants.md) for where it sits among
 the other pipeline invariants.

--- a/.hallouminate/wiki/architecture.md
+++ b/.hallouminate/wiki/architecture.md
@@ -1,0 +1,90 @@
+# Architecture of easy-cheese
+
+easy-cheese is a **skills-only collection**: there is no application
+binary, no long-running service, no library to import. Every change adds,
+edits, or supports a skill under `skills/<name>/`, following the
+[Agent Skills spec](https://agentskills.io/specification). The product
+*is* the set of markdown-plus-scripts skills a coding agent loads at
+runtime (`AGENTS.md:25`).
+
+## The unit: a skill
+
+A skill is a directory whose shape encodes progressive disclosure
+(`README.md:42-53`):
+
+```text
+skills/<skill-name>/
+├── SKILL.md          # required: YAML frontmatter (name + description) + body
+├── references/       # optional: detail pulled in on demand
+├── scripts/          # optional: executable helpers (often a .pyz bundle)
+└── assets/           # optional: templates / static resources
+```
+
+`SKILL.md` is the always-loaded surface. Its frontmatter `description`
+is what the host matches against a user request to decide whether to
+invoke the skill, so it carries trigger phrases. The body is the
+operating procedure; anything heavy is pushed into `references/` and
+pulled in only when the flow reaches it. Example: `/mold` keeps its
+two-key handshake checklist in `references/handshake.md` and links it
+from the body rather than inlining it (`skills/mold/SKILL.md:21`).
+
+## Progressive disclosure
+
+The pattern is deliberate context economy: the agent reads `SKILL.md`
+first, then descends into `references/<topic>.md` only for the step it
+is on. Cross-cutting material that many skills share lives at the
+top-level `shared/` directory (`shared/handoff-gate.md`,
+`shared/formatting.md`) and is referenced by relative path
+`../../shared/<file>.md` (`README.md:53`).
+
+Skills that depend on `shared/scripts/` ship a pre-bundled `.pyz` so the
+shared helpers are self-contained at install time — invoked as
+`python3 ${CLAUDE_SKILL_DIR}/scripts/<skill>.pyz <subcommand>`
+(`skills/mold/SKILL.md:22`). Bundles exist for affinage, briesearch,
+cheese-factory, cook, melt, and mold; `build-pyz.yml` rebuilds them on
+every relevant push to `main`.
+
+## The cheese pipeline
+
+The workflow skills compose into one pipeline, ordered
+**culture → mold → cook → press → age → cure → ship**
+(`skills/mold/SKILL.md:125`, `skills/cook/SKILL.md:90`):
+
+| Skill | Role in the pipeline |
+|---|---|
+| `/cheese` | Front door — classifies input, routes to the right skill |
+| `/culture` | No-write thinking / exploration |
+| `/mold` | Converge a fuzzy idea into an approved spec |
+| `/cook` | TDD-disciplined implementation of a spec |
+| `/press` | Adversarial test hardening |
+| `/age` | Ten-dimension review → severity-grouped findings |
+| `/cure` | Apply selected findings as focused fixes |
+| `/cheese-factory` | Fan an approved spec into parallel curds → PRs |
+
+Lower-level **tool skills** sit beneath the pipeline: `/cheez-search`,
+`/cheez-read`, `/cheez-write` (tilth-backed primitives), plus the
+`/ultracook` composite that chains cook → press → age → cure
+non-interactively (`AGENTS.md:42-49`).
+
+## Portability is the design center
+
+No repo-wide MCP requirement. Workflow skills *suggest* tools (tilth,
+Context7, Tavily, code-review-graph) but carry host-native fallbacks, so
+the collection runs on any compliant agent host (`README.md:161`).
+
+The one deliberate exception is the `cheez-*` tool skills: they require
+tilth MCP and **hard-fail** when it is unavailable rather than silently
+degrade to `grep`/`cat`/`Edit` (`AGENTS.md:73`, `README.md:87`). That
+asymmetry is intentional — the workflow skills stay universal; the tool
+skills trade portability for AST-grounded precision and announce the
+trade by refusing to run without it (`skills/cheez-search/SKILL.md:3-5`).
+
+## Why a wiki at all
+
+Transient task output lives in `.cheese/` (gitignored). Durable
+architecture/convention/rationale knowledge needs a git-tracked home
+that survives the task that produced it — that is this wiki. The split
+is enforced as a git-tracking boundary; see
+[wiki-conventions](./wiki-conventions.md) for the classification rule and
+[workflow-invariants](./workflow-invariants.md) for where it sits among
+the other pipeline invariants.

--- a/.hallouminate/wiki/index.md
+++ b/.hallouminate/wiki/index.md
@@ -1,11 +1,14 @@
 # easy-cheese wiki — index
 
-This wiki is the durable memory lane for the `easy-cheese` repo. It lives
-at `.hallouminate/wiki/`, is **git-tracked**, and is indexed as the
-`repo:easy-cheese:wiki` corpus — distinct from the per-task scratch under
-`.cheese/` (corpus `cheese-local`, gitignored). Write here when a fact is
-worth remembering across sessions: architecture, protocols, conventions,
-and "why this design not that one" rationale.
+This wiki is the **git-tracked** durable memory lane for the
+`easy-cheese` repo. It lives at `.hallouminate/wiki/` and is indexed as
+the `repo:easy-cheese:wiki` corpus. Write here when a fact is worth
+remembering across sessions: architecture, protocols, conventions, and
+"why this design not that one" rationale. Two sibling lanes hold the
+rest: durable specs and research reports live out of git at the XDG
+project corpus (`$XDG_DATA_HOME/cheese/<project>/`), and transient
+per-task scratch stays gitignored under `.cheese/`. Durability is not the
+git-tracking axis (`shared/formatting.md:103`).
 
 ## Topics
 

--- a/.hallouminate/wiki/index.md
+++ b/.hallouminate/wiki/index.md
@@ -1,0 +1,30 @@
+# easy-cheese wiki — index
+
+This wiki is the durable memory lane for the `easy-cheese` repo. It lives
+at `.hallouminate/wiki/`, is **git-tracked**, and is indexed as the
+`repo:easy-cheese:wiki` corpus — distinct from the per-task scratch under
+`.cheese/` (corpus `cheese-local`, gitignored). Write here when a fact is
+worth remembering across sessions: architecture, protocols, conventions,
+and "why this design not that one" rationale.
+
+## Topics
+
+<!-- HALLOUMINATE:INDEX-START -->
+- [architecture](./architecture.md) — skills-only collection, progressive disclosure, the cheese pipeline, portability design center.
+- [tooling](./tooling.md) — `just check`/`just ci`, validators, tilth/`cheez-*` hard-fail, `.pyz` bundles, CI workflows.
+- [wiki-conventions](./wiki-conventions.md) — how to author entries here, plus the durable-vs-transient boundary table.
+- [workflow-invariants](./workflow-invariants.md) — pipeline ordering, two-key handshake, handoff gates, `just check` single gate.
+<!-- HALLOUMINATE:INDEX-END -->
+
+## How to use this index
+
+`index.md` is a table of contents, not a topic. New pages join the list
+above with a one-line gloss; anything substantive belongs in its own
+topic file. The daemon rewrites the link list between the
+`HALLOUMINATE:INDEX` markers after every `add_markdown` — curated prose
+outside the markers is preserved.
+
+If the index looks stale, run `list_files` against the
+`repo:easy-cheese:wiki` corpus — the directory is the source of truth.
+Start with [wiki-conventions](./wiki-conventions.md) before writing your
+first entry.

--- a/.hallouminate/wiki/tooling.md
+++ b/.hallouminate/wiki/tooling.md
@@ -1,0 +1,98 @@
+# Tooling
+
+The build, validation, and tool-dependency surface for easy-cheese. The
+guiding rule: one local gate (`just check`), mirrored read-only in CI
+(`just ci`).
+
+## `just check` vs `just ci`
+
+`just check` is the local pre-flight; `just ci` is the same gate without
+autofixes (`justfile:51-54`). Run `just check` before any commit, push,
+PR, or hand-off (`AGENTS.md:7`).
+
+| | `just check` | `just ci` |
+|---|---|---|
+| markdown | `lint-md-fix` (autofix) | `lint-md` (check only) |
+| yaml | `lint-yaml-fix` + `lint-yaml` | `lint-yaml` |
+| python | `lint-py-fix` (`uvx ruff --fix`) | — |
+| shell | `lint-sh` (`shellcheck scripts/install.sh`) | `lint-sh` |
+| tests | `test` | `test` |
+| docs | `docs-build` (`mkdocs build --strict`) | `docs-build` |
+
+The `test` recipe runs the validator self-test, `validate_skills.py`,
+the pytest suites (`tests/python`, `tests/shared/python`,
+`tests/cheese-factory/python`), and the bats suites
+(`tests/bash/test_install.bats`, the cheese-factory bats)
+(`justfile:8-16`).
+
+Note the markdownlint globs are `skills/**/*.md` and `*.md`
+(`justfile:31-35`) — files outside those globs (for example this wiki
+under `.hallouminate/wiki/`) are not linted by the gate, so keep their
+markdown clean by hand.
+
+## Validators
+
+`.github/scripts/validate_skills.py` enforces the skill contract on every
+`skills/<name>/SKILL.md` (`.github/scripts/validate_skills.py`):
+
+- Path must be exactly `skills/<name>/SKILL.md` — nested sub-skills
+  rejected (line 43).
+- YAML frontmatter present, parseable, and a mapping (lines 53-62).
+- `name` required, kebab-case
+  (`^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$`), and equal to the parent
+  directory name (lines 69-82).
+- `description` required, non-empty, ≤ 1024 chars — the Codex limit
+  (lines 84-92).
+- No keys outside the allow-list (`name`, `description`, `license`,
+  `compatibility`, `metadata`, `allowed-tools`, `version`,
+  `argument-hint`, `disable-model-invocation`, `user-invocable`, `model`,
+  `context`, `agent`, `hooks`) (lines 18-33, 94-96).
+
+`test_validate_skills.py` is the unittest suite covering those rules.
+
+## tilth / cheez-* hard-fail vs optional MCP
+
+Tool dependency is asymmetric by design:
+
+- **`cheez-*` skills require tilth MCP and hard-fail without it.** They
+  refuse to fall back to `grep`/`cat`/`Edit`
+  (`skills/cheez-search/SKILL.md:3-5`, `AGENTS.md:73`).
+- **Every other skill stays portable** and degrades to host-native tools.
+  Workflow skills only *suggest* tilth, Context7, Tavily, and
+  code-review-graph; there is no repo-wide MCP requirement
+  (`README.md:87,161`).
+
+The trade is intentional: the tool skills buy AST-grounded precision and
+announce the cost by refusing to run without it; the workflow skills stay
+universal.
+
+## `.pyz` bundles
+
+Skills that consume `shared/scripts/` ship a pre-built `.pyz` so the
+shared helpers are self-contained at install time, invoked as
+`python3 ${CLAUDE_SKILL_DIR}/scripts/<skill>.pyz <subcommand>`
+(`skills/mold/SKILL.md:22`). Bundles exist for affinage, briesearch,
+cheese-factory, cook, melt, and mold. `just bundle` rebuilds them locally
+(`scripts/build_pyz.py`); `build-pyz.yml` rebuilds and commits them on
+every relevant push to `main` (`justfile:18-19`).
+
+## CI workflows
+
+Under `.github/workflows/`:
+
+| Workflow | Trigger | Does |
+|---|---|---|
+| `validate.yml` | push main, all PRs | frontmatter validation, pytest, install.sh bats + smoke, lint |
+| `build-pyz.yml` | push main (`src/**`, `shared/scripts/**`, build script) | rebuild + commit `.pyz` bundles |
+| `release.yml` | tag `v[0-9]*` | stage slim tree, force-push `release` branch, GitHub release |
+| `docs.yml` | push/PR on docs paths, dispatch | `mkdocs build --strict`, deploy Pages on main |
+| `codeql.yml` | PRs, push main, weekly | CodeQL on python + actions |
+| `dependency-review.yml` | PRs to main | block vulnerable / disallowed-license deps |
+| `scorecard.yml` | push main, weekly | OpenSSF Scorecard → SARIF |
+| `copilot-review.yml` | PR opened/reopened/ready | add Copilot as reviewer |
+
+### Prerequisites
+
+`just`, `uv` (for `uvx ruff`), plus `yamllint`, `yamlfmt`,
+`markdownlint-cli2`, `shellcheck`, and `bats` — see `README.md` for
+install hints (`AGENTS.md:18-21`).

--- a/.hallouminate/wiki/tooling.md
+++ b/.hallouminate/wiki/tooling.md
@@ -14,7 +14,7 @@ PR, or hand-off (`AGENTS.md:7`).
 |---|---|---|
 | markdown | `lint-md-fix` (autofix) | `lint-md` (check only) |
 | yaml | `lint-yaml-fix` + `lint-yaml` | `lint-yaml` |
-| python | `lint-py-fix` (`uvx ruff --fix`) | — |
+| python | `lint-py-fix` (`uvx ruff check --fix .`) | — |
 | shell | `lint-sh` (`shellcheck scripts/install.sh`) | `lint-sh` |
 | tests | `test` | `test` |
 | docs | `docs-build` (`mkdocs build --strict`) | `docs-build` |

--- a/.hallouminate/wiki/wiki-conventions.md
+++ b/.hallouminate/wiki/wiki-conventions.md
@@ -1,0 +1,120 @@
+# Wiki conventions for easy-cheese
+
+You — the agent writing entries in this wiki — are bound by a few
+conventions the hallouminate indexer counts on, plus the durable-vs-
+transient boundary that decides whether a fact belongs here at all.
+
+This page is silent on per-entry lifecycle and frontmatter schema. That
+contract is owned by a separate seam; do not invent frontmatter fields
+here.
+
+## Durable vs transient — the boundary that decides everything
+
+Before writing anything, decide which lane the fact belongs in. This is
+the single most important rule in this repo's memory model.
+
+| Where | Indexed as | Git | Lifecycle | Use for |
+|---|---|---|---|---|
+| `.hallouminate/wiki/` | `repo:easy-cheese:wiki` | **tracked** | durable across sessions | architecture, protocols, conventions, "why this design not that one" |
+| `.cheese/` | `cheese-local` | **gitignored** | transient per-task | `/cook` `/age` `/press` `/cure` output, specs, handoffs, exploration |
+
+**The durable/transient split is the git-tracking split.** If a fact is
+worth committing for the next agent who lands here cold, it is durable —
+write it to the wiki. If it only makes sense inside one task, it is
+transient — leave it in `.cheese/` (which `.gitignore` keeps out of the
+tree, see `.gitignore:2`).
+
+Rule of thumb: *would a future agent benefit from this note with zero
+context about the task that produced it?* Yes → wiki. No → `.cheese/`.
+
+Concrete classification examples:
+
+- "The pipeline order is culture → mold → cook → press → age → cure" → **durable**.
+- "Curd #3 of the durable-memory spec failed its press pass" → **transient**.
+- "cheez-* skills hard-fail without tilth MCP; everything else degrades" → **durable**.
+- "The age report for PR #107 flagged two medium findings" → **transient**.
+
+## One topic per file
+
+A wiki entry is a slice of knowledge with a clear scope. If you find
+yourself drafting two unrelated topics in one file, split them. The
+chunker breaks markdown by H1/H2/H3 headings — a file with two H1
+sections will still chunk, but `ground` will rank both sections together,
+which is almost never what you want.
+
+## First non-blank line is the H1
+
+The first non-blank line of every entry must be `# Topic Name`. The
+chunker uses the H1 as the breadcrumb root for every chunk in the file,
+and the auto-index reads it as the trailing gloss on the file's link
+row. Skip the H1 and breadcrumbs degrade and the index row is ungloss'd.
+
+## File stem matches the slug
+
+Topic "Workflow invariants" → file `workflow-invariants.md`. Lowercase,
+kebab-case, no spaces, no capitals, `.md` only. The stem is what other
+pages link to and what shows up in `ground` outline paths.
+
+## Idempotent writes
+
+`add_markdown` rejects existing files by default. To update:
+
+1. `read_markdown` to inspect current content.
+2. Decide what changes.
+3. `add_markdown` with `overwrite: true`.
+
+This forces a look at current state before clobbering, so concurrent
+authors don't silently lose each other's edits.
+
+## Tree layout & progressive disclosure
+
+Top-level files hold foundational topics (`architecture.md`,
+`workflow-invariants.md`, `tooling.md`, `wiki-conventions.md`). Group
+related entries under subdirectories as the wiki grows
+(`add_markdown` accepts nested paths and creates parents on demand).
+
+Every directory carries an `index.md`: the first H1 names the subtopic,
+the body holds curated prose plus a link list to siblings and children.
+The daemon scaffolds and maintains the link list between
+`<!-- HALLOUMINATE:INDEX-START -->` / `<!-- HALLOUMINATE:INDEX-END -->`
+markers — prose outside the markers is preserved verbatim. Remove the
+marker pair to opt a file out of auto-indexing.
+
+### Link convention
+
+- `[stem](./stem.md)` for files in the same directory.
+- `[subdir/](./subdir/index.md)` for child directories.
+- Relative paths only — the wiki should survive moving the whole tree.
+
+## When to update — the post-land cadence
+
+`AGENTS.md` instructs every agent to refresh this wiki **after a change
+lands on `main`**, but only when the change altered durable knowledge:
+architecture, protocols, conventions, or a "why this design not that one"
+decision. Routine bug fixes and per-task output stay in `.cheese/`.
+
+Do the update through the hallouminate MCP (`read_markdown` →
+`add_markdown { overwrite: true }`), not raw file edits, so the LanceDB
+index and ancestor `index.md` link lists stay in sync.
+
+## The authoring loop
+
+```text
+1. list_tree                            (see the existing shape)
+2. ground "<topic adjacent search>"     (find related entries)
+3. read_markdown index.md               (confirm naming + style)
+4. draft the page (H1 first line, kebab slug, link siblings)
+5. add_markdown { corpus: "repo:easy-cheese:wiki",
+                  path: "<slug>.md", content: "<markdown>",
+                  overwrite: false }
+6. (the daemon rewrites ancestor index.md link lists for you)
+```
+
+## Style
+
+- Lead with the conclusion. Don't bury the point under preamble.
+- Cite files and line ranges by path: `skills/mold/references/handshake.md:1-3`.
+- Cite commits by SHA when behavior depends on history.
+- Prefer concrete examples to abstract description.
+- Keep entries short — ~50–150 lines is the right band. A wiki page is
+  not a tutorial.

--- a/.hallouminate/wiki/wiki-conventions.md
+++ b/.hallouminate/wiki/wiki-conventions.md
@@ -10,29 +10,46 @@ here.
 
 ## Durable vs transient — the boundary that decides everything
 
-Before writing anything, decide which lane the fact belongs in. This is
-the single most important rule in this repo's memory model.
+Before writing anything, decide which lane the fact belongs in — and
+note that **durability is not the same axis as git-tracking**. There are
+three lanes, two of which live outside git (`shared/formatting.md:103`):
 
-| Where | Indexed as | Git | Lifecycle | Use for |
-|---|---|---|---|---|
-| `.hallouminate/wiki/` | `repo:easy-cheese:wiki` | **tracked** | durable across sessions | architecture, protocols, conventions, "why this design not that one" |
-| `.cheese/` | `cheese-local` | **gitignored** | transient per-task | `/cook` `/age` `/press` `/cure` output, specs, handoffs, exploration |
+| Where | Git | Lifecycle | Use for |
+|---|---|---|---|
+| `.hallouminate/wiki/` (`repo:easy-cheese:wiki`) | **tracked** | durable across sessions | architecture, protocols, conventions, "why this design not that one" |
+| `$XDG_DATA_HOME/cheese/<project>/` (`paths.py`) | **out of git** | durable across branches/clones | specs, research reports |
+| `.cheese/` (`cheese-local`) | **gitignored** | transient per-task | `/cook` `/age` `/press` `/cure` reports, notes, hard, handoffs, exploration |
 
-**The durable/transient split is the git-tracking split.** If a fact is
-worth committing for the next agent who lands here cold, it is durable —
-write it to the wiki. If it only makes sense inside one task, it is
-transient — leave it in `.cheese/` (which `.gitignore` keeps out of the
-tree, see `.gitignore:2`).
+**Durable ≠ git-tracked.** Architecture/convention/rationale notes are
+durable *and* committed into the tree — they go in this wiki. Specs and
+research reports are just as durable but anchor at a stable XDG path
+(`$XDG_DATA_HOME/cheese/<project>/`, default
+`~/.local/share/cheese/<project>/`) so they survive branch switches and
+clones while staying out of git; the path math is owned by
+`shared/scripts/paths.py` (`project_corpus_root`, `artifact_path`). Only
+per-task pipeline output is *transient*, and it stays repo-local under
+`.cheese/` so it travels with the branch and shows up in the PR
+(`.gitignore:2`).
 
-Rule of thumb: *would a future agent benefit from this note with zero
-context about the task that produced it?* Yes → wiki. No → `.cheese/`.
+> **Migration note.** Some skill docs still name `.cheese/specs/<slug>.md`.
+> That path predates the durable/transient split and is being moved onto
+> the `paths.py` helpers (`shared/formatting.md:103`); treat the XDG
+> corpus as the home for specs.
+
+Classify in two steps:
+
+1. *Worth keeping past the task that produced it?* No → transient,
+   `.cheese/`.
+2. If durable: *architecture / protocol / convention / rationale* → this
+   wiki; *spec or research report* → the XDG project corpus.
 
 Concrete classification examples:
 
-- "The pipeline order is culture → mold → cook → press → age → cure" → **durable**.
-- "Curd #3 of the durable-memory spec failed its press pass" → **transient**.
-- "cheez-* skills hard-fail without tilth MCP; everything else degrades" → **durable**.
-- "The age report for PR #107 flagged two medium findings" → **transient**.
+- "The pipeline order is culture → mold → cook → press → age → cure" → **durable → wiki**.
+- "The approved spec for the durable-memory boundary" → **durable → XDG corpus**.
+- "Curd #3 of the durable-memory spec failed its press pass" → **transient → `.cheese/`**.
+- "cheez-* skills hard-fail without tilth MCP; everything else degrades" → **durable → wiki**.
+- "The age report for PR #107 flagged two medium findings" → **transient → `.cheese/`**.
 
 ## One topic per file
 

--- a/.hallouminate/wiki/workflow-invariants.md
+++ b/.hallouminate/wiki/workflow-invariants.md
@@ -66,7 +66,7 @@ after the user chooses (`shared/handoff-gate.md:7`).
 `--auto` propagates through the chain to skip these gates for autonomous
 runs. `/ultracook` runs the chain
 `cook → press → age → cure → age → cure → age` (all `--auto`), capped at
-**two cure passes** (`skills/cook/SKILL.md:132`, `README.md:72`).
+**two cure passes** (`skills/cook/SKILL.md:132`).
 
 ## `just check` is the single quality gate
 

--- a/.hallouminate/wiki/workflow-invariants.md
+++ b/.hallouminate/wiki/workflow-invariants.md
@@ -1,0 +1,89 @@
+# Workflow invariants
+
+These are the rules the cheese pipeline holds constant across every task.
+Break one and the pipeline's guarantees stop holding, so treat them as
+contracts, not conventions.
+
+## Pipeline ordering
+
+The canonical order is fixed
+(`skills/mold/SKILL.md:125`, `skills/cook/SKILL.md:90`):
+
+```text
+culture → mold → cook → press → age → cure → ship
+```
+
+- **culture** — no-write thinking; never edits code, never the gate.
+- **mold** — converges a fuzzy idea into an approved spec under
+  `.cheese/specs/<slug>.md` (or the durable resolver path).
+- **cook** — TDD-disciplined implementation of that spec.
+- **press** — adversarial test hardening of the cooked diff.
+- **age** — ten-dimension review producing a findings report.
+- **cure** — applies the selected findings as focused fixes.
+- **ship** — push / open PR once `just check` is green.
+
+Skipping forward is allowed (e.g. cook → age, skipping press) but the
+relative order never inverts: you do not cure before age, or press before
+cook. Each phase hands off through a gate (below), and writes a handoff
+slug the next phase reads.
+
+## The two-key handshake (mold's curdle gate)
+
+`/mold` will not extract a spec until **both keys** turn
+(`skills/mold/references/handshake.md:1-3`):
+
+1. **User key** — the user says an explicit extraction verb: `curdle`,
+   `ship it`, `extract`, `that's enough`. A vague "ok let's go" does not
+   count (`handshake.md:5-9`).
+2. **Agent key** — the agent prints a 10-item coherence self-check
+   (problem grounded, ≥2 options weighed including Do Nothing, interface
+   sketches with pseudocode signatures, Validate Cycles judged, Grill run
+   for high-blast-radius work, open questions marked, quality gates
+   specified) and every box must be checked, or the user issues an
+   explicit `curdle anyway` override (`handshake.md:11-27`).
+
+Mandatory gates fire even before the keys: Ground (≥1 citation), Shape
+(≥1 option block), Sketch (when >1 module is touched), Grill (when blast
+radius is `high`), and the agent-introduced-scope gate — every
+distinguishing noun in the spec must trace to a user mention or get
+explicit per-term approval (`handshake.md:31-64`).
+
+The handshake is **bypassed** in mold's agent-invoked mini-spec mode,
+i.e. when `/cheese` calls `/mold` internally to materialise a spec for an
+already-clear task (`skills/mold/SKILL.md:12,46`).
+
+## Handoff gates between phases
+
+Phases never dispatch the next phase silently. Each ends at a handoff
+gate defined by `shared/handoff-gate.md`: a `handoff_gate:` block naming
+the `source_skill`, a `recommended` option, and an `options` list, each
+option carrying a `label` plus a `dispatch` / `continue` / `dispatch:
+none` action (`shared/handoff-gate.md:18-40`). Context for the next phase
+rides alongside as `handoff_context:` (`shared/handoff-gate.md:69-85`).
+A gate prevents silent dispatch; it does **not** mean the agent halts
+after the user chooses (`shared/handoff-gate.md:7`).
+
+`--auto` propagates through the chain to skip these gates for autonomous
+runs. `/ultracook` runs the chain
+`cook → press → age → cure → age → cure → age` (all `--auto`), capped at
+**two cure passes** (`skills/cook/SKILL.md:132`, `README.md:72`).
+
+## `just check` is the single quality gate
+
+There is exactly one shippability signal: green from `just check`
+(`AGENTS.md:7`). It autofixes lint (markdown, yaml, python via ruff) then
+runs skill-frontmatter validation, shell lint, the python + bash test
+suites, and `mkdocs build --strict`. CI runs `just ci` — the same gates,
+no autofixes. **Never commit or push on a red `just check`**, and never
+weaken or skip a test to force green. See [tooling](./tooling.md) for the
+recipe breakdown.
+
+## The durable/transient boundary
+
+Durable knowledge (architecture, protocols, conventions, rationale) is
+git-tracked under `.hallouminate/wiki/`. Transient task output (specs,
+`/cook` `/age` `/press` `/cure` reports, handoffs) is gitignored under
+`.cheese/` (`.gitignore:2`). The split is the git-tracking split — see
+[wiki-conventions](./wiki-conventions.md) for the classification rule.
+This invariant exists so later integration seams cannot dump transient
+noise into durable memory.

--- a/.hallouminate/wiki/workflow-invariants.md
+++ b/.hallouminate/wiki/workflow-invariants.md
@@ -14,8 +14,9 @@ culture → mold → cook → press → age → cure → ship
 ```
 
 - **culture** — no-write thinking; never edits code, never the gate.
-- **mold** — converges a fuzzy idea into an approved spec under
-  `.cheese/specs/<slug>.md` (or the durable resolver path).
+- **mold** — converges a fuzzy idea into an approved spec at the durable
+  XDG corpus path (`$XDG_DATA_HOME/cheese/<project>/specs/<slug>.md`,
+  resolved by `shared/scripts/paths.py`; `shared/formatting.md:103`).
 - **cook** — TDD-disciplined implementation of that spec.
 - **press** — adversarial test hardening of the cooked diff.
 - **age** — ten-dimension review producing a findings report.
@@ -80,10 +81,14 @@ recipe breakdown.
 
 ## The durable/transient boundary
 
-Durable knowledge (architecture, protocols, conventions, rationale) is
-git-tracked under `.hallouminate/wiki/`. Transient task output (specs,
-`/cook` `/age` `/press` `/cure` reports, handoffs) is gitignored under
-`.cheese/` (`.gitignore:2`). The split is the git-tracking split — see
-[wiki-conventions](./wiki-conventions.md) for the classification rule.
-This invariant exists so later integration seams cannot dump transient
-noise into durable memory.
+Durable knowledge splits two ways. Architecture, protocols, conventions,
+and rationale are git-tracked under `.hallouminate/wiki/`; specs and
+research reports are durable too but live out of git at the XDG project
+corpus (`$XDG_DATA_HOME/cheese/<project>/`, owned by
+`shared/scripts/paths.py`). Only per-task pipeline output (`/cook` `/age`
+`/press` `/cure` reports, notes, hard, handoffs) is transient, gitignored
+under `.cheese/` (`.gitignore:2`). Durability is not the git-tracking
+axis (`shared/formatting.md:103`) — see
+[wiki-conventions](./wiki-conventions.md) for the full classification
+rule. This invariant exists so later integration seams cannot dump
+transient noise into durable memory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,22 @@ This is a skills-only collection following the [Agent Skills spec](https://agent
 
 See `README.md` for the full workflow and the suggested skill ordering.
 
+## Durable memory
+
+This repo keeps a durable-knowledge wiki at `.hallouminate/wiki/`
+(git-tracked, corpus `repo:easy-cheese:wiki`), separate from the
+transient per-task scratch under `.cheese/` (gitignored). **Recommended
+default:** after a change lands on `main` that altered durable
+knowledge — architecture, protocols, conventions, or a "why this design
+not that one" decision — query the wiki and update it. Routine fixes and
+per-task output stay in `.cheese/`.
+
+This is a recommended default, not a hard gate: updating the wiki
+requires the [hallouminate](https://github.com/paulnsorensen/hallouminate)
+MCP server. When it is unavailable, skip the update — do not hand-edit
+the LanceDB-indexed tree. See `.hallouminate/wiki/wiki-conventions.md`
+for the durable-vs-transient boundary and the authoring loop.
+
 ## Development notes
 
 - Python validators in `.github/scripts/` allow only `pyyaml` and `pytest` as third-party deps — see `.github/instructions/python.instructions.md`.


### PR DESCRIPTION
## What

Scaffolds the durable-memory lane for easy-cheese: a repo-layer `.hallouminate/config.toml`, four real-content wiki pages plus a TOC index, and a "Durable memory" section in `AGENTS.md`. Establishes the **durable-vs-transient boundary as the git-tracking split** — durable knowledge committed under `.hallouminate/wiki/`, transient task output gitignored in `.cheese/`.

Curdled from integration seam I1 (`durable-memory-boundary`); structure/cadence ported from the hallouminate reference and rewritten with easy-cheese substance.

## Changes

| File | |
|---|---|
| `.hallouminate/config.toml` (new) | Declares `repo:easy-cheese:wiki` tenant; XDG-collision warning comment |
| `.hallouminate/wiki/wiki-conventions.md` (new) | Authoring contract + **durable-vs-transient boundary table**; silent on lifecycle/frontmatter (seam E1) |
| `.hallouminate/wiki/architecture.md` (new) | Skills-only collection, progressive disclosure, the cheese pipeline, portability design center |
| `.hallouminate/wiki/workflow-invariants.md` (new) | Pipeline ordering, two-key handshake, handoff gates, `just check` single gate, durable/transient boundary |
| `.hallouminate/wiki/tooling.md` (new) | `just check`/`just ci`, validators, tilth/`cheez-*` hard-fail, `.pyz` bundles, CI workflows |
| `.hallouminate/wiki/index.md` (new) | Wiki TOC with auto-maintained `HALLOUMINATE:INDEX` marker block |
| `AGENTS.md` | +"Durable memory" section: recommended-default cadence + requires-hallouminate-MCP caveat |

## Acceptance — verified live

- **Cold-agent classification** — `ground "where does /cook output go"` returns the durable-vs-transient boundary table as the top hit.
- **Indexes cleanly** — `hallouminate index repo:easy-cheese:wiki`: 5 files / 21 chunks, 0 errors.
- **git-tracked** — `.hallouminate/` is not gitignored.
- **`just check`** — every step this change can affect is green (markdownlint 0 errors, skill validators ok, pytest 408+114+95, `mkdocs build --strict`).

## Out of scope

Skill wiring (I3/I4), CI lint for the wiki (I6), frontmatter/lifecycle schema (E1) — `wiki-conventions.md` stays silent on lifecycle.

## Notes

- Wiki pages fall outside markdownlint's globs (`skills/**/*.md`, `*.md`); linted by hand instead (0 errors).
- Pipeline self-corrected one finding during review: the in-diff `AGENTS.md` insertion shifted the `cheez-*` rule from line 57 → 73, leaving two wiki citations stale — both fixed.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)