### PR TITLE
test: make install.sh bats suite hermetic against host binaries

### DIFF
--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -7,13 +7,19 @@
 
 # Build a hermetic essentials dir once per file: symlinks to the only
 # external commands the script and suite actually use. Resolved against
-# the original full PATH, which is still active here.
+# the original full PATH, which is still active here. env and bash are
+# allowlisted only to back the stubs' `#!/usr/bin/env bash` shebangs,
+# not direct use — don't prune them.
 setup_file() {
     ESSENTIALS_BIN="$BATS_FILE_TMPDIR/essentials"
     mkdir -p "$ESSENTIALS_BIN"
-    local cmd
+    local cmd resolved
     for cmd in bash cat chmod grep mkdir ln dirname basename sort tr uname env; do
-        ln -sf "$(command -v "$cmd")" "$ESSENTIALS_BIN/$cmd"
+        resolved="$(command -v "$cmd")" || {
+            echo "setup_file: essential command not found: $cmd" >&2
+            return 1
+        }
+        ln -sf "$resolved" "$ESSENTIALS_BIN/$cmd"
     done
     export ESSENTIALS_BIN
 }
@@ -882,13 +888,21 @@ STUB
 # -- test harness hermeticity -------------------------------------------------
 
 @test "hermetic PATH: non-allowlisted host tools are unreachable" {
-    # sed lives in /usr/bin on both Linux and macOS but is not an essential;
-    # if setup()'s PATH regresses to include /usr/bin or /bin this goes red.
-    run command -v sed
+    # sed and awk live in /usr/bin on both Linux and macOS but are not
+    # essentials; if setup()'s PATH regresses to include /usr/bin or /bin
+    # this goes red. type -P is a PATH-only lookup, so an env-exported
+    # shell function can't satisfy it.
+    run type -P sed
+    [ "$status" -ne 0 ]
+    run type -P awk
     [ "$status" -ne 0 ]
 }
 
 @test "hermetic PATH: stubs shadow allowlisted essentials" {
+    # Both halves of precedence: the essential resolves from the allowlist
+    # dir before any stub exists, and the stub wins once dropped in. Goes
+    # red if $ESSENTIALS_BIN drops out of PATH or the ordering flips.
+    [[ "$(command -v uname)" == "$ESSENTIALS_BIN/uname" ]]
     make_stub uname
     [[ "$(command -v uname)" == "$STUB_BIN/uname" ]]
 }

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -5,6 +5,19 @@
 # The script is sourced (the BASH_SOURCE != $0 guard skips main on source)
 # so each test can call individual functions with controlled stubs.
 
+# Build a hermetic essentials dir once per file: symlinks to the only
+# external commands the script and suite actually use. Resolved against
+# the original full PATH, which is still active here.
+setup_file() {
+    ESSENTIALS_BIN="$BATS_FILE_TMPDIR/essentials"
+    mkdir -p "$ESSENTIALS_BIN"
+    local cmd
+    for cmd in bash cat chmod grep mkdir ln dirname basename sort tr uname env; do
+        ln -sf "$(command -v "$cmd")" "$ESSENTIALS_BIN/$cmd"
+    done
+    export ESSENTIALS_BIN
+}
+
 setup() {
     REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
     INSTALL_SH="$REPO_ROOT/scripts/install.sh"
@@ -14,9 +27,10 @@ setup() {
     : > "$STUB_LOG"
     export STUB_LOG
     PATH_ORIG="$PATH"
-    # Use a sparse PATH so the only commands available are real /usr/bin
-    # essentials plus whatever stubs each test adds.
-    PATH="$STUB_BIN:/usr/bin:/bin"
+    # Hermetic PATH: stubs first, then only the allowlisted essentials.
+    # No /usr/bin or /bin, so real host tools cannot satisfy the install
+    # script's command -v probes in absence-asserting tests.
+    PATH="$STUB_BIN:$ESSENTIALS_BIN"
     # shellcheck disable=SC1090
     source "$INSTALL_SH"
 }
@@ -863,4 +877,22 @@ STUB
         echo "actual:   $actual"
         return 1
     fi
+}
+
+# -- test harness hermeticity -------------------------------------------------
+
+@test "hermetic PATH: non-allowlisted host tools are unreachable" {
+    # sed lives in /usr/bin on both Linux and macOS but is not an essential;
+    # if setup()'s PATH regresses to include /usr/bin or /bin this goes red.
+    run command -v sed
+    [ "$status" -ne 0 ]
+}
+
+@test "hermetic PATH: stubs shadow allowlisted essentials" {
+    make_stub uname
+    [[ "$(command -v uname)" == "$STUB_BIN/uname" ]]
+}
+
+@test "hermetic PATH: allowlisted essentials resolve from the essentials dir" {
+    [[ "$(command -v grep)" == "$ESSENTIALS_BIN/grep" ]]
 }


### PR DESCRIPTION
## Why

`tests/bash/test_install.bats` used a "sparse" PATH of `$STUB_BIN:/usr/bin:/bin`. Since `install.sh` probes tools with `command -v` on bare names, any real host binary in `/usr/bin` defeated tests that assert absence/fallback behavior. On a Linux dev machine with `rg`, `npm`, `pipx`, `pip` installed, 5 tests failed (27–29, 37, 51) — and test 37 actually executed a real `npm install -g tilth`, a side-effect hazard. Sibling tests (pipx fallback, npm fallback, tilth-missing, harness detection) passed only because `uv`/`cargo`/`tilth`/`claude` happened not to be in `/usr/bin`.

## What

- `setup_file()` builds a per-file essentials dir of symlinks to the 12 external commands the script and suite actually use (`bash cat chmod grep mkdir ln dirname basename sort tr uname env`), resolved against the original full PATH.
- `setup()` now sets `PATH="$STUB_BIN:$ESSENTIALS_BIN"` — no `/usr/bin` or `/bin`, so host tools can't leak into the probes. Stubs keep precedence; per-test fakes (`uname` → Darwin, etc.) are unchanged.
- Three hardening tests lock the behavior: non-allowlisted tools unreachable, stubs shadow essentials, essentials resolve from the essentials dir.

The 5 previously-failing tests pass from the PATH change alone — no per-test edits. A future test reaching for a non-allowlisted external fails loudly with command-not-found instead of silently using a host binary.

## Verification

- `bats tests/bash/test_install.bats`: 86/86 green on Linux (was 78/83).
- `just check`: exit 0.
- Red-check: under the old PATH, `command -v sed` resolves, turning the new hermeticity test red.

Spec: `hermetic-bats-path` (durable corpus); pipeline reports under `.cheese/{cook,press,age}/hermetic-bats-path.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)