### PR TITLE
docs: clarify skills.sh global install

### DIFF
--- a/.github/workflows/build-pyz.yml
+++ b/.github/workflows/build-pyz.yml
@@ -45,7 +45,7 @@ jobs:
       # freshly-added skill (still untracked) are caught by the index-vs-HEAD
       # diff — a plain `git diff` on the working tree would skip them.
       - name: Commit and push if changed
-        run: |
+        run: |-
           set -euo pipefail
           git add -- 'skills/*/scripts/*.pyz'
           if git diff --cached --quiet; then

--- a/README.md
+++ b/README.md
@@ -200,9 +200,10 @@ Install all currently published skills in this repo's manifest without prompts:
 npx skills@latest add paulnsorensen/easy-cheese --skill "*" -y
 ```
 
-Without `--global`, `skills.sh` uses project-level scope. With `-y`, it
-auto-detects project scope when run inside a project. Run those commands from
-the repo where you want easy-cheese recorded under `.agents/skills/`.
+Without `--global`, the skills CLI uses project-level scope. Run those
+commands from the repo where you want easy-cheese recorded under
+`.agents/skills/`. The `-y` flag only skips confirmation prompts; it does not
+make a project install global.
 
 For a user-wide Codex install that is available across repos, pass the Codex
 agent and global scope explicitly:

--- a/README.md
+++ b/README.md
@@ -200,6 +200,17 @@ Install all currently published skills in this repo's manifest without prompts:
 npx skills@latest add paulnsorensen/easy-cheese --skill "*" -y
 ```
 
+Without `--global`, `skills.sh` uses project-level scope. With `-y`, it
+auto-detects project scope when run inside a project. Run those commands from
+the repo where you want easy-cheese recorded under `.agents/skills/`.
+
+For a user-wide Codex install that is available across repos, pass the Codex
+agent and global scope explicitly:
+
+```sh
+npx skills@latest add paulnsorensen/easy-cheese --skill "*" --agent codex --global -y
+```
+
 The installer reads this repo's published skill manifest, lets you pick the
 skills you want, and installs them into the coding agents you select.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,10 +28,11 @@ npx skills@latest add paulnsorensen/easy-cheese
 ```
 
 Pick the skills and agents you want in the installer, then start with
-`/cheese` if you want routing help. macOS users who also want the surrounding
-ecosystem (CLI tools + MCP servers) in one shot can use the optional bootstrap
-script. See [Install](install.md) for every install path, MCP server setup, and
-CLI tool setup.
+`/cheese` if you want routing help. The default `skills.sh` install is
+project-local; see [Install](install.md) for Codex user-wide install flags,
+every install path, MCP server setup, and CLI tool setup. macOS users who also
+want the surrounding ecosystem (CLI tools + MCP servers) in one shot can use
+the optional bootstrap script.
 
 ## Skills
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,11 +28,11 @@ npx skills@latest add paulnsorensen/easy-cheese
 ```
 
 Pick the skills and agents you want in the installer, then start with
-`/cheese` if you want routing help. The default `skills.sh` install is
-project-local; see [Install](install.md) for Codex user-wide install flags,
-every install path, MCP server setup, and CLI tool setup. macOS users who also
-want the surrounding ecosystem (CLI tools + MCP servers) in one shot can use
-the optional bootstrap script.
+`/cheese` if you want routing help. The skills CLI supports project-local and
+user-wide installs; see [Install](install.md) for global install flags, Codex
+examples, every install path, MCP server setup, and CLI tool setup. macOS users
+who also want the surrounding ecosystem (CLI tools + MCP servers) in one shot
+can use the optional bootstrap script.
 
 ## Skills
 


### PR DESCRIPTION
Summary:
- Clarifies that skills.sh defaults to project-level scope, with -y auto-detecting project scope inside a project.
- Adds the Codex user-wide install command using --agent codex --global.
- Points the docs landing page at the install page for global flags.

Verification:
- PATH=/private/tmp/easy-cheese/.venv/bin:$PATH just check