### PR TITLE
docs(age): flag caller-shadowed domain invariants in encapsulation dimension

### DIFF
--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -37,7 +37,7 @@ Dimensions answer **what kind of problem**. Severity (`blocker / high / medium /
 | --- | --- | --- |
 | correctness | low → blocker | broken behaviour, silent failures, ordering, null/empty edge cases, races, lost writes |
 | security | low → blocker | auth, injection, secrets, unsafe parsing, tainted inputs, weak crypto |
-| encapsulation | low → blocker | class-private peeks, module-internal leaks, cross-slice internals, ingress/egress contract violations |
+| encapsulation | low → blocker | class-private peeks, module-internal leaks, cross-slice internals, ingress/egress contract violations, caller-shadowed domain invariants |
 | spec | low → blocker | drift from stated requirements or acceptance criteria; silent drift on security/data/correctness reqs |
 | complexity | low → high | unnecessary nesting, long functions, speculative abstractions, redundant state, parameter sprawl, stringly-typed code |
 | deslop | low → high | dead code, AI residue, duplicated logic, copy-paste-with-variation, vague names |

--- a/skills/age/references/dimensions.md
+++ b/skills/age/references/dimensions.md
@@ -141,18 +141,21 @@ Recommendation shape: "Validate at the boundary" / "Use the project's existing `
 
 ### encapsulation
 
-Look for: cross-module reach into internals, public APIs leaking implementation types, parameters that take more context than needed, new exports without a use case.
+Look for: cross-module reach into internals, public APIs leaking implementation types, parameters that take more context than needed, new exports without a use case, and the inverse — a domain invariant lifted *out* of the producer and enforced above it by every caller.
 
 | Base | Trigger |
 | --- | --- |
 | `blocker` | **Ingress/egress contract violation** — public API leaks ORM model, infra adapter, framework type, or storage internal across the slice boundary; slice's `index` re-exports an internal type |
 | `high` | Cross-module reach into another slice's internals, bypassing crust/index |
+| `high` | **Caller-shadowed domain invariant** — a guard/validation that all callers must invoke (or redundantly do) lives *outside* the producer; the domain doesn't enforce its own invariant, so a caller can skip it. Especially when a symbol is made public *solely* to be called from above the domain layer. |
 | `medium` | Module-internal leak (cross-file inside one slice exposes private detail) |
 | `low` | Class-level — one class touches another's private member within the same file |
 
+Detection signals for the caller-shadowed invariant: a guard defined inside a slice but never called by that slice (only by external entrypoints); N callers each repeating the same check before/after one producer; a public/exported guard whose only consumers sit above the domain layer; asymmetry where some callers apply the check and others skip it. Beware the false-clean trap — this often reads as good Sliced-Bread hygiene (a private helper promoted to public + crust-exported), so a diff-scoped pass grades it clean. The violation is usually *inherited*, not introduced by the diff under review.
+
 Note: base tier *is* the location tier here, so the contract bump tends to redundantly raise an already-blocker finding (capped).
 
-Recommendation shape: "Import from `<slice>/index` instead of `<slice>/internal/foo`" / "Narrow the public surface to `<minimal-type>`".
+Recommendation shape: "Import from `<slice>/index` instead of `<slice>/internal/foo`" / "Narrow the public surface to `<minimal-type>`" / "Move the `<invariant>` into `<producer>` so every caller inherits it; drop the external guard and narrow the public surface".
 
 ### spec
 


### PR DESCRIPTION
## What

Encodes the inverse-leak trigger requested in #110 into the `/age` **encapsulation** dimension.

Today the dimension catches **outward** leaks (internals escaping a slice boundary). It had no trigger for the **inverse**: a domain invariant lifted *out* of its producer and enforced above it by every caller. When the domain doesn't validate its own invariant, any caller that forgets the check is a latent correctness bug — the invariant is enforced *by convention at call sites, not by construction*.

## Changes

`skills/age/references/dimensions.md` (§ encapsulation):
- New `high` trigger row — **caller-shadowed domain invariant**: a guard/validation all callers must invoke (or redundantly do) lives outside the producer; especially when a symbol is made public *solely* to be called from above the domain layer.
- Extended the "Look for" line to name the inverse pattern.
- Added **detection signals** (guard defined-in-slice-but-never-called-by-slice, N callers repeating the same check, public guard whose only consumers sit above the domain, asymmetric application) and the **false-clean trap** — this often reads as good Sliced-Bread hygiene (private helper promoted to public + crust-exported), so a diff-scoped pass grades it clean; the violation is usually *inherited*, not introduced by the diff.
- Added the recommendation shape: *"Move the `<invariant>` into `<producer>` so every caller inherits it; drop the external guard and narrow the public surface."*

`skills/age/SKILL.md`:
- Added `caller-shadowed domain invariants` to the encapsulation summary row so it shows in the dimension quick-glance table.

## Verification

`tests/shared/python/test_severity.py` — 29 passed. Change is additive markdown; the dimension count stays at ten and severity computation is untouched.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)