### PR TITLE
chore(gitignore): ignore Claude worktree registry and milknado runtime data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@
 # Serena MCP project state
 .serena/
 
+# Claude Code machine-local worktree registry
+.claude/worktrees/
+
+# milknado optional-plugin runtime data (SQLite task graph)
+.milknado/
+
 # Python
 __pycache__/
 *.pyc


### PR DESCRIPTION
## What

Adds two entries to `.gitignore`:

- `.claude/worktrees/` — Claude Code's machine-local worktree registry
- `.milknado/` — the milknado optional-plugin's runtime SQLite task graph (`milknado.db`)

Neither is tracked upstream; both are per-machine artifacts that were showing as untracked noise.

## Why

While fixing a blocked `git pull` (the durable-memory boundary commit added tracked `.hallouminate/config.toml` + `wiki/index.md` that collided with stale untracked local copies), three untracked dirs surfaced. The two above are machine-local/runtime artifacts and belong in `.gitignore`, matching the existing `.serena/` / `.context/` pattern.

A set of local `.hallouminate/wiki/roadmaps/**` files also surfaced but were **not** committed — they duplicate the parity follow-ups already tracked as issues #151–#164 (per `.hallouminate/wiki/skill-parity-analysis.md`) and carried dangling refs to the `docs/skill-parity-followups.md` that PR #138 removed. They were deleted locally instead.

## Scope

`.gitignore` only — 6 lines added, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHXmFR3w7oMi9SzjbmPRnf