### PR TITLE
docs: add cross-harness question routing guide

### DIFF
--- a/.github/instructions/skills.instructions.md
+++ b/.github/instructions/skills.instructions.md
@@ -75,7 +75,7 @@ Spend your review budget on the things linters cannot see.
   skill body — never as silent auto-dispatch.
 - No intent classification, no automatic routing inside a skill body except
   in `/cheese`, where routing **is** the skill's purpose and dispatch is
-  gated behind `AskUserQuestion`.
+  gated through the host routing guide in `shared/handoff-gate.md`.
 
 ## Quick triage prompt for review comments
 

--- a/shared/handoff-gate.md
+++ b/shared/handoff-gate.md
@@ -51,11 +51,42 @@ Every option must include:
 
 `dispatch: none` is for *terminal* options only. Options that keep the current skill running must use `continue:`, not `dispatch: none`, so the gate reader can tell "stop" apart from "do something else in this skill".
 
-## Codex-compatible asking
+## Host routing guide
 
-Prefer the host's structured question primitive when it is callable (`AskUserQuestion`, Codex `request_user_input`, or the host equivalent). If no structured primitive is available, ask a plain numbered question and wait for the next user reply.
+The `handoff_gate:` block is the semantic source of truth. After building it,
+choose the richest question mechanism the current harness actually exposes;
+never name a host tool in the transcript unless it is callable in that session.
 
