### PR TITLE
feat(skills): wire milknado + hallouminate as optional plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ See `README.md` for the full workflow and the suggested skill ordering.
 
 - Python validators in `.github/scripts/` allow only `pyyaml` and `pytest` as third-party deps — see `.github/instructions/python.instructions.md`.
 - Shell scripts and bats tests follow the rules in `.github/instructions/shell.instructions.md`.
-- `cheez-*` skills require [tilth MCP](https://github.com/paulnsorensen/tilth) and hard-fail without it. Every other skill stays portable and degrades to host-native tools.
+- `cheez-*` skills require [tilth MCP](https://github.com/paulnsorensen/tilth) and hard-fail without it. Every other skill stays portable and degrades to host-native tools. Optional integrations — hallouminate (repo-wiki grounding for `/mold` and `/age`) and milknado (mikado task-graph backend for `/cheese-factory`) — are wired in as optional plugins per `shared/optional-plugins.md`: they degrade gracefully when absent and never block a skill run.
 - SKILL.md files must pass `validate_skills.py` (YAML frontmatter validation).
 - Conventional Commits format for all commits and PR titles (enforced by `validate.yml` for PRs).
 - Cheese / Dune / Mad Max / LOTR / Princess Bride flavor is welcome in user-facing docs and `SKILL.md` files. Keep commit messages and YAML frontmatter neutral.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Workflow skills name preferred tools when they help, with fallbacks for portabil
 | Tavily (MCP) | Current web/vendor research | host web search or user-supplied sources |
 | code-review-graph (MCP) | Review impact radius, architecture framing, and embeddings-backed semantic / cross-repo search | import searches, caller searches, tests |
 | LSP / [Serena](https://github.com/oraios/serena) (MCP) | Type-aware xrefs (`find_referencing_symbols`, `find_implementations`), symbol-bounded edits (`rename_symbol`, `replace_symbol_body`, `safe_delete_symbol`), and LSP diagnostics — concrete tools for the abstract "if your harness has an LSP" sections in `cheez-*` skills | `sg`, `tilth_search`, targeted reads via tilth |
+| hallouminate (MCP) | Per-repo wiki for cross-session design rationale, ADR grounding, and `/mold` evidence | Skip wiki grounding; proceed with diff + code evidence only; cap at `speculating` when design rationale is central |
+| milknado (MCP) | Mikado task-graph backend for `/cheese-factory` curd prerequisite tracking | In-report curd decomposition in manifest YAML; no external task-graph backend needed |
 | `ripgrep` | Fast text search | `grep`, `find`, editor search |
 | `gh` | GitHub issues, PRs, checks, examples | local git commands or user-provided links/logs |
 | `delta` | Readable diffs | plain `git diff` |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,7 +69,7 @@ Options:
                                 just, mergiraf, tilth
   --mcp <list>         Comma-separated MCP servers to register. Default:
                        tilth,context7. Choices: tilth, context7, tavily,
-                       code-review-graph, none
+                       code-review-graph, hallouminate, milknado, none
   --skip-mcp           Same as --mcp none.
   --skip-tools         Skip CLI tool installs (useful for MCP-only runs).
   --harness <selection> Harness to register skills + MCP servers with.
@@ -227,6 +227,12 @@ ec_install_mcp() {
         code-review-graph)
             ec_install_mcp_crg "$harness"
             ;;
+        hallouminate)
+            ec_install_mcp_hallouminate "$harness"
+            ;;
+        milknado)
+            ec_install_mcp_milknado "$harness"
+            ;;
         none)
             ec_log "MCP: skipping (none selected)"
             ;;
