### PR TITLE
feat(age): scale-triggered per-dimension fan-out mode (Bucket B)

### DIFF
--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -50,7 +50,7 @@ Per-dimension base-severity tables, location-sensitivity, fix-cost-now / fix-cos
 
 ## Flow
 
-1. Identify the diff, scope, and relevant spec or issue.
+1. Identify the diff, scope, and relevant spec or issue. **Mode check (one decision point):** if the scale threshold is met — `(diff > 15 files) OR (review context > ~25 KB) OR (caller graph crosses multiple subsystems)` — and `/age` is not itself a sub-agent, switch to `### Scale-triggered fan-out mode`; steps 2–6 are the single-parent path only.
 2. Gather evidence: diff, touched files, tests, callers/imports. If `.cheese/press/<slug>.md` exists, read it and include a `## Press findings` sub-section in the age report summarising unresolved items — `/cure` reads only `.cheese/age/<slug>.md` and cannot access the press report directly.
 3. Review every dimension; dimensions with no findings simply omit themselves.
 4. Compute severity per finding (base + location bump + compounding bump, capped at `blocker`). Group findings by severity (`## Blocker → ## High → ## Medium → ## Low`); within a severity group, order by file.
@@ -86,10 +86,30 @@ Spawn when any of these are true:
 - Caller / dependency graph expansion crosses multiple subsystems.
 - code-review-graph or `tilth_deps` output is needed for hotspot, bridge-node, or blast-radius framing.
 
-The sub-agent returns a digest: orientation paragraph, high-signal `path:line` citations, gap list. The parent owns the ten-dimension review, severity grading, and the `.cheese/age/<slug>.md` report. Do not spawn for small diffs, to outsource severity grading, or to outsource the final verdict.
+The sub-agent returns a digest: orientation paragraph, high-signal `path:line` citations, gap list. In single-parent mode (below threshold), the parent owns the ten-dimension review, severity grading, and the `.cheese/age/<slug>.md` report — do not spawn for small diffs, to outsource severity grading, or to outsource the final verdict. In fan-out mode, per-dimension severity is delegated to workers; the parent retains cross-dimension reconciliation, the final verdict, and the report — see `### Scale-triggered fan-out mode` below.
 
 Digest size, parent-vs-sub-agent split, and harness-agnostic sub-agent selection live in `references/sub-agent-gate.md` — single source of truth for the cross-cutting rules.
 
+### Scale-triggered fan-out mode
+
+Activates when **all** hold: the size threshold above is met AND `/age` is not itself a sub-agent (no `invoked-from:` marker). Below threshold, or when running as a sub-agent, the single-parent path applies unchanged.
+
+**Seam 1 — Predicate.** Fan out when `(diff > 15 files) OR (review context > ~25 KB) OR (caller graph crosses multiple subsystems)` — the threshold from `## Sub-agent context gate`, reused verbatim — AND `/age` is not itself a sub-agent.
+
+**Seam 2 — Shared context packet.** The orchestrator assembles the packet once and writes it to `.cheese/age/<slug>-packet.md` (transient — rebuilt every run, no cross-run cache). Each worker reads this file. Eight components are documented in `references/packet.md`. The existing review-context digester above is reused as the packet's orientation + citations block — not duplicated.
+
+**Seam 3 — Worker contract.** One worker per dimension. Each worker:
+- Reviews only its assigned dimension.
+- Computes **full per-finding severity** for that dimension (base + location bump + compounding bump).
+- Tags each finding with its dimension and an `also-relevant-to: [<dim>, ...]` field when cross-dimension overlap is suspected.
+- Returns a ≤~2 KB digest per `references/sub-agent-gate.md § Digest contract`.
+- Does **not** dedup, apply boundary tiebreakers, reconcile severity across dimensions, or write the report.
+
+**Seam 4 — Orchestrator reconciliation.** After all workers return: collect findings; for any `file:line` flagged by two or more workers, apply the `## Dimension boundaries` table (`references/dimensions.md:319–340`) verbatim — keep the higher-base finding / suppress / emit-both-with-cross-reference per the 15 tiebreaker rules. The pass touches only colliding lines. Group by severity; write `.cheese/age/<slug>.md`. The parent owns the canonical artifact.
+
+**Seam 5 — Graph freshness.** The orchestrator calls `build_or_update_graph_tool` **once** before fan-out (per `## Preferred tools and fallbacks` above). The packet carries a "graph fresh as of this run" marker. Workers never call `build_or_update_graph_tool`.
+
+**Output mode-invariance (invariant).** The findings report (`.cheese/age/<slug>.md`) is identical in shape — same dedup rule, same severity grouping, same finding format — whether produced by the single-parent path or fan-out mode. Only the internal execution path differs. (Mirrors the inline-degrade invariant at `### Inline-degrade mode` below.)
 ## Output
 
 Cross-cutting house style and citation form: [`../../shared/formatting.md`](../../shared/formatting.md). This section owns the findings-report shape; formatting.md owns the voice rules and the footnote primitive.
