### PR TITLE
docs(age): clarify review dimensions for the parent grader

### DIFF
--- a/skills/age/references/dimensions.md
+++ b/skills/age/references/dimensions.md
@@ -61,6 +61,8 @@ Every finding carries these fields:
 | `cross-module` | Reaches into another module's internals (bypasses the public index/crust). |
 | `contract` | Crosses an ingress/egress boundary: slice's public `index` re-exports, HTTP/RPC handler signature, DB schema, language-FFI boundary, plugin extension point, published library API. |
 
+Language-agnostic note: in projects without an explicit public-index layer (flat scripts, no crust / `__init__` re-export surface, as in this repo's `src/melt`, `src/affinage`, `src/mold`, `src/cheese-factory`), treat a direct import of another file's internal function across a directory boundary as `cross-module`, and CLI `argv` / stdin ingress as `contract`.
+
 ## Location sensitivity
 
 The `contract` bump only applies to dimensions where boundary position genuinely changes how bad a finding is:
@@ -95,6 +97,8 @@ Source priority for the raw count:
 2. **CRG `get_impact_radius_tool`** — when code-review-graph is wired. Equivalent blast-radius output.
 3. **LSP `find-references` / `find-callers`** — fallback when neither tilth nor CRG is available.
 
+**Worked recipe.** Given a finding at `path:line`, run `tilth_deps` on the *containing file*. Count the imported-by entries as `--files` and the distinct top-level directories among them as `--modules`, then `python3 shared/scripts/severity.py bucket --files <N> --modules <M>`. Falling back to CRG `get_impact_radius_tool` or LSP callers, count the same way (touched files, distinct module dirs) so buckets stay comparable across tools.
+
 Fix-cost-now is **reported, not bumped**. Severity decides what to fix; fix-cost-now explains effort and lets triage schedule.
 
 ## Fix-cost-later (compounding)
@@ -106,6 +110,23 @@ Fix-cost-now is **reported, not bumped**. Severity decides what to fix; fix-cost
 | `contained` | Cost stays roughly fixed. A typo in a docstring is the same fix in six months. |
 | `spreading` | Cost grows linearly. New code piles onto the bad pattern; each new caller adds one unit of fix work. |
 | `structural` | Cost grows non-linearly. Consumers *harden* against the current shape — types get re-exported, mocks calcify, downstream APIs build on the leak. Public-API leaks, DB-schema mistakes, and ingress-contract violations live here. |
+
+**Decision.** `structural` if the changed symbol is re-exported by any consumer or fixing it requires touching a file outside the diff. `spreading` if the fix is local but the diff adds new callers of the bad shape, or the pattern is being copy-pasted. `contained` otherwise. When two tiers apply, take the higher.
+
+Per-dimension `structural` anchors:
+
+| Dimension | `structural` looks like |
+| --- | --- |
+| correctness | A race or lost write at a public API boundary; consumers harden retry/mock logic around the broken atomicity. |
+| security | A taint path through a published signature; every consumer must re-validate once the contract leaks the unsafe shape. |
+| encapsulation | A leaked internal type re-exported from a slice `index`; downstream slices build on it. |
+| spec | A dropped requirement now baked into downstream behaviour that later code depends on. |
+| complexity | A god module new code keeps landing in; each addition compounds the untangling cost. |
+| deslop | A duplicated block forked across modules; each copy diverges and multiplies the eventual merge. |
+| assertions | A mocked SUT or weak harness other tests copy as the pattern to follow. |
+| nih | A reinvented primitive other modules import; replacing it later means migrating every caller. |
+| efficiency | An unbounded structure on a long-running path; retained references accumulate as callers grow. |
+| telemetry | A hand-rolled logging shape new code standardises on; migrating to the real logger later touches every call site. |
 
 `structural` triggers the compounding `+1` bump in the formula. The point of carrying this tag is to surface "fix now or pay exponentially later" to the user without dressing it up as severity.
 
@@ -124,6 +145,10 @@ Look for: off-by-one, ordering, null/empty edge cases, silent failures, races, c
 | `medium` | Edge case in a flow with a recovery path; null/empty handling that misbehaves on rare input |
 | `low` | Cosmetic edge case in well-bounded leaf code |
 
+Inherited shape: a race, lost write, or contradictory branch already present in the caller graph that the diff's new path now exercises. Expand callers one level before grading clean.
+
+Boundaries: telemetry (no-log failure to here), security (access-control to security), deslop (silent-failure claim to here), efficiency (TOCTOU wrong-data to here), spec (runtime risk to here, contract to spec). Full rules in § Dimension boundaries.
+
 Recommendation shape: "Add a guard for X" / "Return early when Y" / "Replace `catch (_)` with explicit handling".
 
 ### security
@@ -136,6 +161,12 @@ Look for: authN/authZ holes, injection, secrets in source/logs/URLs, tainted inp
 | `high` | Unvalidated input reaches dangerous sink; broken authz on internal route; weak crypto on durable data |
 | `medium` | Tainted input reaches limited surface with secondary validation; missing rate-limit on auth-adjacent route |
 | `low` | Missing defense-in-depth on already-validated input |
+
+Inherited shape: a tainted-input path or missing authz that predates the diff, where the change only adds a new caller of the unsafe sink. Trace the input to its boundary before grading clean.
+
+Definitions: a *dangerous sink* is any call that executes, queries, renders, deserialises, or persists its argument (SQL/shell exec, template render, `eval` / `pickle` / `yaml.load`, file-path open, request to an internal service). *Secondary validation* is an independent check downstream of the sink's entry that constrains the value (a schema parse, an allowlist, a parameterised query) so the tainted value cannot reach the sink unconstrained.
+
+Boundaries: telemetry (secrets-in-logs to security), correctness (access-control to security), nih (reinvented crypto/sanitizer to security). Full rules in § Dimension boundaries.
 
 Recommendation shape: "Validate at the boundary" / "Use the project's existing `<helper>`" / "Move secret to env or vault".
 
@@ -153,6 +184,8 @@ Look for: cross-module reach into internals, public APIs leaking implementation 
 
 Detection signals for the caller-shadowed invariant: a guard defined inside a slice but never called by that slice (only by external entrypoints); N callers each repeating the same check before/after one producer; a public/exported guard whose only consumers sit above the domain layer; asymmetry where some callers apply the check and others skip it. Beware the false-clean trap — this often reads as good Sliced-Bread hygiene (a private helper promoted to public + crust-exported), so a diff-scoped pass grades it clean. The violation is usually *inherited*, not introduced by the diff under review.
 
+Boundaries: deslop (misplaced-invariant dup to encapsulation), complexity (boundary-leaking param to encapsulation). Full rules in § Dimension boundaries.
+
 Note: base tier *is* the location tier here, so the contract bump tends to redundantly raise an already-blocker finding (capped).
 
 Recommendation shape: "Import from `<slice>/index` instead of `<slice>/internal/foo`" / "Narrow the public surface to `<minimal-type>`" / "Move the `<invariant>` into `<producer>` so every caller inherits it; drop the external guard and narrow the public surface".
@@ -168,6 +201,12 @@ Look for: behaviour in the spec but not in the diff, behaviour in the diff but n
 | `medium` | Acceptance criterion partially implemented |
 | `low` | Naming/style drift the user can re-align in 30s |
 
+Inherited shape: a requirement dropped in an earlier commit that the current diff neither restores nor violates outright. Compare against the spec, not only the diff.
+
+Spec resolution: locate the spec before grading. Search order: `.cheese/specs/<slug>.md`, then unresolved items in `.cheese/press/<slug>.md`, then the PR body or linked issue (`gh pr view`), then a commit-message ticket ref. If none resolves, record "no spec located; searched [list]" and grade spec findings `don't know` rather than clean.
+
+Boundaries: correctness (contract commitment to spec, runtime risk to correctness; emit both). Full rules in § Dimension boundaries.
+
 Recommendation shape: "Restore the X requirement" / "Confirm with the user that Y is intentional" / "Update the spec to reflect Z".
 
 ### complexity
@@ -180,7 +219,11 @@ Look for: functions over budget (40 lines / 4 params / 3 nesting), files over 30
 | `medium` | 2× budget, generic helper with one user, redundant cached state |
 | `low` | Few lines over budget, mildly speculative abstraction |
 
-No default `blocker` row — complexity blockers are rare. (Once criticality returns, the floor may push complexity findings up on `critical`-tier paths.)
+Inherited shape: a god function or param-sprawl the diff extends by a few lines rather than introduces. Grade the function as it now stands, not only the added lines.
+
+Boundaries: encapsulation (boundary-leaking param to encapsulation), efficiency (cache decision to complexity, runtime cost to efficiency). Full rules in § Dimension boundaries.
+
+No default `blocker` row, but complexity still *reaches* `blocker`: a base `high` finding with `fix-cost-later: structural` takes the `+1` compounding bump to `blocker`. "No blocker row" means no *base* blocker, not that complexity caps at high. (Once criticality returns, the floor may push complexity findings up on `critical`-tier paths.)
 
 Recommendation shape: "Extract `<sub-function>`" / "Inline `<one-call helper>`" / "Derive `<value>` instead of caching" / "Replace `<string>` with `<enum>`" / "Replace `<vague-name>` with `<concrete-name>`".
 
@@ -193,6 +236,10 @@ Look for: dead code, AI tells (generic catches, useless docstrings, "// TODO: im
 | `high` | Large duplicated logic with diverging behavior; AI residue actively misshapes flow |
 | `medium` | Dead branch left "for reference", duplicated small block, "// TODO: implement" committed |
 | `low` | Vague name; single weak copy-paste |
+
+Inherited shape: duplicated logic or a dead branch the diff copies or leaves untouched beside its change. Read the surrounding block, not only the hunk.
+
+Boundaries: correctness (AI-residue claim to deslop, silent-failure to correctness), nih (existing helper to nih), assertions (generic catch in tests to assertions), encapsulation (misplaced-invariant dup to encapsulation). Full rules in § Dimension boundaries.
 
 No default `blocker` row.
 
@@ -207,9 +254,13 @@ Look for: existence assertions instead of equality, catch-any-error, no-crash-as
 | `blocker` | SUT itself is mocked; test asserts the bug as correct behavior |
 | `high` | Test passes when the implementation is wrong (no-crash-as-success) |
 | `medium` | Catches generic `Exception`; depends on time/random without bounding |
-| `low` | `toBeDefined` where equality is one line away |
+| `low` | `toBeDefined` where equality is one line away (`assert x is not None` where `assert x == <expected>` is one line away) |
 
-Recommendation shape: "Replace `toBeTruthy` with `toEqual(<expected>)`" / "Catch `<specific-error>` not `Exception`".
+Inherited shape: a weak assertion in a touched-but-unmodified test that the diff's behaviour change now leaves under-covering. Read the touched test bodies, not only the diff hunks.
+
+Boundaries: deslop (generic catch in production to deslop), telemetry (asserting on log strings to telemetry). Full rules in § Dimension boundaries.
+
+Recommendation shape: "Replace `toBeTruthy` with `toEqual(<expected>)`" / "Catch `<specific-error>` not `Exception`" / "Replace `assert result` with `assert result == <expected>`" / "Catch `<SpecificError>`, not bare `except:` / `except Exception`".
 
 ### nih
 
@@ -220,6 +271,10 @@ Look for: hand-rolled retry/validation/UUID/debounce/date-parse/argparse/deep-eq
 | `high` | Reinvented logging/telemetry/concurrency primitives the project already wires; reinvented crypto |
 | `medium` | Reinvented retry, debounce, validation, UUID |
 | `low` | Reinvented small util the stdlib already has |
+
+Inherited shape: an in-project helper or dependency already does this; the diff re-implements it because the existing one was not visible from the changed file. Check imports and the helper set before grading clean.
+
+Boundaries: deslop (diff-internal dup to deslop), security (crypto/sanitizer to security), telemetry (custom logger to telemetry), efficiency (algorithm choice to efficiency). Full rules in § Dimension boundaries.
 
 No default `blocker` row.
 
@@ -236,6 +291,10 @@ Look for: unnecessary work, missed concurrency, hot-path bloat, no-op updates, T
 | `medium` | N+1 on a moderate endpoint; redundant compute in a non-hot loop |
 | `low` | Redundant compute outside hot paths |
 
+Inherited shape: an N+1, unbounded structure, or hot-path cost already present that the diff's new call site now triggers. Check whether the changed path runs hot or long-running before grading clean.
+
+Boundaries: nih (import exists to nih), correctness (TOCTOU wrong-data to correctness), complexity (cache decision to complexity). Full rules in § Dimension boundaries.
+
 Recommendation shape: "Hoist `<call>` out of the loop" / "Run `<a>` and `<b>` in parallel with `Promise.all` (or equivalent)" / "Guard the store write on a value change" / "Drop the existence pre-check; handle the error from `<op>` instead" / "Bound `<structure>` or add cleanup on `<teardown>`" / "Read only the needed range/columns".
 
 ### telemetry
@@ -249,9 +308,35 @@ Covers logging, metrics, and tracing hygiene — both **presence** (is the path 
 | `medium` | Silent catch on a non-critical worker; un-instrumented new background loop |
 | `low` | Missing one structured field; wrong level on dev path |
 
+Inherited shape: a silent catch or un-instrumented loop in a touched module that the diff extends rather than introduces. Check the surrounding handler, not only the changed branch.
+
+Boundaries: correctness (no-handling silent failure to correctness), security (secrets-in-logs to security), nih (custom logger to telemetry primary), assertions (log-string asserts to telemetry). Full rules in § Dimension boundaries.
+
 Look for: silent error branches on non-interactive paths; outbound calls without observability; silent daemons/workers/schedulers; missing request/response instrumentation; hand-rolled logging infrastructure; missing operational hygiene (rotation/retention) on new file logging; unstructured/string-concat log messages; wrong log levels; double-logging; errors logged without context; missing correlation/trace ids; high-cardinality metric labels or span names; logs-as-metrics; `print()`/`console.log` left in production; tests asserting on log strings; unbounded list/object dumps into logs.
 
 Recommendation shape: "Emit a structured error log (and a failure counter) in this catch block before re-raising" / "Wrap the outbound `<call>` in a span and add a failure-counter metric" / "Add startup + per-iteration logs to the `<worker>` loop with the failing item id on error" / "Add entry/exit log + latency metric to the new `<handler>`" / "Use the project's existing logger / standard `<stdlib-or-ecosystem-library>` instead of the hand-rolled `<class>`" / "Configure rotation (size + age cap, retention policy) on the new file handler" / "Read log path / level from project config instead of hardcoding" / "Replace string-concat log with structured fields" / "Demote to DEBUG (or drop)" / "Log once at the boundary, not at every catch" / "Add `exc_info=True` (or equivalent) to capture the stack" / "Thread `trace_id` through the log context at the request boundary" / "Move `<high-cardinality-attr>` from metric label to span attribute" / "Emit a counter instead of grepping logs" / "Replace `print()` with the project logger" / "Assert on behavior, not on log text".
+
+## Dimension boundaries
+
+When two dimensions could tag the same `path:line`, this table decides the primary. The per-dimension `Boundaries:` lines point here. The parent grader dedups by `file:line` when writing the report, keeping the higher-base finding and noting the secondary dimension.
+
+| Pair | Tiebreaker |
+| --- | --- |
+| correctness / telemetry | Silent failure with no logging is correctness; telemetry owns it once the failure is caught and the gap is observability. |
+| security / telemetry | Secrets in logs or URLs are security regardless of surrounding code. |
+| security / correctness | A behavioural bug with an access-control consequence tags security; correctness only when there is no security consequence. |
+| security / nih | Reinvented crypto or a security sanitizer tags security (higher base wins); leave nih off to avoid downgrading a blocker through nih's missing blocker row. |
+| deslop / correctness | Tag by the claim: deslop when the primary claim is AI residue, correctness when it is silent failure. |
+| deslop / nih | nih when a pre-existing helper or import already does it; deslop when the duplication is internal to the diff with no existing helper. |
+| deslop / assertions | Generic catches in test files are assertions; in production code they are deslop, correctness, or telemetry per the claim. |
+| nih / telemetry | Custom loggers tag telemetry primary (richer rubric); note the nih angle in the recommendation; do not double-tag. |
+| efficiency / nih | nih when an import or library exists for the primitive; efficiency when it is an algorithm or concurrency choice with no available import. |
+| efficiency / correctness | TOCTOU as wasted work tags efficiency; TOCTOU that can produce wrong data under a race tags correctness. Split by failure mode. |
+| encapsulation / deslop | Duplication caused by a misplaced invariant tags encapsulation (root cause is ownership), not deslop. |
+| encapsulation / complexity | A parameter that leaks context or type across a boundary tags encapsulation; raw param count or threading with no boundary concern tags complexity. |
+| spec / correctness | Emit both with a cross-reference: spec records the broken contract commitment, correctness records the runtime risk. They are orthogonal. |
+| assertions / telemetry | Tests asserting on log strings are telemetry-owned. |
+| complexity / efficiency | Complexity owns the structural decision to cache; efficiency owns the runtime cost of redundant work. |
 
 ## Deferred: criticality inference (v2)
 

--- a/skills/age/references/dimensions.md
+++ b/skills/age/references/dimensions.md
@@ -97,7 +97,7 @@ Source priority for the raw count:
 2. **CRG `get_impact_radius_tool`** — when code-review-graph is wired. Equivalent blast-radius output.
 3. **LSP `find-references` / `find-callers`** — fallback when neither tilth nor CRG is available.
 
-**Worked recipe.** Given a finding at `path:line`, run `tilth_deps` on the *containing file*. Count the imported-by entries as `--files` and the distinct top-level directories among them as `--modules`, then `python3 shared/scripts/severity.py bucket --files <N> --modules <M>`. Falling back to CRG `get_impact_radius_tool` or LSP callers, count the same way (touched files, distinct module dirs) so buckets stay comparable across tools.
+**Worked recipe.** Given a finding at `path:line`, run `tilth_deps` on the *containing file*. Count the **distinct files** in the imported-by set as `--files` — use the `<N> dependents` header count, since the `Used by` list emits one entry per call site and several entries can map to one file (counting raw entries overcounts). Count the **distinct slice/module roots** among them as `--modules` — the directory immediately under `src/` (so `src/melt` and `src/affinage` are two modules, not the shared `src` parent). Then run `python3 shared/scripts/severity.py bucket --files <N> --modules <M>`. Falling back to CRG `get_impact_radius_tool` or LSP callers, count the same way (distinct touched files, distinct module dirs) so buckets stay comparable across tools.
 
 Fix-cost-now is **reported, not bumped**. Severity decides what to fix; fix-cost-now explains effort and lets triage schedule.
 
@@ -147,7 +147,7 @@ Look for: off-by-one, ordering, null/empty edge cases, silent failures, races, c
 
 Inherited shape: a race, lost write, or contradictory branch already present in the caller graph that the diff's new path now exercises. Expand callers one level before grading clean.
 
-Boundaries: telemetry (no-log failure to here), security (access-control to security), deslop (silent-failure claim to here), efficiency (TOCTOU wrong-data to here), spec (runtime risk to here, contract to spec). Full rules in § Dimension boundaries.
+Boundaries: telemetry (no-log failure to here), security (access-control to security), deslop (silent-failure claim to here), efficiency (TOCTOU wrong-data to here), spec (contract commitment to spec, runtime risk to here; emit both). Full rules in § Dimension boundaries.
 
 Recommendation shape: "Add a guard for X" / "Return early when Y" / "Replace `catch (_)` with explicit handling".
 
@@ -203,7 +203,7 @@ Look for: behaviour in the spec but not in the diff, behaviour in the diff but n
 
 Inherited shape: a requirement dropped in an earlier commit that the current diff neither restores nor violates outright. Compare against the spec, not only the diff.
 
-Spec resolution: locate the spec before grading. Search order: `.cheese/specs/<slug>.md`, then unresolved items in `.cheese/press/<slug>.md`, then the PR body or linked issue (`gh pr view`), then a commit-message ticket ref. If none resolves, record "no spec located; searched [list]" and grade spec findings `don't know` rather than clean.
+Spec resolution: locate the spec before grading. Search order: the durable spec corpus via `python3 shared/scripts/paths.py artifact_path specs <slug>` (or `mold.pyz artifact-path specs <slug>`), falling back to the legacy literal `.cheese/specs/<slug>.md` only when the resolver is unavailable (see `shared/formatting.md` § Corpus location; never hardcode `.cheese/specs/`); then unresolved items in `.cheese/press/<slug>.md`, then the PR body or linked issue (`gh pr view`), then a commit-message ticket ref. If none resolves, record "no spec located; searched [list]" and grade spec findings `don't know` rather than clean.
 
 Boundaries: correctness (contract commitment to spec, runtime risk to correctness; emit both). Full rules in § Dimension boundaries.
 
@@ -258,7 +258,7 @@ Look for: existence assertions instead of equality, catch-any-error, no-crash-as
 
 Inherited shape: a weak assertion in a touched-but-unmodified test that the diff's behaviour change now leaves under-covering. Read the touched test bodies, not only the diff hunks.
 
-Boundaries: deslop (generic catch in production to deslop), telemetry (asserting on log strings to telemetry). Full rules in § Dimension boundaries.
+Boundaries: deslop (generic catch in production to deslop, correctness, or telemetry per the claim), telemetry (asserting on log strings to telemetry). Full rules in § Dimension boundaries.
 
 Recommendation shape: "Replace `toBeTruthy` with `toEqual(<expected>)`" / "Catch `<specific-error>` not `Exception`" / "Replace `assert result` with `assert result == <expected>`" / "Catch `<SpecificError>`, not bare `except:` / `except Exception`".
 


### PR DESCRIPTION
## What

Bucket A rubric-clarity improvements to `skills/age/references/dimensions.md`. These sharpen the **single parent grader** `/age` runs today (the contract keeps grading in the parent — `SKILL.md:89`, `sub-agent-gate.md:17`). No code change: `shared/scripts/severity.py` and its tests are untouched.

## Why

A 13-agent audit (11 sonnet dimension assessors → opus synthesis → adversarial critic) found every dimension `needs-additions`. The recurring gaps:

- **Inherited violations slip through.** Only `encapsulation` warned that a violation is "usually inherited, not introduced by the diff." Races, lost writes, duplication, N+1, and weak tests on touched-but-unmodified code are dominantly pre-existing, so a diff-scoped pass grades them clean.
- **`fix-cost-now` was non-reproducible** — the rubric never said which file to pass to `tilth_deps`.
- **`fix-cost-later: structural` had no repeatable test**, yet it flips final severity a full tier.
- **~15 dimension pairs could double-count** the same `path:line`, and the three existing carve-outs lived only on `telemetry`'s side.

## Changes

- Shared "expand scope one level" principle + an `Inherited shape:` line on the nine dimensions that lacked one (encapsulation keeps its fuller note as the exemplar).
- Worked blast-radius recipe in § Fix-cost-now.
- Structural-vs-spreading decision tree + per-dimension `structural` anchor table in § Fix-cost-later.
- New `## Dimension boundaries` matrix (source of truth) + terse per-dimension `Boundaries:` cues so a stateless reader sees the tiebreaker without scrolling.
- Spec-resolution order (§ spec), language-agnostic location note for flat-Python repos (§ Location classification), `dangerous sink` / `secondary validation` definitions (§ security), pytest assertion examples (§ assertions), and a correction to complexity's "no blocker row" note (reachable via the structural bump).

## Verification

- `markdownlint-cli2` clean (0 errors).
- `tests/shared/python/test_severity.py` passes (29) — formula unchanged.
- Self-check: 9 `Inherited shape:` lines + 10 `Boundaries:` lines; every per-dimension cue maps to a matrix row and back.

## Scope

Bucket B (per-dimension sonnet fan-out, shared context packet, dedup/freshness ownership) is **deferred** to its own spec — it would require a SKILL.md + sub-agent-gate.md contract change to authorize delegated grading. Rationale captured in the audit notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)