@@ -375,6 +381,45 @@ ec_install_mcp_crg() {
     fi
     ec_log "code-review-graph: registering with $harness"
     "$crg" install --platform "$harness"
+}
+ec_install_mcp_hallouminate() {
+    local harness="$1"
+    local claude="${EC_CLAUDE:-claude}"
+    local npx="${EC_NPX:-npx}"
+    if [[ "$harness" != "claude-code" ]]; then
+        ec_warn "hallouminate MCP: only claude-code is auto-registered; configure $harness manually."
+        return 0
+    fi
+    if ! ec_cmd_exists "$claude"; then
+        ec_warn "hallouminate MCP: claude CLI not found; install Claude Code first."
+        return 1
+    fi
+    if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+        ec_log "hallouminate MCP: would run '$claude mcp add hallouminate -- $npx -y @agentskills/hallouminate-mcp@latest'"
+        return 0
+    fi
+    ec_log "hallouminate MCP: registering with claude-code"
+    "$claude" mcp add hallouminate -- "$npx" -y @agentskills/hallouminate-mcp@latest
+}
+
+ec_install_mcp_milknado() {
+    local harness="$1"
+    local claude="${EC_CLAUDE:-claude}"
+    local npx="${EC_NPX:-npx}"
+    if [[ "$harness" != "claude-code" ]]; then
+        ec_warn "milknado MCP: only claude-code is auto-registered; configure $harness manually."
+        return 0
+    fi
+    if ! ec_cmd_exists "$claude"; then
+        ec_warn "milknado MCP: claude CLI not found; install Claude Code first."
+        return 1
+    fi
+    if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
+        ec_log "milknado MCP: would run '$claude mcp add milknado -- $npx -y @agentskills/milknado-mcp@latest'"
+        return 0
+    fi
+    ec_log "milknado MCP: registering with claude-code"
+    "$claude" mcp add milknado -- "$npx" -y @agentskills/milknado-mcp@latest
 }
 
 ec_install_mcp_list() {
@@ -597,7 +642,7 @@ ec_parse_args() {
     done
 
     ec_validate_selection "$EC_TOOLS" "$EC_KNOWN_TOOLS" || return 2
-    ec_validate_selection "$EC_MCP" "tilth context7 tavily code-review-graph none" || return 2
+    ec_validate_selection "$EC_MCP" "tilth context7 tavily code-review-graph hallouminate milknado none" || return 2
 }
 
 ec_main() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -90,6 +90,7 @@ Environment:
   EC_CURSOR EC_CODEX   Override cursor / codex binaries for detection.
   EC_NPX               Override npx (used to launch context7 / tavily MCP).
   EC_UVX               Override uvx (used to launch milknado MCP).
+  EC_HALLOUMINATE      Override hallouminate binary (used to launch hallouminate MCP).
   EC_UV     EC_PIPX    Override uv / pipx for code-review-graph install.
   EC_PIP    EC_CRG     Override pip / code-review-graph binaries.
   EC_SKILL_REF         Pin skill installs to a git tag or commit SHA
@@ -383,9 +384,11 @@ ec_install_mcp_crg() {
     ec_log "code-review-graph: registering with $harness"
     "$crg" install --platform "$harness"
 }
+
 ec_install_mcp_hallouminate() {
     local harness="$1"
     local claude="${EC_CLAUDE:-claude}"
+    local hallouminate="${EC_HALLOUMINATE:-hallouminate}"
     if [[ "$harness" != "claude-code" ]]; then
         ec_warn "hallouminate MCP: only claude-code is auto-registered; configure $harness manually."
         return 0
@@ -394,16 +397,16 @@ ec_install_mcp_hallouminate() {
         ec_warn "hallouminate MCP: claude CLI not found; install Claude Code first."
         return 1
     fi
-    if ! ec_cmd_exists hallouminate; then
+    if ! ec_cmd_exists "$hallouminate"; then
         ec_warn "hallouminate MCP: hallouminate binary not found — install via 'cargo install hallouminate' or the release installer, then re-run with --mcp hallouminate"
         return 0
     fi
     if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-        ec_log "hallouminate MCP: would run '$claude mcp add hallouminate -- hallouminate serve'"
+        ec_log "hallouminate MCP: would run '$claude mcp add hallouminate -- $hallouminate serve'"
         return 0
     fi
     ec_log "hallouminate MCP: registering with claude-code"
-    "$claude" mcp add hallouminate -- hallouminate serve
+    "$claude" mcp add hallouminate -- "$hallouminate" serve
 }
 
 ec_install_mcp_milknado() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -89,6 +89,7 @@ Environment:
   EC_TILTH  EC_CLAUDE  Override the tilth / claude binaries (used by tests).
   EC_CURSOR EC_CODEX   Override cursor / codex binaries for detection.
   EC_NPX               Override npx (used to launch context7 / tavily MCP).
+  EC_UVX               Override uvx (used to launch milknado MCP).
   EC_UV     EC_PIPX    Override uv / pipx for code-review-graph install.
   EC_PIP    EC_CRG     Override pip / code-review-graph binaries.
   EC_SKILL_REF         Pin skill installs to a git tag or commit SHA
@@ -385,7 +386,6 @@ ec_install_mcp_crg() {
 ec_install_mcp_hallouminate() {
     local harness="$1"
     local claude="${EC_CLAUDE:-claude}"
-    local npx="${EC_NPX:-npx}"
     if [[ "$harness" != "claude-code" ]]; then
         ec_warn "hallouminate MCP: only claude-code is auto-registered; configure $harness manually."
         return 0
@@ -394,18 +394,22 @@ ec_install_mcp_hallouminate() {
         ec_warn "hallouminate MCP: claude CLI not found; install Claude Code first."
         return 1
     fi
+    if ! ec_cmd_exists hallouminate; then
+        ec_warn "hallouminate MCP: hallouminate binary not found — install via 'cargo install hallouminate' or the release installer, then re-run with --mcp hallouminate"
+        return 0
+    fi
     if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-        ec_log "hallouminate MCP: would run '$claude mcp add hallouminate -- $npx -y @agentskills/hallouminate-mcp@latest'"
+        ec_log "hallouminate MCP: would run '$claude mcp add hallouminate -- hallouminate serve'"
         return 0
     fi
     ec_log "hallouminate MCP: registering with claude-code"
-    "$claude" mcp add hallouminate -- "$npx" -y @agentskills/hallouminate-mcp@latest
+    "$claude" mcp add hallouminate -- hallouminate serve
 }
 
 ec_install_mcp_milknado() {
     local harness="$1"
     local claude="${EC_CLAUDE:-claude}"
-    local npx="${EC_NPX:-npx}"
+    local uvx="${EC_UVX:-uvx}"
     if [[ "$harness" != "claude-code" ]]; then
         ec_warn "milknado MCP: only claude-code is auto-registered; configure $harness manually."
         return 0
@@ -414,12 +418,16 @@ ec_install_mcp_milknado() {
         ec_warn "milknado MCP: claude CLI not found; install Claude Code first."
         return 1
     fi
+    if ! ec_cmd_exists "$uvx"; then
+        ec_warn "milknado MCP: uvx not found — install uv from https://docs.astral.sh/uv and re-run with --mcp milknado"
+        return 0
+    fi
     if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-        ec_log "milknado MCP: would run '$claude mcp add milknado -- $npx -y @agentskills/milknado-mcp@latest'"
+        ec_log "milknado MCP: would run '$claude mcp add milknado -- $uvx --from milknado milknado-mcp'"
         return 0
     fi
     ec_log "milknado MCP: registering with claude-code"
-    "$claude" mcp add milknado -- "$npx" -y @agentskills/milknado-mcp@latest
+    "$claude" mcp add milknado -- "$uvx" --from milknado milknado-mcp
 }
 
 ec_install_mcp_list() {

--- a/shared/optional-plugins.md
+++ b/shared/optional-plugins.md
@@ -1,6 +1,6 @@
 # Optional plugins — detect-and-degrade contract
 
-Three MCP servers extend the skill stack beyond the required tilth + Context7 baseline. All three follow the same contract: probe at skill entry, use when present, degrade to a documented fallback when absent. **Never block on absence.**
+Three optional MCP servers extend the skill stack beyond the required tilth + Context7 baseline; they share one contract: probe at skill entry, use when present, degrade to a documented fallback when absent. **Never block on absence.**
 
 This document is the single source of truth for the contract. Every skill that references an optional plugin points here rather than duplicating the wording.
 
@@ -15,8 +15,8 @@ This document is the single source of truth for the contract. Every skill that r
 | MCP | Key tool(s) to probe | Fallback when absent | Confidence impact |
 | --- | --- | --- | --- |
 | code-review-graph | `build_or_update_graph_tool`, `get_review_context_tool` | `tilth_deps` + `cheez-search kind: "callers"` for blast radius; skip cross-repo, semantic search, and architecture framing | Cap at `speculating` for cross-repo or large-architecture questions |
-| hallouminate | `mcp__plugin_hallouminate_hallouminate__list_corpora`, `mcp__plugin_hallouminate_hallouminate__ground` | Skip wiki grounding; note absence once; proceed with diff + code evidence only | Cap at `speculating` when design rationale is central |
-| milknado | `mcp__plugin_milknado_milknado__milknado_todo_add`, `mcp__plugin_milknado_milknado__milknado_graph_summary` | Use the in-report curd decomposition (manifest YAML in `.cheese/cheese-factory/<slug>/manifest.yaml`); no external task-graph backend | No confidence impact — the decomposition itself is unchanged |
+| hallouminate | `mcp__hallouminate__list_corpora`, `mcp__hallouminate__ground` | Skip wiki grounding; note absence once; proceed with diff + code evidence only | Cap at `speculating` when design rationale is central |
+| milknado | `mcp__milknado__milknado_todo_add`, `mcp__milknado__milknado_graph_summary` | Use the in-report curd decomposition (manifest YAML in `.cheese/cheese-factory/<slug>/manifest.yaml`); no external task-graph backend | No confidence impact — the decomposition itself is unchanged |
 
 ## Reporting an unavailable optional MCP
 
@@ -34,8 +34,8 @@ Do not retry. Do not ask the user to install the MCP during the run. Do not sile
 Detection is instruction-level, not code. At the relevant phase entry, check whether the tool name is in the agent's available toolset:
 
 - **code-review-graph** — look for `build_or_update_graph_tool` in available tools.
-- **hallouminate** — look for `mcp__plugin_hallouminate_hallouminate__list_corpora` in available tools.
-- **milknado** — look for `mcp__plugin_milknado_milknado__milknado_todo_add` in available tools.
+- **hallouminate** — look for `mcp__hallouminate__list_corpora` in available tools.
+- **milknado** — look for `mcp__milknado__milknado_todo_add` in available tools.
 
 If the tool is present, it is available. If absent, skip and note once.
 

--- a/shared/optional-plugins.md
+++ b/shared/optional-plugins.md
@@ -1,0 +1,44 @@
+# Optional plugins — detect-and-degrade contract
+
+Three MCP servers extend the skill stack beyond the required tilth + Context7 baseline. All three follow the same contract: probe at skill entry, use when present, degrade to a documented fallback when absent. **Never block on absence.**
+
+This document is the single source of truth for the contract. Every skill that references an optional plugin points here rather than duplicating the wording.
+
+## The contract in three lines
+
+1. **Detect** — check whether the MCP's tools appear in the agent's toolset before the first call.
+2. **Use** — call the tool if present; fold its output into the skill's evidence.
+3. **Degrade** — if absent, fall back as documented below; state the absence and any confidence reduction once; never hard-block the skill.
+
+## Optional MCPs
+
+| MCP | Key tool(s) to probe | Fallback when absent | Confidence impact |
+| --- | --- | --- | --- |
+| code-review-graph | `build_or_update_graph_tool`, `get_review_context_tool` | `tilth_deps` + `cheez-search kind: "callers"` for blast radius; skip cross-repo, semantic search, and architecture framing | Cap at `speculating` for cross-repo or large-architecture questions |
+| hallouminate | `mcp__plugin_hallouminate_hallouminate__list_corpora`, `mcp__plugin_hallouminate_hallouminate__ground` | Skip wiki grounding; note absence once; proceed with diff + code evidence only | Cap at `speculating` when design rationale is central |
+| milknado | `mcp__plugin_milknado_milknado__milknado_todo_add`, `mcp__plugin_milknado_milknado__milknado_graph_summary` | Use the in-report curd decomposition (manifest YAML in `.cheese/cheese-factory/<slug>/manifest.yaml`); no external task-graph backend | No confidence impact — the decomposition itself is unchanged |
+
+## Reporting an unavailable optional MCP
+
+Once per run, at the point where the tool would first be called:
+
+```text
+OPTIONAL MCP ABSENT: <name> not loaded. Falling back to <fallback>.
+<Confidence note when applicable.>
+```
+
+Do not retry. Do not ask the user to install the MCP during the run. Do not silently swap to a different question.
+
+## Probe pattern
+
+Detection is instruction-level, not code. At the relevant phase entry, check whether the tool name is in the agent's available toolset:
+
+- **code-review-graph** — look for `build_or_update_graph_tool` in available tools.
+- **hallouminate** — look for `mcp__plugin_hallouminate_hallouminate__list_corpora` in available tools.
+- **milknado** — look for `mcp__plugin_milknado_milknado__milknado_todo_add` in available tools.
+
+If the tool is present, it is available. If absent, skip and note once.
+
+## Install
+
+See `scripts/install.sh --help` and `README.md § Optional tools` for install instructions for each MCP. All three are opt-in — they are not in `EC_DEFAULT_MCP`.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -68,10 +68,13 @@ Beyond `cheez-*` there are review-specific tools:
 | Diff inspection | `delta` | `git diff --unified=3` |
 | Risk-scored impact + curated review context | code-review-graph: `get_review_context_tool`, `get_impact_radius_tool`, `detect_changes_tool` | `tilth_deps` + manual scoping |
 | Architecture / hotspot framing for large diffs | code-review-graph: `get_architecture_overview_tool`, `get_hub_nodes_tool`, `get_bridge_nodes_tool` | skip and note in confidence |
+| Design rationale for encapsulation/spec dimensions (optional) | hallouminate `ground` on `repo:<repo>:wiki` corpus — if available, ground design intent before grading encapsulation and spec findings | skip; proceed with diff + code evidence only; cap at `speculating` when rationale is the primary evidence |
 | GitHub/PR context | `gh` | local git commands or user-provided PR data |
 | Merge/conflict awareness | mergiraf | manual conflict checks |
 
 **Freshness:** before the first code-review-graph query in a run, call `build_or_update_graph_tool`. The graph is persistent and goes stale between sessions. See [`/cheez-search`](../cheez-search/SKILL.md#when-code-review-graph-beats-tilth-if-your-harness-has-it) for the full freshness contract and when semantic search beats tilth — steel threads across renamed layers, concepts under divergent names, spec-vs-code vocabulary mismatch.
+
+**Optional MCPs:** code-review-graph, hallouminate, and milknado follow the detect-and-degrade contract in [`../../shared/optional-plugins.md`](../../shared/optional-plugins.md) — state absence once, fall back, reduce confidence only if evidence quality suffers, never block.
 
 Missing optional tools should not block review. State which evidence was unavailable and reduce confidence accordingly.
 

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -68,7 +68,7 @@ Beyond `cheez-*` there are review-specific tools:
 | Diff inspection | `delta` | `git diff --unified=3` |
 | Risk-scored impact + curated review context | code-review-graph: `get_review_context_tool`, `get_impact_radius_tool`, `detect_changes_tool` | `tilth_deps` + manual scoping |
 | Architecture / hotspot framing for large diffs | code-review-graph: `get_architecture_overview_tool`, `get_hub_nodes_tool`, `get_bridge_nodes_tool` | skip and note in confidence |
-| Design rationale for encapsulation/spec dimensions (optional) | hallouminate `ground` on `repo:<repo>:wiki` corpus — if available, ground design intent before grading encapsulation and spec findings | skip; proceed with diff + code evidence only; cap at `speculating` when rationale is the primary evidence |
+| Design rationale for encapsulation/spec dimensions (optional) | `mcp__hallouminate__list_corpora` / `mcp__hallouminate__ground` on `repo:<repo>:wiki` corpus — if available, ground design intent before grading encapsulation and spec findings | skip; proceed with diff + code evidence only; cap at `speculating` when rationale is the primary evidence |
 | GitHub/PR context | `gh` | local git commands or user-provided PR data |
 | Merge/conflict awareness | mergiraf | manual conflict checks |
 

--- a/skills/cheese-factory/SKILL.md
+++ b/skills/cheese-factory/SKILL.md
@@ -106,6 +106,10 @@ Eight phases. The orchestrator walks them top-to-bottom and stops after the last
 | 6 | Post-merge review (fresh-context, ultracook-style) | Three sub-agent spawns: `/press --auto`, `/age --auto`, `/cure --auto --stake medium+`. Single pass. |
 | 7 | PR plan + publish | Heavy PR planner sub-agent decides layout, orchestrator delegates publish via skill discovery (`/pr-stack`, `/gh`, fallbacks) |
 
+### Optional: milknado prerequisite-graph backend
+
+If milknado MCP is available (`mcp__plugin_milknado_milknado__milknado_todo_add` in toolset), persist the curd prerequisite graph to the milknado task graph during Phase 0 decomposition. Use `milknado_todo_add` per curd and `milknado_graph_summary` to surface the dependency order alongside the manifest. This provides cross-session tracking and a visual prerequisite graph. If milknado is absent, proceed with the in-report curd decomposition (manifest YAML at `.cheese/cheese-factory/<slug>/manifest.yaml`) — the decomposition itself is unchanged. See `shared/optional-plugins.md` for the detect-and-degrade contract.
+
 ### Phase 0 — Pre-compile
 
 Read the spec from the argument (or, if `--resume <slug>`, read the manifest and skip to the next incomplete phase).

--- a/skills/cheese-factory/SKILL.md
+++ b/skills/cheese-factory/SKILL.md
@@ -108,7 +108,7 @@ Eight phases. The orchestrator walks them top-to-bottom and stops after the last
 
 ### Optional: milknado prerequisite-graph backend
 
-If milknado MCP is available (`mcp__plugin_milknado_milknado__milknado_todo_add` in toolset), persist the curd prerequisite graph to the milknado task graph during Phase 0 decomposition. Use `milknado_todo_add` per curd and `milknado_graph_summary` to surface the dependency order alongside the manifest. This provides cross-session tracking and a visual prerequisite graph. If milknado is absent, proceed with the in-report curd decomposition (manifest YAML at `.cheese/cheese-factory/<slug>/manifest.yaml`) — the decomposition itself is unchanged. See `shared/optional-plugins.md` for the detect-and-degrade contract.
+If milknado MCP is available (`mcp__plugin_milknado_milknado__milknado_todo_add` in toolset), persist the curd prerequisite graph to the milknado task graph during Phase 0 decomposition. Use `milknado_todo_add` per curd and `milknado_graph_summary` to surface the dependency order alongside the manifest. This provides cross-session tracking and a visual prerequisite graph. If milknado is absent, proceed with the in-report curd decomposition (manifest YAML at `.cheese/cheese-factory/<slug>/manifest.yaml`) — the decomposition itself is unchanged. See [`../../shared/optional-plugins.md`](../../shared/optional-plugins.md) for the detect-and-degrade contract.
 
 ### Phase 0 — Pre-compile
 

--- a/skills/cheese-factory/SKILL.md
+++ b/skills/cheese-factory/SKILL.md
@@ -106,9 +106,9 @@ Eight phases. The orchestrator walks them top-to-bottom and stops after the last
 | 6 | Post-merge review (fresh-context, ultracook-style) | Three sub-agent spawns: `/press --auto`, `/age --auto`, `/cure --auto --stake medium+`. Single pass. |
 | 7 | PR plan + publish | Heavy PR planner sub-agent decides layout, orchestrator delegates publish via skill discovery (`/pr-stack`, `/gh`, fallbacks) |
 
-### Optional: milknado prerequisite-graph backend
+### Optional: milknado curd-tracking backend
 
-If milknado MCP is available (`mcp__milknado__milknado_todo_add` in toolset), persist the curd prerequisite graph to the milknado task graph during Phase 0 decomposition. Use `mcp__milknado__milknado_todo_add` per curd and `mcp__milknado__milknado_graph_summary` to surface the dependency order alongside the manifest. This provides cross-session tracking and a visual prerequisite graph. If milknado is absent, proceed with the in-report curd decomposition (manifest YAML at `.cheese/cheese-factory/<slug>/manifest.yaml`) — the decomposition itself is unchanged. See [`../../shared/optional-plugins.md`](../../shared/optional-plugins.md) for the detect-and-degrade contract.
+If milknado MCP is available (`mcp__milknado__milknado_todo_add` in toolset), persist the curd list to the milknado task graph during Phase 0 decomposition. Use `mcp__milknado__milknado_todo_add` per curd and `mcp__milknado__milknado_graph_summary` to surface the tracked curds alongside the manifest. This provides cross-session tracking of curd status across the factory run. If milknado is absent, proceed with the in-report curd decomposition (manifest YAML at `.cheese/cheese-factory/<slug>/manifest.yaml`) — the decomposition itself is unchanged. See [`../../shared/optional-plugins.md`](../../shared/optional-plugins.md) for the detect-and-degrade contract.
 
 ### Phase 0 — Pre-compile
 

--- a/skills/cheese-factory/SKILL.md
+++ b/skills/cheese-factory/SKILL.md
@@ -108,7 +108,7 @@ Eight phases. The orchestrator walks them top-to-bottom and stops after the last
 
 ### Optional: milknado prerequisite-graph backend
 
-If milknado MCP is available (`mcp__plugin_milknado_milknado__milknado_todo_add` in toolset), persist the curd prerequisite graph to the milknado task graph during Phase 0 decomposition. Use `milknado_todo_add` per curd and `milknado_graph_summary` to surface the dependency order alongside the manifest. This provides cross-session tracking and a visual prerequisite graph. If milknado is absent, proceed with the in-report curd decomposition (manifest YAML at `.cheese/cheese-factory/<slug>/manifest.yaml`) — the decomposition itself is unchanged. See [`../../shared/optional-plugins.md`](../../shared/optional-plugins.md) for the detect-and-degrade contract.
+If milknado MCP is available (`mcp__milknado__milknado_todo_add` in toolset), persist the curd prerequisite graph to the milknado task graph during Phase 0 decomposition. Use `mcp__milknado__milknado_todo_add` per curd and `mcp__milknado__milknado_graph_summary` to surface the dependency order alongside the manifest. This provides cross-session tracking and a visual prerequisite graph. If milknado is absent, proceed with the in-report curd decomposition (manifest YAML at `.cheese/cheese-factory/<slug>/manifest.yaml`) — the decomposition itself is unchanged. See [`../../shared/optional-plugins.md`](../../shared/optional-plugins.md) for the detect-and-degrade contract.
 
 ### Phase 0 — Pre-compile
 

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -86,6 +86,7 @@ Beyond `cheez-*` there are mold-specific tools:
 | Need | Prefer | Fallback |
 | --- | --- | --- |
 | External validation | `/briesearch` with Context7/Tavily | user-provided docs, repo docs, or note as unverified |
+| Wiki grounding (Ground phase) | hallouminate `list_corpora` + `ground` on `repo:<repo>:wiki` — see `references/grounding.md` | skip; proceed with code evidence only; cap at `speculating` when design rationale is central |
 
 Optional tools accelerate the work; missing tools do not block the dialogue. When evidence is unavailable, mark the affected claim `[?]` until settled.
 

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -86,7 +86,7 @@ Beyond `cheez-*` there are mold-specific tools:
 | Need | Prefer | Fallback |
 | --- | --- | --- |
 | External validation | `/briesearch` with Context7/Tavily | user-provided docs, repo docs, or note as unverified |
-| Wiki grounding (Ground phase) | hallouminate `list_corpora` + `ground` on `repo:<repo>:wiki` — see `references/grounding.md` | skip; proceed with code evidence only; cap at `speculating` when design rationale is central |
+| Wiki grounding (Ground phase) | `mcp__hallouminate__list_corpora` + `mcp__hallouminate__ground` on `repo:<repo>:wiki` — see `references/grounding.md` | skip; proceed with code evidence only; cap at `speculating` when design rationale is central |
 
 Optional tools accelerate the work; missing tools do not block the dialogue. When evidence is unavailable, mark the affected claim `[?]` until settled.
 

--- a/skills/mold/references/grounding.md
+++ b/skills/mold/references/grounding.md
@@ -9,18 +9,18 @@ Mirrors the wiki probe pattern from the detect-and-degrade contract in [`../../.
 ```pseudocode
 ground_wiki(topic):
   # 1. Check hallouminate availability.
-  if "mcp__plugin_hallouminate_hallouminate__list_corpora" not in available_tools:
-    note once: "OPTIONAL MCP ABSENT: hallouminate not loaded. Skipping wiki grounding."
+  if "mcp__hallouminate__list_corpora" not in available_tools:
+    note once: "OPTIONAL MCP ABSENT: hallouminate not loaded. Falling back to diff + code evidence only."
     return []
 
   # 2. Find the consumer's wiki corpus (dynamic; their repo, not ours).
-  corpora = hallouminate.list_corpora()
+  corpora = mcp__hallouminate__list_corpora()
   wiki = first(c for c in corpora if c.startswith("repo:") and c.endswith(":wiki"))
   if not wiki:
     return []   # no wiki configured; skip silently
 
   # 3. Ground the topic.
-  results = hallouminate.ground(query=topic, corpus=wiki, limit=5)
+  results = mcp__hallouminate__ground(query=topic, corpus=wiki, limit=5)
   return results
 ```
 

--- a/skills/mold/references/grounding.md
+++ b/skills/mold/references/grounding.md
@@ -1,0 +1,43 @@
+# Grounding — hallouminate wiki probe
+
+During the **Ground** phase of a `/mold` dialogue, if hallouminate is available, probe the consumer's wiki corpus before asking the user the next question. Fold any matching rationale or ADR entries into the evidence base. If hallouminate is absent, skip silently and continue with diff + code evidence only.
+
+## Probe shape
+
+Mirrors the ADR resolution in `adr.md`:
+
+```pseudocode
+ground_wiki(topic):
+  # 1. Check hallouminate availability.
+  if "mcp__plugin_hallouminate_hallouminate__list_corpora" not in available_tools:
+    note once: "OPTIONAL MCP ABSENT: hallouminate not loaded. Skipping wiki grounding."
+    return []
+
+  # 2. Find the consumer's wiki corpus (dynamic; their repo, not ours).
+  corpora = hallouminate.list_corpora()
+  wiki = first(c for c in corpora if c.startswith("repo:") and c.endswith(":wiki"))
+  if not wiki:
+    return []   # no wiki configured; skip silently
+
+  # 3. Ground the topic.
+  results = hallouminate.ground(query=topic, corpus=wiki, limit=5)
+  return results
+```
+
+- The corpus name comes from `list_corpora`, never a literal string — that is the portability invariant (the consumer's repo, not easy-cheese's).
+- If `list_corpora` is unreachable or returns no wiki corpus, fall back silently. Never block the Ground phase on the probe.
+- State the absence once per run if the tool is missing; do not repeat on every question.
+
+## When to probe
+
+Probe once per **Ground** phase entry, before generating the next question, when any of these are true:
+
+- The topic involves a design decision that could have prior rationale (e.g. "why not X").
+- The user references an existing system or module that may have ADRs.
+- The spec being molded overlaps with a prior mold session in this repo.
+
+Skip the probe for pure Explore mode (no named system) and for Diagnose mode (evidence comes from code/logs, not rationale docs).
+
+## Confidence when absent
+
+If hallouminate is absent and design rationale is central to the Ground question, cap at `speculating` and note it inline. See `shared/optional-plugins.md` for the full degrade contract.

--- a/skills/mold/references/grounding.md
+++ b/skills/mold/references/grounding.md
@@ -4,7 +4,7 @@ During the **Ground** phase of a `/mold` dialogue, if hallouminate is available,
 
 ## Probe shape
 
-Mirrors the ADR resolution in `adr.md`:
+Mirrors the wiki probe pattern from the detect-and-degrade contract in [`../../../shared/optional-plugins.md`](../../../shared/optional-plugins.md):
 
 ```pseudocode
 ground_wiki(topic):
@@ -40,4 +40,4 @@ Skip the probe for pure Explore mode (no named system) and for Diagnose mode (ev
 
 ## Confidence when absent
 
-If hallouminate is absent and design rationale is central to the Ground question, cap at `speculating` and note it inline. See `shared/optional-plugins.md` for the full degrade contract.
+If hallouminate is absent and design rationale is central to the Ground question, cap at `speculating` and note it inline. See [`../../../shared/optional-plugins.md`](../../../shared/optional-plugins.md) for the full degrade contract.

--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -53,6 +53,15 @@ Every spawn uses the canonical `/<phase> <slug> --auto` form. Cook accepts a bar
 | 6 | `/cure <slug> --auto --stake medium+`     | `.cheese/cure/<slug>.md` (overwritten) |
 | 7 | `/age <slug> --auto`                      | `.cheese/age/<slug>.md` (final report) |
 
+### Optional: code-review-graph pre-build
+
+Before spawning phase 3 (first `/age`), if code-review-graph MCP is available, call `build_or_update_graph_tool` once from the orchestrator context. This deduplicates the per-sub-agent freshness calls: each age sub-agent would otherwise rebuild the graph on first use, causing redundant work across the three age spawns. If code-review-graph is absent, skip this step and continue — each age sub-agent degrades per `shared/optional-plugins.md`.
+
+```
+if build_or_update_graph_tool in available_tools:
+    build_or_update_graph_tool()   # warm the graph once; age sub-agents reuse it
+# then spawn phase 3
+```
 ### Cap enforcement
 
 The two-cure-pass cap is enforced by **chain length, not by age**. Each age sub-agent boots in fresh context and cannot count prior cure passes, so the contract cannot rely on age tracking the count. Instead:

--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -62,6 +62,7 @@ if build_or_update_graph_tool in available_tools:
     build_or_update_graph_tool()   # warm the graph once; age sub-agents reuse it
 # then spawn phase 3
 ```
+
 ### Cap enforcement
 
 The two-cure-pass cap is enforced by **chain length, not by age**. Each age sub-agent boots in fresh context and cannot count prior cure passes, so the contract cannot rely on age tracking the count. Instead:

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -516,6 +516,58 @@ STUB
     ! grep -q " install --platform " "$STUB_LOG" || false
 }
 
+# -- ec_install_mcp_hallouminate -----------------------------------------------
+
+@test "ec_install_mcp_hallouminate warns and skips for non-claude harness" {
+    run ec_install_mcp_hallouminate cursor
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"only claude-code is auto-registered"* ]]
+}
+
+@test "ec_install_mcp_hallouminate gracefully skips when hallouminate binary missing" {
+    make_stub claude
+    # EC_HALLOUMINATE points at a path that does not exist — detection should warn, not abort.
+    EC_CLAUDE="$STUB_BIN/claude" EC_HALLOUMINATE="$STUB_BIN/no-such-hallouminate" \
+        run ec_install_mcp_hallouminate claude-code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"hallouminate binary not found"* ]]
+}
+
+@test "ec_install_mcp_hallouminate dry-run shows resolved claude and hallouminate paths" {
+    make_stub claude
+    make_stub hallouminate
+    EC_CLAUDE="$STUB_BIN/claude" EC_HALLOUMINATE="$STUB_BIN/hallouminate" EC_DRY_RUN=1 \
+        run ec_install_mcp_hallouminate claude-code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$STUB_BIN/claude mcp add hallouminate -- $STUB_BIN/hallouminate serve"* ]]
+}
+
+# -- ec_install_mcp_milknado ---------------------------------------------------
+
+@test "ec_install_mcp_milknado warns and skips for non-claude harness" {
+    run ec_install_mcp_milknado cursor
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"only claude-code is auto-registered"* ]]
+}
+
+@test "ec_install_mcp_milknado gracefully skips when uvx binary missing" {
+    make_stub claude
+    # EC_UVX points at a path that does not exist — detection should warn, not abort.
+    EC_CLAUDE="$STUB_BIN/claude" EC_UVX="$STUB_BIN/no-such-uvx" \
+        run ec_install_mcp_milknado claude-code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"uvx not found"* ]]
+}
+
+@test "ec_install_mcp_milknado dry-run shows resolved claude and uvx paths" {
+    make_stub claude
+    make_stub uvx
+    EC_CLAUDE="$STUB_BIN/claude" EC_UVX="$STUB_BIN/uvx" EC_DRY_RUN=1 \
+        run ec_install_mcp_milknado claude-code
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$STUB_BIN/claude mcp add milknado -- $STUB_BIN/uvx --from milknado milknado-mcp"* ]]
+}
+
 # -- ec_install_skills --------------------------------------------------------
 
 @test "ec_detect_harnesses finds installed main-line harness CLIs" {

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -531,6 +531,7 @@ STUB
         run ec_install_mcp_hallouminate claude-code
     [ "$status" -eq 0 ]
     [[ "$output" == *"hallouminate binary not found"* ]]
+    ! grep -q "mcp add hallouminate" "$STUB_LOG"
 }
 
 @test "ec_install_mcp_hallouminate dry-run shows resolved claude and hallouminate paths" {
@@ -557,6 +558,7 @@ STUB
         run ec_install_mcp_milknado claude-code
     [ "$status" -eq 0 ]
     [[ "$output" == *"uvx not found"* ]]
+    ! grep -q "mcp add milknado" "$STUB_LOG"
 }
 
 @test "ec_install_mcp_milknado dry-run shows resolved claude and uvx paths" {
@@ -566,6 +568,41 @@ STUB
         run ec_install_mcp_milknado claude-code
     [ "$status" -eq 0 ]
     [[ "$output" == *"$STUB_BIN/claude mcp add milknado -- $STUB_BIN/uvx --from milknado milknado-mcp"* ]]
+}
+
+@test "ec_install_mcp_hallouminate real invocation logs correct argv" {
+    make_stub claude
+    make_stub hallouminate
+    EC_CLAUDE="$STUB_BIN/claude" EC_HALLOUMINATE="$STUB_BIN/hallouminate" \
+        run ec_install_mcp_hallouminate claude-code
+    [ "$status" -eq 0 ]
+    grep -q "^claude mcp add hallouminate -- $STUB_BIN/hallouminate serve$" "$STUB_LOG"
+}
+
+@test "ec_install_mcp_milknado real invocation logs correct argv" {
+    make_stub claude
+    make_stub uvx
+    EC_CLAUDE="$STUB_BIN/claude" EC_UVX="$STUB_BIN/uvx" \
+        run ec_install_mcp_milknado claude-code
+    [ "$status" -eq 0 ]
+    grep -q "^claude mcp add milknado -- $STUB_BIN/uvx --from milknado milknado-mcp$" "$STUB_LOG"
+}
+
+@test "ec_parse_args accepts --mcp hallouminate,milknado" {
+    ec_parse_args --mcp hallouminate,milknado
+    [[ "$EC_MCP" == "hallouminate,milknado" ]]
+}
+
+@test "ec_install_mcp_hallouminate fails when claude CLI missing" {
+    run ec_install_mcp_hallouminate claude-code
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"claude CLI not found"* ]]
+}
+
+@test "ec_install_mcp_milknado fails when claude CLI missing" {
+    run ec_install_mcp_milknado claude-code
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"claude CLI not found"* ]]
 }
 
 # -- ec_install_skills --------------------------------------------------------


### PR DESCRIPTION
## Summary
Wire `milknado` (PyPI/uvx mikado task-graph MCP) and `hallouminate` (Rust wiki MCP) as **optional, gracefully-degrading integrations** across the easy-cheese skill stack — mirroring how `code-review-graph` is already made optional. No integration hard-blocks when the MCP is absent.

## Changes (8 deliverables)
- `shared/optional-plugins.md` (new) — canonical detect→use→degrade contract for the three optional MCPs.
- `scripts/install.sh` — `--mcp hallouminate|milknado` via real runtimes: `claude mcp add milknado -- uvx --from milknado milknado-mcp`; `claude mcp add hallouminate -- hallouminate serve` (binary-on-PATH guard + graceful skip + install hint; `EC_UVX` override). `EC_DEFAULT_MCP` unchanged (opt-in).
- `README.md` — Optional tools rows for both.
- `AGENTS.md` — portability statement names both optional integrations.
- `skills/mold/` — Ground-phase hallouminate wiki grounding (`references/grounding.md`) + Preferred-tools row.
- `skills/age/SKILL.md` — optional hallouminate design-rationale grounding + shared-contract pointer.
- `skills/ultracook/SKILL.md` — optional code-review-graph `build_or_update_graph_tool` pre-build before age 1 (graceful skip).
- `skills/cheese-factory/SKILL.md` — optional milknado mikado-graph backend for the curd dependency graph.

## Decisions
- No `plugin.json` schema change (flat manifest; agentskills.io defines no optional-dep key). Optional-plugin wiring = install.sh + README + skill-level degradation — the existing pattern.
- "Runs the graph" on ultracook = code-review-graph build (not milknado); milknado's mikado graph is the cheese-factory concern.

## Verification
- `bash -n scripts/install.sh`; `--help` lists both; install commands match live `claude mcp list`.
- `validate_skills.py` OK (18 skills); `pytest test_plugin_manifest.py test_pyz_bundle.py` → 54 passed.
- Opus taste-test pass (1 blocker + 1 medium + 1 low found and fixed in f08fa82).
- No `src/` or `.pyz` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)