@@ -236,7 +256,7 @@ Detection mechanism: scan the invoking prompt for an `invoked-from:` line — va
 - Output (the findings report + handoff slug) is identical between fan-out and inline-degrade modes — only the internal execution differs.
 - Honour the no-chain-forward directive as usual: write the slug and stop. Do not invoke `/cure` from the sub-agent — the orchestrator owns the chain.
 
-Inline-degrade is forced when the marker is present; there is no opt-out. Spawning a deeper sub-agent from inside a curd worker can exceed the harness's nesting limit and fail silently — the marker is the only honest signal that the parent has already consumed the available depth.
+Inline-degrade is forced when the marker is present; there is no opt-out. Even above the scale-triggered fan-out threshold, the marker takes precedence — fan-out is forbidden when `/age` runs as a sub-agent because the harness nesting depth is already consumed. Spawning a deeper sub-agent from inside a curd worker can exceed the harness's nesting limit and fail silently — the marker is the only honest signal that the parent has already consumed the available depth.
 
 ## Rules
 

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -50,7 +50,7 @@ Per-dimension base-severity tables, location-sensitivity, fix-cost-now / fix-cos
 
 ## Flow
 
-1. Identify the diff, scope, and relevant spec or issue. **Mode check (one decision point):** if the scale threshold is met — `(diff > 15 files) OR (review context > ~25 KB) OR (caller graph crosses multiple subsystems)` — and `/age` is not itself a sub-agent, switch to `### Scale-triggered fan-out mode`; steps 2–6 are the single-parent path only.
+1. Identify the diff, scope, and relevant spec or issue. **Mode check (one decision point):** if the scale threshold is met — `(diff > 15 files) OR (review context > ~25 KB) OR (caller graph crosses multiple subsystems)` — and `/age` is not itself a sub-agent, switch to `### Scale-triggered fan-out mode`; steps 2–4 (evidence-gather, per-dimension review, severity computation) are replaced by the fan-out path — both modes converge on steps 5–6.
 2. Gather evidence: diff, touched files, tests, callers/imports. If `.cheese/press/<slug>.md` exists, read it and include a `## Press findings` sub-section in the age report summarising unresolved items — `/cure` reads only `.cheese/age/<slug>.md` and cannot access the press report directly.
 3. Review every dimension; dimensions with no findings simply omit themselves.
 4. Compute severity per finding (base + location bump + compounding bump, capped at `blocker`). Group findings by severity (`## Blocker → ## High → ## Medium → ## Low`); within a severity group, order by file.
@@ -102,14 +102,15 @@ Activates when **all** hold: the size threshold above is met AND `/age` is not i
 - Reviews only its assigned dimension.
 - Computes **full per-finding severity** for that dimension (base + location bump + compounding bump).
 - Tags each finding with its dimension and an `also-relevant-to: [<dim>, ...]` field when cross-dimension overlap is suspected.
-- Returns a ≤~2 KB digest per `references/sub-agent-gate.md § Digest contract`.
+- Returns its dimension's findings as full per-finding rows in the `SKILL.md § Output` finding format (`**[dim:sev]** path:line — claim` + `location / fix-cost-now / fix-cost-later` + `recommendation`). Not an orientation digest — the `§ Digest contract` size ceiling does not apply.
 - Does **not** dedup, apply boundary tiebreakers, reconcile severity across dimensions, or write the report.
 
-**Seam 4 — Orchestrator reconciliation.** After all workers return: collect findings; for any `file:line` flagged by two or more workers, apply the `## Dimension boundaries` table (`references/dimensions.md:319–340`) verbatim — keep the higher-base finding / suppress / emit-both-with-cross-reference per the 15 tiebreaker rules. The pass touches only colliding lines. Group by severity; write `.cheese/age/<slug>.md`. The parent owns the canonical artifact.
+**Seam 4 — Orchestrator reconciliation.** After all workers return, apply the `## Dimension boundaries` table (`references/dimensions.md:319-340`) verbatim to any line meeting EITHER condition: (1) flagged by two or more workers at the same `file:line`; (2) tagged `also-relevant-to: [d]` by any worker — the orchestrator re-evaluates dimension `d` against that line and applies the tiebreaker (keep the higher-base finding / suppress / emit-both-with-cross-reference per the 15 rules). This consumes the `also-relevant-to` signal and provides the cross-dimension coverage single-parent gets for free. Lines neither flagged by ≥2 workers nor tagged `also-relevant-to` need no reconciliation. Group by severity. The parent owns the canonical artifact. After reconciliation, continue at step 5 (write + print the report path) and `## Handoff` exactly as the single-parent path does.
 
