### PR TITLE
docs(ultracook,cheese-factory): nudge workers to read before host edits

### DIFF
--- a/skills/cheese-factory/references/curd-prompt.md
+++ b/skills/cheese-factory/references/curd-prompt.md
@@ -74,7 +74,7 @@ branch. Set `next: done` if you halted.
 - Run the full test suite (test_target only).
 - Push or create PRs (the orchestrator handles that).
 - Modify any file not in your file list.
-- Call the host Edit/Write tool on a file you haven't Read this turn — prefer /cheez-write (it reads first); host-edit only as a tilth fallback.
+- Call the host `Edit`/`Write` tool on a file you haven't `Read` this turn — prefer /cheez-write (it reads first); use host edit only as a fallback when tilth is unavailable.
 - Invoke /pr-stack, /gh, or any PR-related skill.
 - Chain forward (the orchestrator owns the chain).
 - Retry on failure — write the halt and return; the orchestrator decides retry policy.

--- a/skills/cheese-factory/references/curd-prompt.md
+++ b/skills/cheese-factory/references/curd-prompt.md
@@ -74,6 +74,7 @@ branch. Set `next: done` if you halted.
 - Run the full test suite (test_target only).
 - Push or create PRs (the orchestrator handles that).
 - Modify any file not in your file list.
+- Call the host Edit/Write tool on a file you haven't Read this turn — prefer /cheez-write (it reads first); host-edit only as a tilth fallback.
 - Invoke /pr-stack, /gh, or any PR-related skill.
 - Chain forward (the orchestrator owns the chain).
 - Retry on failure — write the halt and return; the orchestrator decides retry policy.

--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -90,8 +90,8 @@ Agent(
            .cheese/<phase>/<slug>.md with the handoff schema and stop.
            Do not chain forward to the next phase even though your
            auto-mode contract documents that. The /ultracook orchestrator
-           is driving the chain. Edit through cheez-write; if you fall back
-           to the host Edit/Write tool, Read the file first."
+           is driving the chain. Edit through /cheez-write; if you fall back
+           to the host `Edit`/`Write` tool, `Read` the file first."
 )
 ```
 

--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -90,7 +90,8 @@ Agent(
            .cheese/<phase>/<slug>.md with the handoff schema and stop.
            Do not chain forward to the next phase even though your
            auto-mode contract documents that. The /ultracook orchestrator
-           is driving the chain."
+           is driving the chain. Edit through cheez-write; if you fall back
+           to the host Edit/Write tool, Read the file first."
 )
 ```
 


### PR DESCRIPTION
## What

Adds a one-line read-before-host-edit directive to the sub-agent dispatch prompts of both pipeline skills:

- **ultracook** — appended to the per-phase `Agent()` dispatch prompt (`skills/ultracook/SKILL.md`).
- **cheese-factory** — new `## Do NOT` bullet in the curd-worker template (`skills/cheese-factory/references/curd-prompt.md`).

Prompt-text only — no code or behavioral logic changes. `markdownlint` passes (0 errors).

## Why

`/session-analytics` over **9 ultracook + 3 cheese-factory runs** (May 23 – Jun 1) found that almost every friction signature clustered in the May 23–24 early-adoption window and is already resolved in source. The **one signature still appearing in recent runs** (last seen Jun 1) was host `Edit`/`Write` **"File has not been read yet"** errors — phase/curd sub-agents reaching for the host edit tool without a prior read.

Both skills already *prefer* `cheez-write` (which reads first for hash anchors, so the error can't occur on that path). This change reinforces that routing and requires a read on the host-edit fallback path, killing the error class at its source.

This is **low-frequency hardening** (1 hit on the latest run, ~16 total), not a fix for a live failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)