### PR TITLE
docs(ultracook): make sub-agent contract harness-agnostic

### DIFF
--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -80,7 +80,9 @@ Each phase spawns a **full peer** sub-agent — same model as the parent, full t
 
 Diminutive defaults (haiku model, restricted tools, `Explore`-style read-only workers) will choke phases that need to edit dozens of files or run real test suites.
 
-Concrete `Agent()` signature shape (harness-agnostic; adapt the keyword names to the host):
+The spawn call must satisfy the five invariants (fresh context, full-peer inheritance, no-chain-forward, returns control, writes handoff slug) regardless of harness. For the complete per-harness invocation examples — Claude Code `Agent()`, GitHub Copilot CLI fleets, OpenAI Codex subagents, and the evaluation checklist for new harnesses — see [`../cheese-factory/references/spawn-primitive-reference.md`](../cheese-factory/references/spawn-primitive-reference.md).
+
+Claude Code example (one harness; adapt keyword names on other hosts):
 
 ```
 Agent(


### PR DESCRIPTION
## Summary
Closes the single harness-agnosticism leak found by a parity eval of easy-cheese vs obra/superpowers' subagent skills.

**Eval verdict:** easy-cheese is *ahead* of obra on subagent orchestration — a five-invariant abstract spawn contract, an on-disk handoff-slug schema, no-chain-forward isolation, and post-merge integration review, none of which obra has (obra names the Claude Code `Task tool` directly with no portability abstraction). The lone exception was `ultracook`'s `## Sub-agent contract` section, which embedded only the Claude-Code `Agent()` syntax in its body — stranding readers on other harnesses.

## Change
- `skills/ultracook/SKILL.md` — the sub-agent contract now states the abstract five-invariant requirement, points to `cheese-factory/references/spawn-primitive-reference.md` for the per-harness (Claude Code / Copilot CLI / Codex) spawn syntax, and keeps the CC `Agent()` form only as one clearly-labeled example. Net +3/-1, no per-harness duplication (DRY).

## Verification
- `validate_skills.py` → OK (18 skills).
- Relative pointer path resolves from `skills/ultracook/`.
- No overlap with PR #136's ultracook edit (different section; clean co-merge expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)