-After the answer arrives:
+| Harness | Prefer | Notes |
+| --- | --- | --- |
+| Claude Code | `AskUserQuestion` | Supports `questions[]` with `question`, short `header`, `options[]`, and optional `multiSelect`; hooks can fill `answers` via `updatedInput`. Source: [Claude Code hooks reference](https://docs.anthropic.com/en/docs/claude-code/hooks#askuserquestion). |
+| Codex / OpenAI app-server | `request_user_input` / `tool/requestUserInput` when exposed | OpenAI's app server documents `tool/requestUserInput` for 1-3 short questions and free-form `isOther` options. In Codex CLI, use `request_user_input` only when the active tool list and current collaboration mode both allow it; otherwise fall back to numbered text. Source: [Codex app-server reference](https://developers.openai.com/codex/app-server). |
+| Conductor | Underlying agent primitive | Conductor runs Claude Code or Codex sessions; route to that agent's question primitive. Conductor Plan Mode exists for both, but Conductor is not a separate question API. Source: [Conductor agent modes](https://conductor.build/docs/concepts/agent-modes). |
+| OpenCode | `question` tool | The built-in `question` tool asks during execution with header, question text, options, and custom answers; ensure `permission.question` is not denied. Source: [OpenCode tools](https://opencode.ai/docs/tools#question). |
+| GitHub Copilot CLI | `ask_user` tool | Copilot CLI lists `ask_user` as "Ask the user a question" and `--no-ask-user` disables it. Use it when available; otherwise numbered text. Source: [Copilot CLI command reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference). |
+| Gemini CLI | `ask_user` tool | Google codelab output lists `Ask User (ask_user)` in `/tools`; use it when present. Source: [Gemini CLI codelab](https://codelabs.developers.google.com/gemini-cli-hands-on). |
+| Cursor CLI / ACP | `cursor/ask_question` when exposed | Cursor ACP documents `cursor/ask_question` as a blocking extension method; use it only inside hosts that expose that ACP method. Source: [Cursor ACP docs](https://cursor.com/docs/cli/acp#cursor-extension-methods). |
+| Windsurf Cascade | Plan-mode interactive questions when in Plan Mode | Cascade Plan Mode can ask clarifying questions and present multiple options with an interactive interface. Outside that mode, fall back to numbered text unless a host tool is exposed. Source: [Cascade modes](https://docs.windsurf.com/windsurf/cascade/modes). |
+| MCP server flows | `elicitation/create` | Use only when an MCP server is requesting user input through a client that supports elicitation. It is not a general assistant-to-user question primitive. Source: [MCP elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation). |
+| Aider and unknown harnesses | Numbered text | If no structured primitive is visible, ask a plain numbered question and wait for the next user reply. |
+
+### Portable fallback format
+
+```markdown
+Question: <one short question>
+Recommended: 1 — <why>
+
+1. <label> — <effect/tradeoff>
+2. <label> — <effect/tradeoff>
+3. <label> — <effect/tradeoff>
+Other: reply with `other: <short answer>`
+```
+
+Keep gates small: one decision by default, at most three questions when the
+host primitive explicitly supports batching. Include a free-form `Other` path
+when the host supports it; otherwise spell out the `other:` fallback in text.
+
+## After the answer arrives
 
 1. Normalize the answer to one option label or recognized free-text verb.
 2. If the answer is ambiguous, ask one clarifying question; do not guess.

--- a/shared/handoff-gate.md
+++ b/shared/handoff-gate.md
@@ -74,13 +74,17 @@ never name a host tool in the transcript unless it is callable in that session.
 
 ```markdown
 Question: <one short question>
-Recommended: 1 — <why>
+Recommended: <label> — <why>
 
 1. <label> — <effect/tradeoff>
 2. <label> — <effect/tradeoff>
 3. <label> — <effect/tradeoff>
 Other: reply with `other: <short answer>`
 ```
+
+Use the option label from `handoff_gate.recommended`; do not assume the
+recommended option is numbered `1` unless you deliberately rendered that label
+as option 1 in this fallback.
 
 Keep gates small: one decision by default, at most three questions when the
 host primitive explicitly supports batching. Include a free-form `Other` path

--- a/skills/cheese/SKILL.md
+++ b/skills/cheese/SKILL.md
@@ -29,14 +29,14 @@ Optional flags:
 - `--continue <slug>` — resume an in-flight pipeline from the latest handoff slug. See `## --continue` below.
 - `--hard` — inject the `/hard-cheese` metacognitive gate before code is shared for review. The flag propagates to whichever target the router dispatches and fires at `/cure`'s share-for-review handoff (or end of `/cure`'s final auto pass under `--auto --hard`). See `skills/hard-cheese/SKILL.md`.
 
-If `$ARGUMENTS` is missing entirely and there is no recent context to lean on, ask one clarifying question via `AskUserQuestion` before classifying.
+If `$ARGUMENTS` is missing entirely and there is no recent context to lean on, ask one clarifying question through the host routing guide in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md) before classifying.
 
 ## Flow
 
 1. **Think first (silent).** Before announcing, model the problem internally per `skills/culture/SKILL.md` — restate the ask in one sentence, list the candidate targets, name the deciding signal. This is the agent's own reasoning, not a user-facing dialogue; the only output of this step is the classification decision that drives step 2.
 2. **Classify** — match `$ARGUMENTS` against the intent shapes in `references/classification.md`. Pick the highest-confidence shape; below the threshold, route to `clarify` (handled by the tier-3 escalation in step 4).
 3. **Clarity check (implementation intents only).** For `cook` and `mold` intents, run the cook fast-path check (`skills/cook/SKILL.md:30-35` — clear I/O, bounded scope, obvious verification). The result drives the three-tier escalation in `## Escalation` below. Non-implementation intents (`research`, `rubber-duck`, `debug`, `age`, `age-then-cure`, `cheese-factory`) skip the clarity check and route directly to their target skill.
-4. **Escalate (if needed).** Tier 1 dispatches the chosen target (writing a mini-spec via `/mold`'s agent-invoked mode when the dispatch is `/cook --auto` and no spec path was supplied). Tier 2 autonomously invokes `/culture` and/or `/briesearch` in internal mode, then re-runs the clarity check. Tier 3 blocks on a single targeted `AskUserQuestion` and re-enters classification on the answer. See `## Escalation`.
+4. **Escalate (if needed).** Tier 1 dispatches the chosen target (writing a mini-spec via `/mold`'s agent-invoked mode when the dispatch is `/cook --auto` and no spec path was supplied). Tier 2 autonomously invokes `/culture` and/or `/briesearch` in internal mode, then re-runs the clarity check. Tier 3 blocks on a single targeted host-routed question and re-enters classification on the answer. See `## Escalation`.
 5. **Announce** — print a short three-line block (Intent / Reason / Target) per the format in `## Output`. Cite the signal that drove the routing decision.
 6. **Self-check** — run the coherence questions in `references/coherence-check.md`. If any fails, downgrade to `clarify` (tier 3) or `research`.
 7. **Dispatch** — without `--safe`, run the chosen skill immediately with its exact dispatch command and context packet, in the same turn as the announce. With `--safe`, issue a handoff gate per [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md) (recommended target pre-selected, at least one alternative, `Stop`) and wait for the user's selection before dispatching. Either way the downstream skill owns its flow; `/cheese` does not narrate beyond the routing decision.
@@ -47,7 +47,7 @@ If `$ARGUMENTS` is missing entirely and there is no recent context to lean on, a
 
 | Intent | Trigger signals | Pre-step | Target skill |
 | --- | --- | --- | --- |
-| clarify | Empty input, single keyword, or critical ambiguity | `AskUserQuestion` for the missing fact | re-enter `/cheese` once answered |
+| clarify | Empty input, single keyword, or critical ambiguity | host-routed question for the missing fact | re-enter `/cheese` once answered |
 | research | Library / API / vendor question, "what's the best…", comparison | — | `/briesearch` |
 | rubber-duck | User explicitly asks for discussion only — "no writes", "let's just talk", "rubber-duck this" — with no artifact intent | — | `/culture` |
 | mold | Feature description with fuzzy scope, multi-module idea, or stated need for a spec | optional `/briesearch` first if external evidence is missing | `/mold` → `/cook` |
@@ -69,7 +69,7 @@ For implementation intents (`cook` and `mold`), `/cheese` runs the cook fast-pat
 
 **Tier 2 — borderline (any check fails or is uncertain).** Agent autonomously invokes `/culture` (internal-mode thinking) and/or `/briesearch` (internal-mode research) — agent's choice each call, no fixed order, no requirement to run both — to fill the missing context. After the internal pass, re-run the cook fast-path check on the refined understanding. If all three checks now pass, drop into tier 1 (the mini-spec records the culture / briesearch synthesis under `## Provenance`). Otherwise tier 3.
 
-**Tier 3 — still borderline after tier 2.** Block on the human via a single targeted `AskUserQuestion` whose answer closes the failing check. On the answer, re-enter classification with the augmented input. This is the only sanctioned user-facing prompt in the autonomous-by-default path; the `clarify` intent and the below-`medium`-confidence path both map here.
+**Tier 3 — still borderline after tier 2.** Block on the human via a single targeted host-routed question whose answer closes the failing check. On the answer, re-enter classification with the augmented input. This is the only sanctioned user-facing prompt in the autonomous-by-default path; the `clarify` intent and the below-`medium`-confidence path both map here.
 
 `--safe` does not skip the escalation logic — the tiers still run silently — but it inserts a handoff gate before the final dispatch in every tier. The recommended option stays auto-flavoured (`/cook --auto <spec-path>` etc., using the explicit mini-spec path); the non-auto variant is offered as the alternative.
 
@@ -95,7 +95,7 @@ Under `--safe`, gate the resumption through the handoff gate in [`../../shared/h
 
 Treat classification confidence qualitatively (`low | medium | high`). Threshold for direct routing is `medium` or better. Below that, route to tier 3 (`clarify`):
 
-- Ask exactly one question via `AskUserQuestion`.
+- Ask exactly one question through the host routing guide in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md).
 - Offer the two most-likely targets as alternatives plus `Stop`.
 - Re-enter `/cheese` with the answer.
 
@@ -110,7 +110,7 @@ Beyond `cheez-*` there are router-specific tools:
 | Need | Prefer | Fallback |
 | --- | --- | --- |
 | PR / issue context | `gh` | the URL or numbers the user provided |
-| Confirming routing target with the user (only under `--safe` or `clarify`) | `AskUserQuestion` / host structured question (`request_user_input` in Codex when available) | a numbered list with explicit dispatch commands |
+| Confirming routing target with the user (only under `--safe` or `clarify`) | host-routed structured question per [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md) | a numbered list with explicit dispatch commands |
 
 `/cheese` keeps tool use light. Treat anything heavier than a single-file read or one search call as a sign the work belongs in the downstream skill, not in the router.
 

--- a/skills/cheese/references/classification.md
+++ b/skills/cheese/references/classification.md
@@ -4,7 +4,7 @@ Intent shapes for `/cheese`, with the signals that drive each one and the disamb
 
 ## Clarity check (implementation intents)
 
-For `cook` and `mold` intents — and only these — classification feeds into the cook-fast-path clarity check (`skills/cook/SKILL.md:30-35`: clear I/O, bounded scope, obvious verification). All three checks passing means tier 1: write a mini-spec via `/mold`'s agent-invoked mode and dispatch `/cook --auto`. Any check borderline means tier 2: invoke `/culture` and/or `/briesearch` internally, re-check. Still borderline means tier 3: a single targeted `AskUserQuestion`. The full three-tier escalation lives in `skills/cheese/SKILL.md` § Escalation.
+For `cook` and `mold` intents — and only these — classification feeds into the cook-fast-path clarity check (`skills/cook/SKILL.md:30-35`: clear I/O, bounded scope, obvious verification). All three checks passing means tier 1: write a mini-spec via `/mold`'s agent-invoked mode and dispatch `/cook --auto`. Any check borderline means tier 2: invoke `/culture` and/or `/briesearch` internally, re-check. Still borderline means tier 3: a single targeted host-routed question. The full three-tier escalation lives in `skills/cheese/SKILL.md` § Escalation.
 
 The `clarify` intent below is exclusively the tier-3 path; classify a request as `clarify` when the cook-fast-path check fails twice (input + post-tier-2-refined input) or when intent confidence stays below `medium` after the silent culture pass.
 
@@ -14,7 +14,7 @@ Other intents (`research`, `rubber-duck`, `debug`, `age`, `age-then-cure`, `chee
 
 | Intent | Pre-step | Target |
 | --- | --- | --- |
-| clarify | one `AskUserQuestion` | re-enter `/cheese` |
+| clarify | one host-routed question | re-enter `/cheese` |
 | research | — | `/briesearch` |
 | rubber-duck | — | `/culture` (only when the user explicitly opted out of writes) |
 | mold | optional `/briesearch` | `/mold` → `/cook` |

--- a/skills/cheese/references/coherence-check.md
+++ b/skills/cheese/references/coherence-check.md
@@ -1,6 +1,6 @@
 # Coherence self-check
 
-Run these questions before dispatching the chosen target. If any answer is `no`, downgrade the routing decision (usually to `clarify` or `research`) instead of pre-selecting a target. Under `--safe` the downgrade lands in the dispatch gate; otherwise it lands in the announce block, and on the `clarify` path it replaces the dispatch with a single targeted `AskUserQuestion`.
+Run these questions before dispatching the chosen target. If any answer is `no`, downgrade the routing decision (usually to `clarify` or `research`) instead of pre-selecting a target. Under `--safe` the downgrade lands in the dispatch gate; otherwise it lands in the announce block, and on the `clarify` path it replaces the dispatch with a single targeted host-routed question per `shared/handoff-gate.md`.
 
 ## Pre-dispatch checklist
 
@@ -37,7 +37,7 @@ Run these questions before dispatching the chosen target. If any answer is `no`,
 When the checklist trips:
 
 - Switch the announce block to name the failing check (e.g. "spec path `.cheese/specs/foo.md` does not exist on disk").
-- Replace the dispatch with a single clarifying `AskUserQuestion` whose options resolve the failed check. Under `--safe` the gate already exists, so swap its options for the clarifying ones; without `--safe` the clarify path is the only sanctioned reason to ask the user at all.
+- Replace the dispatch with a single clarifying host-routed question whose options resolve the failed check. Under `--safe` the gate already exists, so swap its options for the clarifying ones; without `--safe` the clarify path is the only sanctioned reason to ask the user at all.
 - Never pre-select a target the checklist downgraded.
 
 ## Why this is separate

--- a/skills/pasteurize/SKILL.md
+++ b/skills/pasteurize/SKILL.md
@@ -73,7 +73,7 @@ Each hypothesis must be **falsifiable**: state the prediction it makes.
 
 If you cannot state the prediction, the hypothesis is a vibe — discard or sharpen it.
 
-**Show the ranked list to the user via `AskUserQuestion` before testing.** They often have domain knowledge that re-ranks instantly ("we just deployed a change to #3"), or know hypotheses they've already ruled out. Cheap checkpoint, big time saver. Don't block on it — proceed with your ranking if the user is AFK or running `--auto`.
+**Show the ranked list to the user through the host routing guide in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md) before testing.** They often have domain knowledge that re-ranks instantly ("we just deployed a change to #3"), or know hypotheses they've already ruled out. Cheap checkpoint, big time saver. Don't block on it — proceed with your ranking if the user is AFK or running `--auto`.
 
 ## Phase 4 — Instrument
 
@@ -171,7 +171,7 @@ follow_up: <architectural follow-up note, or "none">
 
 **Pipeline:** cheese (debug) → **[pasteurize]** → cook --auto → press → age → cure → ship
 
-After the report is printed and the handoff slug is on disk, ask via `AskUserQuestion` which downstream to run. Lead each option with the verb (what the user wants to _do_ next):
+After the report is printed and the handoff slug is on disk, ask through the host routing guide in [`../../shared/handoff-gate.md`](../../shared/handoff-gate.md) which downstream to run. Lead each option with the verb (what the user wants to _do_ next):
 
 - **Validate and chain forward** _(recommended when `status: ok`)_ — `/cook <slug> --auto`.
 - **Validate without auto chain** — `/cook <slug>` (cook runs taste-test, then the user picks each subsequent step).
@@ -180,7 +180,7 @@ After the report is printed and the handoff slug is on disk, ask via `AskUserQue
 
 Pre-select **Validate and chain forward** when `status: ok`. The chain default is `--auto` because pasteurize already wrote and verified the fix; the work left for cook → press → age → cure is mechanical validation, not new authoring. Never auto-invoke; the user must still select.
 
-When invoked with `--auto`, skip this `AskUserQuestion` entirely and invoke `/cook <slug> --auto` directly.
+When invoked with `--auto`, skip this host-routed question entirely and invoke `/cook <slug> --auto` directly.
 
 ## Auto mode
 


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
## What changed

Added a cross-harness question routing guide to `shared/handoff-gate.md` and updated `/cheese` plus `/pasteurize` to route option questions through that shared guide instead of hard-coding Claude Code's `AskUserQuestion`.

## Why

Skills need a consistent portable way to ask user questions with options across Claude Code, Conductor, Codex, OpenCode, Cursor, Copilot CLI, Gemini CLI, Windsurf, MCP elicitation, and plain-text fallback.

## How to verify

`just check`

## Risk / rollout notes

Low; documentation-only skill guidance change with cited host docs.

## Checklist

- [x] Conventional Commits PR title (`feat:`, `fix:`, `chore:`, `docs:`, ...)
- [x] Tests added or updated (or N/A)
- [x] Documentation updated (or N/A)
- [x] No secrets or credentials added