-**Seam 5 — Graph freshness.** The orchestrator calls `build_or_update_graph_tool` **once** before fan-out (per `## Preferred tools and fallbacks` above). The packet carries a "graph fresh as of this run" marker. Workers never call `build_or_update_graph_tool`.
+**Seam 5 — Graph freshness.** The orchestrator calls `build_or_update_graph_tool` **once** before fan-out (per `## Preferred tools and fallbacks` above). The packet carries a "graph fresh as of this run" marker. Workers never call `build_or_update_graph_tool`, but they MAY issue read-only code-review-graph queries (e.g. `get_impact_radius_tool`, `get_review_context_tool`, `get_hub_nodes_tool`, `get_bridge_nodes_tool`) against the pre-built graph for impact and hotspot framing — the same evidence the single-parent path uses for large diffs.
 
 **Output mode-invariance (invariant).** The findings report (`.cheese/age/<slug>.md`) is identical in shape — same dedup rule, same severity grouping, same finding format — whether produced by the single-parent path or fan-out mode. Only the internal execution path differs. (Mirrors the inline-degrade invariant at `### Inline-degrade mode` below.)
+
 ## Output
 
 Cross-cutting house style and citation form: [`../../shared/formatting.md`](../../shared/formatting.md). This section owns the findings-report shape; formatting.md owns the voice rules and the footnote primitive.

--- a/skills/age/references/dimensions.md
+++ b/skills/age/references/dimensions.md
@@ -318,7 +318,7 @@ Recommendation shape: "Emit a structured error log (and a failure counter) in th
 
 ## Dimension boundaries
 
-When two dimensions could tag the same `path:line`, this table decides the primary. The per-dimension `Boundaries:` lines point here. The parent grader dedups by `file:line` when writing the report, keeping the higher-base finding and noting the secondary dimension.
+When two dimensions could tag the same `path:line`, this table decides the primary. The per-dimension `Boundaries:` lines point here. The grader dedups by `file:line` when writing the report, keeping the higher-base finding and noting the secondary dimension.
 
 | Pair | Tiebreaker |
 | --- | --- |

--- a/skills/age/references/dimensions.md
+++ b/skills/age/references/dimensions.md
@@ -61,6 +61,8 @@ Every finding carries these fields:
 | `cross-module` | Reaches into another module's internals (bypasses the public index/crust). |
 | `contract` | Crosses an ingress/egress boundary: slice's public `index` re-exports, HTTP/RPC handler signature, DB schema, language-FFI boundary, plugin extension point, published library API. |
 
+Language-agnostic note: in projects without an explicit public-index layer (flat scripts, no crust / `__init__` re-export surface, as in this repo's `src/melt`, `src/affinage`, `src/mold`, `src/cheese-factory`), treat a direct import of another file's internal function across a directory boundary as `cross-module`, and CLI `argv` / stdin ingress as `contract`.
+
 ## Location sensitivity
 
 The `contract` bump only applies to dimensions where boundary position genuinely changes how bad a finding is:
@@ -95,6 +97,8 @@ Source priority for the raw count:
 2. **CRG `get_impact_radius_tool`** — when code-review-graph is wired. Equivalent blast-radius output.
 3. **LSP `find-references` / `find-callers`** — fallback when neither tilth nor CRG is available.
 
+**Worked recipe.** Given a finding at `path:line`, run `tilth_deps` on the *containing file*. Count the imported-by entries as `--files` and the distinct top-level directories among them as `--modules`, then `python3 shared/scripts/severity.py bucket --files <N> --modules <M>`. Falling back to CRG `get_impact_radius_tool` or LSP callers, count the same way (touched files, distinct module dirs) so buckets stay comparable across tools.
+
 Fix-cost-now is **reported, not bumped**. Severity decides what to fix; fix-cost-now explains effort and lets triage schedule.
 
 ## Fix-cost-later (compounding)
@@ -106,6 +110,23 @@ Fix-cost-now is **reported, not bumped**. Severity decides what to fix; fix-cost
 | `contained` | Cost stays roughly fixed. A typo in a docstring is the same fix in six months. |
 | `spreading` | Cost grows linearly. New code piles onto the bad pattern; each new caller adds one unit of fix work. |
 | `structural` | Cost grows non-linearly. Consumers *harden* against the current shape — types get re-exported, mocks calcify, downstream APIs build on the leak. Public-API leaks, DB-schema mistakes, and ingress-contract violations live here. |
+
+**Decision.** `structural` if the changed symbol is re-exported by any consumer or fixing it requires touching a file outside the diff. `spreading` if the fix is local but the diff adds new callers of the bad shape, or the pattern is being copy-pasted. `contained` otherwise. When two tiers apply, take the higher.
+
+Per-dimension `structural` anchors:
+
+| Dimension | `structural` looks like |
+| --- | --- |
+| correctness | A race or lost write at a public API boundary; consumers harden retry/mock logic around the broken atomicity. |
+| security | A taint path through a published signature; every consumer must re-validate once the contract leaks the unsafe shape. |
+| encapsulation | A leaked internal type re-exported from a slice `index`; downstream slices build on it. |
+| spec | A dropped requirement now baked into downstream behaviour that later code depends on. |
+| complexity | A god module new code keeps landing in; each addition compounds the untangling cost. |
+| deslop | A duplicated block forked across modules; each copy diverges and multiplies the eventual merge. |
+| assertions | A mocked SUT or weak harness other tests copy as the pattern to follow. |
+| nih | A reinvented primitive other modules import; replacing it later means migrating every caller. |
+| efficiency | An unbounded structure on a long-running path; retained references accumulate as callers grow. |
+| telemetry | A hand-rolled logging shape new code standardises on; migrating to the real logger later touches every call site. |
 
 `structural` triggers the compounding `+1` bump in the formula. The point of carrying this tag is to surface "fix now or pay exponentially later" to the user without dressing it up as severity.
 
@@ -124,6 +145,10 @@ Look for: off-by-one, ordering, null/empty edge cases, silent failures, races, c
 | `medium` | Edge case in a flow with a recovery path; null/empty handling that misbehaves on rare input |
 | `low` | Cosmetic edge case in well-bounded leaf code |
 
+Inherited shape: a race, lost write, or contradictory branch already present in the caller graph that the diff's new path now exercises. Expand callers one level before grading clean.
+
+Boundaries: telemetry (no-log failure to here), security (access-control to security), deslop (silent-failure claim to here), efficiency (TOCTOU wrong-data to here), spec (runtime risk to here, contract to spec). Full rules in § Dimension boundaries.
+
 Recommendation shape: "Add a guard for X" / "Return early when Y" / "Replace `catch (_)` with explicit handling".
 
 ### security
@@ -136,6 +161,12 @@ Look for: authN/authZ holes, injection, secrets in source/logs/URLs, tainted inp
 | `high` | Unvalidated input reaches dangerous sink; broken authz on internal route; weak crypto on durable data |
 | `medium` | Tainted input reaches limited surface with secondary validation; missing rate-limit on auth-adjacent route |
 | `low` | Missing defense-in-depth on already-validated input |
+
+Inherited shape: a tainted-input path or missing authz that predates the diff, where the change only adds a new caller of the unsafe sink. Trace the input to its boundary before grading clean.
+
+Definitions: a *dangerous sink* is any call that executes, queries, renders, deserialises, or persists its argument (SQL/shell exec, template render, `eval` / `pickle` / `yaml.load`, file-path open, request to an internal service). *Secondary validation* is an independent check downstream of the sink's entry that constrains the value (a schema parse, an allowlist, a parameterised query) so the tainted value cannot reach the sink unconstrained.
+
+Boundaries: telemetry (secrets-in-logs to security), correctness (access-control to security), nih (reinvented crypto/sanitizer to security). Full rules in § Dimension boundaries.
 
 Recommendation shape: "Validate at the boundary" / "Use the project's existing `<helper>`" / "Move secret to env or vault".
 
@@ -153,6 +184,8 @@ Look for: cross-module reach into internals, public APIs leaking implementation 
 
 Detection signals for the caller-shadowed invariant: a guard defined inside a slice but never called by that slice (only by external entrypoints); N callers each repeating the same check before/after one producer; a public/exported guard whose only consumers sit above the domain layer; asymmetry where some callers apply the check and others skip it. Beware the false-clean trap — this often reads as good Sliced-Bread hygiene (a private helper promoted to public + crust-exported), so a diff-scoped pass grades it clean. The violation is usually *inherited*, not introduced by the diff under review.
 
+Boundaries: deslop (misplaced-invariant dup to encapsulation), complexity (boundary-leaking param to encapsulation). Full rules in § Dimension boundaries.
+
 Note: base tier *is* the location tier here, so the contract bump tends to redundantly raise an already-blocker finding (capped).
 
 Recommendation shape: "Import from `<slice>/index` instead of `<slice>/internal/foo`" / "Narrow the public surface to `<minimal-type>`" / "Move the `<invariant>` into `<producer>` so every caller inherits it; drop the external guard and narrow the public surface".
@@ -168,6 +201,12 @@ Look for: behaviour in the spec but not in the diff, behaviour in the diff but n
 | `medium` | Acceptance criterion partially implemented |
 | `low` | Naming/style drift the user can re-align in 30s |
 
+Inherited shape: a requirement dropped in an earlier commit that the current diff neither restores nor violates outright. Compare against the spec, not only the diff.
+
+Spec resolution: locate the spec before grading. Search order: `.cheese/specs/<slug>.md`, then unresolved items in `.cheese/press/<slug>.md`, then the PR body or linked issue (`gh pr view`), then a commit-message ticket ref. If none resolves, record "no spec located; searched [list]" and grade spec findings `don't know` rather than clean.
+
+Boundaries: correctness (contract commitment to spec, runtime risk to correctness; emit both). Full rules in § Dimension boundaries.
+
 Recommendation shape: "Restore the X requirement" / "Confirm with the user that Y is intentional" / "Update the spec to reflect Z".
 
 ### complexity
@@ -180,7 +219,11 @@ Look for: functions over budget (40 lines / 4 params / 3 nesting), files over 30
 | `medium` | 2× budget, generic helper with one user, redundant cached state |
 | `low` | Few lines over budget, mildly speculative abstraction |
 
-No default `blocker` row — complexity blockers are rare. (Once criticality returns, the floor may push complexity findings up on `critical`-tier paths.)
+Inherited shape: a god function or param-sprawl the diff extends by a few lines rather than introduces. Grade the function as it now stands, not only the added lines.
+
+Boundaries: encapsulation (boundary-leaking param to encapsulation), efficiency (cache decision to complexity, runtime cost to efficiency). Full rules in § Dimension boundaries.
+
+No default `blocker` row, but complexity still *reaches* `blocker`: a base `high` finding with `fix-cost-later: structural` takes the `+1` compounding bump to `blocker`. "No blocker row" means no *base* blocker, not that complexity caps at high. (Once criticality returns, the floor may push complexity findings up on `critical`-tier paths.)
 
 Recommendation shape: "Extract `<sub-function>`" / "Inline `<one-call helper>`" / "Derive `<value>` instead of caching" / "Replace `<string>` with `<enum>`" / "Replace `<vague-name>` with `<concrete-name>`".
 
@@ -193,6 +236,10 @@ Look for: dead code, AI tells (generic catches, useless docstrings, "// TODO: im
 | `high` | Large duplicated logic with diverging behavior; AI residue actively misshapes flow |
 | `medium` | Dead branch left "for reference", duplicated small block, "// TODO: implement" committed |
 | `low` | Vague name; single weak copy-paste |
+
+Inherited shape: duplicated logic or a dead branch the diff copies or leaves untouched beside its change. Read the surrounding block, not only the hunk.
+
+Boundaries: correctness (AI-residue claim to deslop, silent-failure to correctness), nih (existing helper to nih), assertions (generic catch in tests to assertions), encapsulation (misplaced-invariant dup to encapsulation). Full rules in § Dimension boundaries.
 
 No default `blocker` row.
 
@@ -207,9 +254,13 @@ Look for: existence assertions instead of equality, catch-any-error, no-crash-as
 | `blocker` | SUT itself is mocked; test asserts the bug as correct behavior |
 | `high` | Test passes when the implementation is wrong (no-crash-as-success) |
 | `medium` | Catches generic `Exception`; depends on time/random without bounding |
-| `low` | `toBeDefined` where equality is one line away |
+| `low` | `toBeDefined` where equality is one line away (`assert x is not None` where `assert x == <expected>` is one line away) |
 
-Recommendation shape: "Replace `toBeTruthy` with `toEqual(<expected>)`" / "Catch `<specific-error>` not `Exception`".
+Inherited shape: a weak assertion in a touched-but-unmodified test that the diff's behaviour change now leaves under-covering. Read the touched test bodies, not only the diff hunks.
+
+Boundaries: deslop (generic catch in production to deslop), telemetry (asserting on log strings to telemetry). Full rules in § Dimension boundaries.
+
+Recommendation shape: "Replace `toBeTruthy` with `toEqual(<expected>)`" / "Catch `<specific-error>` not `Exception`" / "Replace `assert result` with `assert result == <expected>`" / "Catch `<SpecificError>`, not bare `except:` / `except Exception`".
 
 ### nih
 
@@ -220,6 +271,10 @@ Look for: hand-rolled retry/validation/UUID/debounce/date-parse/argparse/deep-eq
 | `high` | Reinvented logging/telemetry/concurrency primitives the project already wires; reinvented crypto |
 | `medium` | Reinvented retry, debounce, validation, UUID |
 | `low` | Reinvented small util the stdlib already has |
+
+Inherited shape: an in-project helper or dependency already does this; the diff re-implements it because the existing one was not visible from the changed file. Check imports and the helper set before grading clean.
+
+Boundaries: deslop (diff-internal dup to deslop), security (crypto/sanitizer to security), telemetry (custom logger to telemetry), efficiency (algorithm choice to efficiency). Full rules in § Dimension boundaries.
 
 No default `blocker` row.
 
@@ -236,6 +291,10 @@ Look for: unnecessary work, missed concurrency, hot-path bloat, no-op updates, T
 | `medium` | N+1 on a moderate endpoint; redundant compute in a non-hot loop |
 | `low` | Redundant compute outside hot paths |
 
+Inherited shape: an N+1, unbounded structure, or hot-path cost already present that the diff's new call site now triggers. Check whether the changed path runs hot or long-running before grading clean.
+
+Boundaries: nih (import exists to nih), correctness (TOCTOU wrong-data to correctness), complexity (cache decision to complexity). Full rules in § Dimension boundaries.
+
 Recommendation shape: "Hoist `<call>` out of the loop" / "Run `<a>` and `<b>` in parallel with `Promise.all` (or equivalent)" / "Guard the store write on a value change" / "Drop the existence pre-check; handle the error from `<op>` instead" / "Bound `<structure>` or add cleanup on `<teardown>`" / "Read only the needed range/columns".
 
 ### telemetry
@@ -249,9 +308,35 @@ Covers logging, metrics, and tracing hygiene — both **presence** (is the path 
 | `medium` | Silent catch on a non-critical worker; un-instrumented new background loop |
 | `low` | Missing one structured field; wrong level on dev path |
 
+Inherited shape: a silent catch or un-instrumented loop in a touched module that the diff extends rather than introduces. Check the surrounding handler, not only the changed branch.
+
+Boundaries: correctness (no-handling silent failure to correctness), security (secrets-in-logs to security), nih (custom logger to telemetry primary), assertions (log-string asserts to telemetry). Full rules in § Dimension boundaries.
+
 Look for: silent error branches on non-interactive paths; outbound calls without observability; silent daemons/workers/schedulers; missing request/response instrumentation; hand-rolled logging infrastructure; missing operational hygiene (rotation/retention) on new file logging; unstructured/string-concat log messages; wrong log levels; double-logging; errors logged without context; missing correlation/trace ids; high-cardinality metric labels or span names; logs-as-metrics; `print()`/`console.log` left in production; tests asserting on log strings; unbounded list/object dumps into logs.
 
 Recommendation shape: "Emit a structured error log (and a failure counter) in this catch block before re-raising" / "Wrap the outbound `<call>` in a span and add a failure-counter metric" / "Add startup + per-iteration logs to the `<worker>` loop with the failing item id on error" / "Add entry/exit log + latency metric to the new `<handler>`" / "Use the project's existing logger / standard `<stdlib-or-ecosystem-library>` instead of the hand-rolled `<class>`" / "Configure rotation (size + age cap, retention policy) on the new file handler" / "Read log path / level from project config instead of hardcoding" / "Replace string-concat log with structured fields" / "Demote to DEBUG (or drop)" / "Log once at the boundary, not at every catch" / "Add `exc_info=True` (or equivalent) to capture the stack" / "Thread `trace_id` through the log context at the request boundary" / "Move `<high-cardinality-attr>` from metric label to span attribute" / "Emit a counter instead of grepping logs" / "Replace `print()` with the project logger" / "Assert on behavior, not on log text".
+
+## Dimension boundaries
+
+When two dimensions could tag the same `path:line`, this table decides the primary. The per-dimension `Boundaries:` lines point here. The parent grader dedups by `file:line` when writing the report, keeping the higher-base finding and noting the secondary dimension.
+
+| Pair | Tiebreaker |
+| --- | --- |
+| correctness / telemetry | Silent failure with no logging is correctness; telemetry owns it once the failure is caught and the gap is observability. |
+| security / telemetry | Secrets in logs or URLs are security regardless of surrounding code. |
+| security / correctness | A behavioural bug with an access-control consequence tags security; correctness only when there is no security consequence. |
+| security / nih | Reinvented crypto or a security sanitizer tags security (higher base wins); leave nih off to avoid downgrading a blocker through nih's missing blocker row. |
+| deslop / correctness | Tag by the claim: deslop when the primary claim is AI residue, correctness when it is silent failure. |
+| deslop / nih | nih when a pre-existing helper or import already does it; deslop when the duplication is internal to the diff with no existing helper. |
+| deslop / assertions | Generic catches in test files are assertions; in production code they are deslop, correctness, or telemetry per the claim. |
+| nih / telemetry | Custom loggers tag telemetry primary (richer rubric); note the nih angle in the recommendation; do not double-tag. |
+| efficiency / nih | nih when an import or library exists for the primitive; efficiency when it is an algorithm or concurrency choice with no available import. |
+| efficiency / correctness | TOCTOU as wasted work tags efficiency; TOCTOU that can produce wrong data under a race tags correctness. Split by failure mode. |
+| encapsulation / deslop | Duplication caused by a misplaced invariant tags encapsulation (root cause is ownership), not deslop. |
+| encapsulation / complexity | A parameter that leaks context or type across a boundary tags encapsulation; raw param count or threading with no boundary concern tags complexity. |
+| spec / correctness | Emit both with a cross-reference: spec records the broken contract commitment, correctness records the runtime risk. They are orthogonal. |
+| assertions / telemetry | Tests asserting on log strings are telemetry-owned. |
+| complexity / efficiency | Complexity owns the structural decision to cache; efficiency owns the runtime cost of redundant work. |
 
 ## Deferred: criticality inference (v2)
 

--- a/skills/age/references/packet.md
+++ b/skills/age/references/packet.md
@@ -8,7 +8,7 @@ The orchestrator assembles this packet once per fan-out run and writes it to `.c
 2. **Dependency manifest contents** — `package.json`, `Cargo.toml`, `pyproject.toml`, or equivalent for the project under review.
 3. **Project-helper index** — one `tilth_search` for `sanitize / validate / escape / safe / retry / debounce / logger` across `src/` and `shared/`, so workers can flag NIH or missing helper usage.
 4. **Path-context map** — which entrypoints are non-interactive or hot (servers, daemons, CLI handlers, outbound callers); workers need this for location classification and telemetry coverage.
-5. **Per-dimension rubric slice + shared formula sections** — the worker's assigned dimension rubric from `references/dimensions.md`, plus `§ Location sensitivity`, `§ Fix-cost-now`, and `§ Fix-cost-later` so each worker can compute severity independently.
+5. **Per-dimension rubric slice + shared formula sections** — the worker's assigned dimension rubric from `references/dimensions.md`, plus `§ Location sensitivity`, `§ Fix-cost-now`, and `§ Fix-cost-later` so each worker can compute severity independently. Extract from the dimension's `## <Dimension name>` heading to the next `##` heading.
 6. **The severity machinery** — the full `§ Severity computation` section.
 7. **Output contract** — the per-finding fields table and finding format from `SKILL.md § Output`, so workers emit full per-finding rows the orchestrator can parse unambiguously.
 8. **Dedup-ownership statement** — explicit: workers do NOT dedup, apply boundary tiebreakers, reconcile severity across dimensions, or write the report. The orchestrator owns those steps (Seam 4).

--- a/skills/age/references/packet.md
+++ b/skills/age/references/packet.md
@@ -8,9 +8,9 @@ The orchestrator assembles this packet once per fan-out run and writes it to `.c
 2. **Dependency manifest contents** — `package.json`, `Cargo.toml`, `pyproject.toml`, or equivalent for the project under review.
 3. **Project-helper index** — one `tilth_search` for `sanitize / validate / escape / safe / retry / debounce / logger` across `src/` and `shared/`, so workers can flag NIH or missing helper usage.
 4. **Path-context map** — which entrypoints are non-interactive or hot (servers, daemons, CLI handlers, outbound callers); workers need this for location classification and telemetry coverage.
-5. **Per-dimension rubric slice + shared formula sections** — the worker's assigned dimension rubric from `references/dimensions.md`, plus the shared `§ Severity computation`, `§ Location sensitivity`, and `§ Fix-cost-now / fix-cost-later` sections so each worker can compute severity independently.
-6. **The severity machinery** — the full `§ Severity computation` section (included so workers do not need to read `references/dimensions.md` beyond their rubric slice).
-7. **Output contract** — the per-finding fields table and finding format from `SKILL.md § Output`, so workers emit digests the orchestrator can parse unambiguously.
+5. **Per-dimension rubric slice + shared formula sections** — the worker's assigned dimension rubric from `references/dimensions.md`, plus `§ Location sensitivity`, `§ Fix-cost-now`, and `§ Fix-cost-later` so each worker can compute severity independently.
+6. **The severity machinery** — the full `§ Severity computation` section.
+7. **Output contract** — the per-finding fields table and finding format from `SKILL.md § Output`, so workers emit full per-finding rows the orchestrator can parse unambiguously.
 8. **Dedup-ownership statement** — explicit: workers do NOT dedup, apply boundary tiebreakers, reconcile severity across dimensions, or write the report. The orchestrator owns those steps (Seam 4).
 
 ## Orientation and citations block

--- a/skills/age/references/packet.md
+++ b/skills/age/references/packet.md
@@ -10,7 +10,7 @@ The orchestrator assembles this packet once per fan-out run and writes it to `.c
 4. **Path-context map** — which entrypoints are non-interactive or hot (servers, daemons, CLI handlers, outbound callers); workers need this for location classification and telemetry coverage.
 5. **Per-dimension rubric slice + shared formula sections** — the worker's assigned dimension rubric from `references/dimensions.md`, plus `§ Location sensitivity`, `§ Fix-cost-now`, and `§ Fix-cost-later` so each worker can compute severity independently. Extract from the dimension's `## <Dimension name>` heading to the next `##` heading.
 6. **The severity machinery** — the full `§ Severity computation` section.
-7. **Output contract** — the per-finding fields table and finding format from `SKILL.md § Output`, so workers emit full per-finding rows the orchestrator can parse unambiguously.
+7. **Output contract** — the per-finding fields table and finding format from `SKILL.md § Output`, **plus the `also-relevant-to: [<dim>, ...]` field from Seam 3** — it is the cross-dimension signal Seam 4 reconciliation consumes and is not part of `§ Output`'s base format, so a worker following `§ Output` alone would omit it. Workers emit full per-finding rows (format fields + `also-relevant-to`) the orchestrator can parse and reconcile unambiguously.
 8. **Dedup-ownership statement** — explicit: workers do NOT dedup, apply boundary tiebreakers, reconcile severity across dimensions, or write the report. The orchestrator owns those steps (Seam 4).
 
 ## Orientation and citations block

--- a/skills/age/references/packet.md
+++ b/skills/age/references/packet.md
@@ -1,0 +1,24 @@
+# Shared context packet
+
+The orchestrator assembles this packet once per fan-out run and writes it to `.cheese/age/<slug>-packet.md`. Each per-dimension worker reads the full packet. There is no persistent cross-run cache — every run rebuilds (staleness risk + YAGNI).
+
+## Components (eight, in assembly order)
+
+1. **Located spec** — path + content, resolved via the spec-resolution order in `SKILL.md § Inputs`.
+2. **Dependency manifest contents** — `package.json`, `Cargo.toml`, `pyproject.toml`, or equivalent for the project under review.
+3. **Project-helper index** — one `tilth_search` for `sanitize / validate / escape / safe / retry / debounce / logger` across `src/` and `shared/`, so workers can flag NIH or missing helper usage.
+4. **Path-context map** — which entrypoints are non-interactive or hot (servers, daemons, CLI handlers, outbound callers); workers need this for location classification and telemetry coverage.
+5. **Per-dimension rubric slice + shared formula sections** — the worker's assigned dimension rubric from `references/dimensions.md`, plus the shared `§ Severity computation`, `§ Location sensitivity`, and `§ Fix-cost-now / fix-cost-later` sections so each worker can compute severity independently.
+6. **The severity machinery** — the full `§ Severity computation` section (included so workers do not need to read `references/dimensions.md` beyond their rubric slice).
+7. **Output contract** — the per-finding fields table and finding format from `SKILL.md § Output`, so workers emit digests the orchestrator can parse unambiguously.
+8. **Dedup-ownership statement** — explicit: workers do NOT dedup, apply boundary tiebreakers, reconcile severity across dimensions, or write the report. The orchestrator owns those steps (Seam 4).
+
+## Orientation and citations block
+
+The existing review-context sub-agent (`SKILL.md § Sub-agent context gate`) is reused as the packet's orientation + citations block. Its digest is embedded in the packet — not duplicated or re-generated.
+
+## Transient file contract
+
+- Written to `.cheese/age/<slug>-packet.md` at the start of each fan-out run.
+- Read-only for workers; never written or modified by workers.
+- Not persisted across runs — no cross-run cache. Leave to normal `.cheese/` cleanup.

--- a/skills/age/references/sub-agent-gate.md
+++ b/skills/age/references/sub-agent-gate.md
@@ -14,7 +14,7 @@ The sub-agent returns roughly 2 KB or less: structured summary, citations, gaps.
 
 ## What the parent never delegates
 
-- Severity grading, final verdicts, approval gates.
+- Severity grading, final verdicts, approval gates. **Exception (scope-limited):** a skill may delegate single-dimension grading to a per-dimension worker **iff** the parent retains final cross-dimension reconciliation and the verdict — the verdict and the cross-cutting grade stay central. This exception does not loosen the default for any other case.
 - Dialogue, contradictions, handshakes, user-facing decisions.
 - Writing the canonical artifact (report, spec, claim table) — the sub-agent supplies the digest; the parent writes the doc.
 


### PR DESCRIPTION
## Bucket B — scale-triggered per-dimension fan-out for `/age`

Stacked on **#140** (`feat/age-rubric-clarity`). Adds a scale-triggered execution mode to `/age`: large diffs distribute the ten-dimension review across isolated per-dimension workers; small diffs keep the current single-parent grader unchanged. Markdown prompt-contract change only — no runtime code.

### Decision
The fan-out adoption gate (from the worker-readiness assessment) was resolved in `/mold` to **scale-triggered** — chosen over declining Bucket B and over unconditional fan-out. The small-diff cost caveat (the shared packet front-loads caller analysis + helper index + path-context map) is resolved by construction: small diffs never build the packet. The change reuses `/age`'s existing sub-agent size threshold (>15 files / >25 KB / multi-subsystem) and is forbidden when `/age` is itself a sub-agent (nesting depth already consumed).

### What changed
- `skills/age/SKILL.md` — new `### Scale-triggered fan-out mode` section (mode predicate, shared packet, worker contract, orchestrator reconciliation, graph freshness, output mode-invariance invariant); Flow step 1 mode-check; reworded sub-agent-gate paragraph; inline-degrade extended to forbid fan-out under a sub-agent.
- `skills/age/references/packet.md` — **new** — the 8-component shared-packet contract + transient-file rules.
- `skills/age/references/sub-agent-gate.md` — scope-limited exception permitting single-dimension grading delegation iff the parent retains cross-dimension reconciliation + the verdict.
- `skills/age/references/dimensions.md` — one mode-neutral reword ("parent grader" → "the grader") so the dedup rule reads correctly under both modes.

### Key invariant
The findings report is identical in shape — same dedup rule, same severity grouping, same finding format — whether produced single-parent or fan-out. Only the internal execution path differs. The orchestrator owns cross-dimension reconciliation via the shipped `## Dimension boundaries` table, triggered by both `≥2 workers on a line` and any worker's `also-relevant-to` tag (the cross-dimension signal a single grader gets for free).

### Review
Implemented by a single coder (one tightly-coupled contract change). Validated by an adversarial multi-lens taste-test (6 independent lenses + per-finding refutation + completeness critic): 9 findings confirmed and fixed in one corrective round (13 others refuted and dropped), including two `high`-severity gaps where the reconciliation trigger and worker-output contract did not entail the mode-invariance invariant. Gates: markdownlint 0 errors; skill validators 16/16 + 18/18.

### Stacking
Base is `feat/age-rubric-clarity` (#140). After #140 merges to `main`, rebase this branch onto `main` and retarget the PR.
