### PR TITLE
fix(skills): align cheez-* skills with current tilth MCP API and steer AST search

### DIFF
--- a/skills/age/references/sub-agent-gate.md
+++ b/skills/age/references/sub-agent-gate.md
@@ -21,7 +21,7 @@ The sub-agent returns roughly 2 KB or less: structured summary, citations, gaps.
 ## What the sub-agent owns
 
 - Bulk fetches, extracts, crawls, multi-source research.
-- Many-file reads, dependency / caller graph traversals.
+- Many-file reads, dependency / caller graph traversals. For code navigation, start with `kind:symbol` to find the definition, then `kind:callers` for call sites. Fall to `content`/`regex` only when you don't have a symbol name.
 - Anything yielding mostly raw bodies that the parent will not read line by line — about 5 K tokens of raw output is the industry rule of thumb for "fork it".
 
 ## Parallelism

--- a/skills/cheez-read/SKILL.md
+++ b/skills/cheez-read/SKILL.md
@@ -71,7 +71,7 @@ Hash anchors are emitted automatically — copy `44:b2c` and `89:e1d` and pass t
 ### "List every TypeScript file under `src/handlers/`"
 
 ```
-tilth_list(glob: "*.ts", scope: "src/handlers/")
+tilth_list(patterns: ["*.ts"], scope: "src/handlers/")
 ```
 
 ```text
@@ -196,7 +196,7 @@ tilth_read(paths: ["src/auth.ts", "src/routes.ts", "src/middleware.ts"])
 
 ## Hash Anchors — The Edit Bridge
 
-When reading files in **edit mode**, tilth outputs **hash-anchored lines**:
+When you drill into a file (a line range, `#symbol`, or heading), tilth outputs **hash-anchored lines**:
 
 ```
 42:a3f|  let x = compute();
@@ -205,9 +205,7 @@ When reading files in **edit mode**, tilth outputs **hash-anchored lines**:
 
 The format is `<line>:<hash>|<content>`.
 
-> Plain reads use a `│` (U+2502) column separator. **Edit-mode reads** (the
-> ones required for cheez-write) use `:<hash>|` — note the ASCII pipe and
-> the colon. Anchors are only emitted when tilth is run in `--edit` mode.
+> Plain full-file reads use a `│` (U+2502) column separator. **Drilled reads** (a line range, `#symbol`, or heading — the ones required for cheez-write) use `:<hash>|` — note the ASCII pipe and the colon. Anchors are emitted automatically on these drilled reads.
 
 **Why this matters:**
 - These hashes uniquely identify the line content
@@ -227,7 +225,7 @@ The format is `<line>:<hash>|<content>`.
 Replaces `ls`, `find`, `pwd`, and the Glob tool.
 
 ```
-tilth_list(glob: "**/*.ts", scope: "src/")
+tilth_list(patterns: ["**/*.ts"], scope: "src/")
 ```
 
 **Output:**
@@ -242,16 +240,16 @@ Token estimates inform what to read in full vs outline.
 **Common patterns:**
 ```
 # All TypeScript files
-tilth_list(glob: "**/*.ts")
+tilth_list(patterns: ["**/*.ts"])
 
 # Test files only
-tilth_list(glob: "**/*.test.ts")
+tilth_list(patterns: ["**/*.test.ts"])
 
 # Specific directory
-tilth_list(glob: "*", scope: "src/handlers/")
+tilth_list(patterns: ["*"], scope: "src/handlers/")
 
 # Exclude patterns (negation in the same glob)
-tilth_list(glob: "!*_test.go", scope: ".")
+tilth_list(patterns: ["!*_test.go"], scope: ".")
 ```
 
 ---
@@ -316,7 +314,7 @@ tilth tracks reads within the current session:
 
 1. **List files with token estimates:**
    ```
-   tilth_list(glob: "*", scope: "src/handlers/")
+   tilth_list(patterns: ["*"], scope: "src/handlers/")
    ```
 
 2. **Read small files fully, outline large ones:**

--- a/skills/cheez-read/SKILL.md
+++ b/skills/cheez-read/SKILL.md
@@ -3,7 +3,7 @@ name: cheez-read
 description: Read and list files via AST-aware tilth MCP — replaces cat / head / tail / less / more / bat / ls / tree / eza / find / fd / Read / Glob. Use when the user asks to read, view, show, open, or display a file or directory — phrases like "read src/auth.ts", "show me this file", "what's in this directory", "view lines 44-89", "look at the imports". Use even when the user says "cat", "less", "bat", "tree", "ls", "find", "fd", or "open the file" — never call host Read, Glob, or any shell file viewer / lister directly. If tilth MCP is unavailable, stop and report rather than fall back. Do NOT use for searching symbols or text (use cheez-search), editing code (use cheez-write), or git/gh operations.
 license: MIT
 compatibility: Requires tilth MCP server.
-allowed-tools: mcp__tilth__tilth_read, mcp__tilth__tilth_files, mcp__tilth__tilth_deps
+allowed-tools: mcp__tilth__tilth_read, mcp__tilth__tilth_list, mcp__tilth__tilth_deps
 ---
 
 # cheez-read
@@ -17,10 +17,10 @@ allowed-tools: mcp__tilth__tilth_read, mcp__tilth__tilth_files, mcp__tilth__tilt
 Before the first call, verify tilth is reachable:
 
 1. Check that `mcp__tilth__tilth_read` is available. If absent, stop and report `"tilth MCP server is not loaded — cannot proceed."`
-2. Make a minimal probe call: `tilth_read(path: "README.md", section: "1-1")`. If the response is a JSON-RPC error or transport failure, stop and report `"tilth MCP server present but unhealthy: <error>"`.
+2. Make a minimal probe call: `tilth_read(paths: ["README.md#1-1"])`. If the response is a JSON-RPC error or transport failure, stop and report `"tilth MCP server present but unhealthy: <error>"`.
 3. Any other failure (file not found, bad section range, etc.) is a **content** issue — proceed normally and report the result.
 
-Smart code reading via **tilth MCP** (`tilth_read`, `tilth_files`, `tilth_deps`).
+Smart code reading via **tilth MCP** (`tilth_read`, `tilth_list`, `tilth_deps`).
 tilth replaces cat/head/tail with AST-aware file reading that understands code structure.
 
 ---
@@ -30,17 +30,33 @@ tilth replaces cat/head/tail with AST-aware file reading that understands code s
 ### "Show me `src/auth.ts`"
 
 ```
-tilth_read(path: "src/auth.ts")
+tilth_read(paths: ["src/auth.ts"])
 ```
 
 Small files come back with full content and a header (`# src/auth.ts (258
 lines, ~3.4k tokens) [full]`); large files get the structural outline
 automatically.
 
-### "Read the `handleAuth` function in edit mode so I can change it"
+### "Read the `handleAuth` function by symbol name"
 
 ```
-tilth_read(path: "src/auth.ts", section: "44-89", edit: true)
+tilth_read(paths: ["src/auth.ts#handleAuth"])
+```
+
+The `#symbol_name` suffix resolves to the symbol's line range. Use this when you know the name but not the line numbers.
+
+### "Get a stripped outline of a large file before editing"
+
+```
+tilth_read(paths: ["src/auth.ts"], mode: "stripped")
+```
+
+`mode:stripped` returns the whole file with plain comments and debug logs removed — useful for surveying structure without hash anchors before deciding what to read in full.
+
+### "Read lines 44-89 of `src/auth.ts` to get edit anchors"
+
+```
+tilth_read(paths: ["src/auth.ts#44-89"])
 ```
 
 ```text
@@ -50,13 +66,12 @@ tilth_read(path: "src/auth.ts", section: "44-89", edit: true)
 89:e1d|}
 ```
 
-The `edit: true` flag (or `--edit` in CLI mode) emits hash anchors. Capture
-`44:b2c` and `89:e1d` and pass them to cheez-write.
+Hash anchors are emitted automatically — copy `44:b2c` and `89:e1d` and pass them to cheez-write.
 
 ### "List every TypeScript file under `src/handlers/`"
 
 ```
-tilth_files(glob: "*.ts", scope: "src/handlers/")
+tilth_list(glob: "*.ts", scope: "src/handlers/")
 ```
 
 ```text
@@ -129,7 +144,7 @@ If no LSP is installed for the language, or the file is in a broken / incomplete
 | Just the symbol table of one file (no source lines) | `mcp__serena__get_symbols_overview` | Cheaper than tilth outline mode — LSP-indexed, no parse pass |
 | Read a single symbol's body by name (no line range needed) | `mcp__serena__find_symbol` with body inclusion | Skips the "outline → drill into 44-89" round-trip |
 
-`/cheez-read` itself stays tilth-only — its `allowed-tools` frontmatter does not include `mcp__serena__*` and shouldn't. The routing decision happens in the workflow skill *before* it enters `/cheez-read`. Enter `/cheez-read` when you need hash anchors (any edit follows up), a `tilth_files` directory listing with token estimates, token-budgeted preview mode, or when Serena is unavailable. Serena gives you the symbol; tilth gives you the anchor — if you're going to edit afterwards, prefer tilth so the anchor is already in hand. See [`cheez-write`](../cheez-write/SKILL.md) for the symmetric "When Serena beats `tilth_edit`" guidance.
+`/cheez-read` itself stays tilth-only — its `allowed-tools` frontmatter does not include `mcp__serena__*` and shouldn't. The routing decision happens in the workflow skill *before* it enters `/cheez-read`. Enter `/cheez-read` when you need hash anchors (any edit follows up), a `tilth_list` directory listing with token estimates, token-budgeted preview mode, or when Serena is unavailable. Serena gives you the symbol; tilth gives you the anchor — if you're going to edit afterwards, prefer tilth so the anchor is already in hand. See [`cheez-write`](../cheez-write/SKILL.md) for the symmetric "When Serena beats `tilth_write`" guidance.
 
 ---
 
@@ -138,7 +153,7 @@ If no LSP is installed for the language, or the file is in a broken / incomplete
 ### tilth_read — Smart File Reading
 
 ```
-tilth_read(path: "src/auth.ts")
+tilth_read(paths: ["src/auth.ts"])
 ```
 
 **Output for small files:**
@@ -166,10 +181,10 @@ tilth_read(path: "src/auth.ts")
 **Drilling into sections:**
 ```
 # Line range
-tilth_read(path: "src/auth.ts", section: "44-89")
+tilth_read(paths: ["src/auth.ts#44-89"])
 
 # Markdown heading
-tilth_read(path: "docs/guide.md", section: "## Installation")
+tilth_read(paths: ["docs/guide.md### Installation"])
 ```
 
 **Multiple files in one call:**
@@ -196,7 +211,7 @@ The format is `<line>:<hash>|<content>`.
 
 **Why this matters:**
 - These hashes uniquely identify the line content
-- They're used by `tilth_edit` (cheez-write) for precise edits
+- They're used by `tilth_write` (cheez-write) for precise edits
 - If the file changes, hashes won't match → edit is rejected safely
 - Reading before editing is mandatory to get current hashes
 
@@ -207,12 +222,12 @@ The format is `<line>:<hash>|<content>`.
 
 ---
 
-## tilth_files — Directory Listing
+## tilth_list — Directory Listing
 
 Replaces `ls`, `find`, `pwd`, and the Glob tool.
 
 ```
-tilth_files(glob: "**/*.ts", scope: "src/")
+tilth_list(glob: "**/*.ts", scope: "src/")
 ```
 
 **Output:**
@@ -227,16 +242,16 @@ Token estimates inform what to read in full vs outline.
 **Common patterns:**
 ```
 # All TypeScript files
-tilth_files(glob: "**/*.ts")
+tilth_list(glob: "**/*.ts")
 
 # Test files only
-tilth_files(glob: "**/*.test.ts")
+tilth_list(glob: "**/*.test.ts")
 
 # Specific directory
-tilth_files(glob: "*", scope: "src/handlers/")
+tilth_list(glob: "*", scope: "src/handlers/")
 
 # Exclude patterns (negation in the same glob)
-tilth_files(glob: "!*_test.go", scope: ".")
+tilth_list(glob: "!*_test.go", scope: ".")
 ```
 
 ---
@@ -271,12 +286,12 @@ tilth tracks reads within the current session:
 
 1. **Start with outline** (let tilth auto-decide):
    ```
-   tilth_read(path: "src/auth.ts")
+   tilth_read(paths: ["src/auth.ts"])
    ```
 
 2. **Drill into relevant sections:**
    ```
-   tilth_read(path: "src/auth.ts", section: "44-89")
+   tilth_read(paths: ["src/auth.ts#44-89"])
    ```
 
 3. **Check dependencies if needed:**
@@ -288,20 +303,20 @@ tilth tracks reads within the current session:
 
 1. **Read the target section to get hash anchors:**
    ```
-   tilth_read(path: "src/auth.ts", section: "44-89")
+   tilth_read(paths: ["src/auth.ts#44-89"])
    ```
 
 2. **Memorize:**
    - Start anchor: `44:a3f`
    - End anchor: `89:b7c`
 
-3. **Pass these to cheez-write** (tilth_edit) for the edit.
+3. **Pass these to cheez-write** (`tilth_write`) for the edit.
 
 ### For Exploring a Directory
 
 1. **List files with token estimates:**
    ```
-   tilth_files(glob: "*", scope: "src/handlers/")
+   tilth_list(glob: "*", scope: "src/handlers/")
    ```
 
 2. **Read small files fully, outline large ones:**
@@ -314,7 +329,7 @@ tilth tracks reads within the current session:
 ## DO NOT
 
 - **DO NOT use cat / head / tail / less / more / bat** to view code — use `tilth_read`. Hash anchors and outline-vs-full token budgeting only work through tilth.
-- **DO NOT use ls / tree / eza / find / fd to enumerate code files** — use `tilth_files`. Token estimates and `.gitignore` filtering only work through tilth.
+- **DO NOT use ls / tree / eza / find / fd to enumerate code files** — use `tilth_list`. Token estimates and `.gitignore` filtering only work through tilth.
 - **DO NOT use the host Read or Glob tools** on code paths — they bypass tilth's session deduplication and emit no anchors.
 - **DO NOT re-read files** shown earlier — reference the prior read.
 - **DO NOT use for searching** — use cheez-search.
@@ -326,8 +341,7 @@ tilth tracks reads within the current session:
 ## Output Token Budget
 
 tilth uses ~6000 tokens as the outline threshold. Files under this show in full;
-files over this get structural outlines. Use `section` to get hashlined content
-for specific ranges when preparing edits on large files.
+files over this get structural outlines. Use the `#n-m` line suffix (e.g. `paths: ["src/auth.ts#44-89"]`) or the `#symbol_name` suffix (e.g. `paths: ["src/auth.ts#handleAuth"]`) to get hash-anchored content for specific ranges or symbols. Use `mode:stripped` for a full-file plain-comment-stripped outline read when you need to survey a large file without hash anchors.
 
 ---
 

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -20,7 +20,7 @@ Before the first call, verify tilth is reachable:
 2. Make a minimal probe call: `tilth_search(queries: [{query: "tilth"}])`. If the response is a JSON-RPC error or transport failure, stop and report `"tilth MCP server present but unhealthy: <error>"`.
 3. Any other failure (zero matches, malformed regex, etc.) is a **content** issue — proceed normally and report the result.
 
-**Note:** pass `root` (your absolute checkout directory) whenever `scope` or `paths` are relative — the server's cwd is frozen at startup and cannot resolve relative paths without an explicit `root`.
+**Note:** pass `root` (your absolute checkout directory) whenever `scope` is relative — the server's cwd is frozen at startup and cannot resolve relative paths without an explicit `root`.
 
 AST-aware code search via **tilth MCP** (`tilth_search`, `tilth_deps`).
 Tree-sitter finds where symbols are **defined** — not just where strings appear.
@@ -192,7 +192,7 @@ between one call and a long grep walk.
 
 | Goal | Tool | Example |
 |------|------|---------|
-| Find where a symbol is defined / used | `tilth_search` (default `kind: "symbol"`) | `tilth_search(queries: [{query: "handleAuth"}], scope: "src/")` |
+| Find where a symbol is defined / used | `tilth_search` (default `kind: "symbol"`) | `tilth_search(queries: [{query: "handleAuth"}], scope: "src/", root: "/checkout/root")` |
 | Find every call site of a function | `tilth_search(kind: "callers")` | `tilth_search(queries: [{query: "validateToken", kind: "callers"}])` |
 | Find literal strings, TODOs, error messages | `tilth_search(kind: "content")` | `tilth_search(queries: [{query: "error message", kind: "content"}])` |
 | Find lines matching a regex | `tilth_search(kind: "regex")` | `tilth_search(queries: [{query: "rate.?limit", kind: "regex"}])` |

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -17,8 +17,10 @@ allowed-tools: mcp__tilth__tilth_search, mcp__tilth__tilth_deps, Bash
 Before the first call, verify tilth is reachable:
 
 1. Check that `mcp__tilth__tilth_search` is in your tool list. If absent, stop and report `"tilth MCP server is not loaded — cannot proceed."`
-2. Make a minimal probe call: `tilth_search(query: "tilth", scope: ".")`. If the response is a JSON-RPC error or transport failure, stop and report `"tilth MCP server present but unhealthy: <error>"`.
+2. Make a minimal probe call: `tilth_search(queries: [{query: "tilth"}])`. If the response is a JSON-RPC error or transport failure, stop and report `"tilth MCP server present but unhealthy: <error>"`.
 3. Any other failure (zero matches, malformed regex, etc.) is a **content** issue — proceed normally and report the result.
+
+**Note:** pass `root` (your absolute checkout directory) whenever `scope` or `paths` are relative — the server's cwd is frozen at startup and cannot resolve relative paths without an explicit `root`.
 
 AST-aware code search via **tilth MCP** (`tilth_search`, `tilth_deps`).
 Tree-sitter finds where symbols are **defined** — not just where strings appear.
@@ -31,7 +33,7 @@ Understand dependencies instead of blindly grepping.
 ### "Where is `handleAuth` defined?"
 
 ```
-tilth_search(query: "handleAuth", scope: "src/")
+tilth_search(queries: [{query: "handleAuth"}], scope: "src/", root: "/checkout/root")
 ```
 
 ```text
@@ -48,7 +50,7 @@ The `[definition]` tag answers the question; usages come along for free.
 ### "What calls `validateToken`?"
 
 ```
-tilth_search(query: "validateToken", kind: "callers", scope: ".")
+tilth_search(queries: [{query: "validateToken", kind: "callers"}], scope: ".", root: "/checkout/root")
 ```
 
 ```text
@@ -66,7 +68,7 @@ tilth_search(query: "validateToken", kind: "callers", scope: ".")
 ### "Find any TODO that mentions retries"
 
 ```
-tilth_search(query: "TODO.*retry", kind: "regex", scope: "src/")
+tilth_search(queries: [{query: "TODO.*retry", kind: "regex"}], scope: "src/", root: "/checkout/root")
 ```
 
 Use `kind: "regex"` for pattern matches across content; bound the scope to
@@ -183,15 +185,17 @@ If code-review-graph is unavailable, the cheez-search fallbacks are: name-shaped
 
 ## Choose your search kind
 
+For code navigation (where is X / what calls Y / blast radius): start with `kind:symbol` to find the definition, then `kind:callers` for call sites. Fall to `content`/`regex` only when you don't have a symbol name.
+
 All six rows below are first-class — picking the right one is the difference
 between one call and a long grep walk.
 
 | Goal | Tool | Example |
 |------|------|---------|
-| Find where a symbol is defined / used | `tilth_search` (default `kind: "symbol"`) | `tilth_search(query: "handleAuth", scope: "src/")` |
-| Find every call site of a function | `tilth_search(kind: "callers")` | `tilth_search(query: "validateToken", kind: "callers")` |
-| Find literal strings, TODOs, error messages | `tilth_search(kind: "content")` | `tilth_search(query: "TODO: fix", kind: "content")` |
-| Find lines matching a regex | `tilth_search(kind: "regex")` | `tilth_search(query: "rate.?limit", kind: "regex")` |
+| Find where a symbol is defined / used | `tilth_search` (default `kind: "symbol"`) | `tilth_search(queries: [{query: "handleAuth"}], scope: "src/")` |
+| Find every call site of a function | `tilth_search(kind: "callers")` | `tilth_search(queries: [{query: "validateToken", kind: "callers"}])` |
+| Find literal strings, TODOs, error messages | `tilth_search(kind: "content")` | `tilth_search(queries: [{query: "error message", kind: "content"}])` |
+| Find lines matching a regex | `tilth_search(kind: "regex")` | `tilth_search(queries: [{query: "rate.?limit", kind: "regex"}])` |
 | Match an AST shape (template with metavars) | `sg` (ast-grep, via Bash) | `sg --lang typescript -p 'JSON.parse(JSON.stringify($X))' --json src/` |
 | Module import / blast-radius graph | `tilth_deps` | `tilth_deps(path: "src/auth.ts")` |
 
@@ -207,7 +211,7 @@ Drop to `sg` only when the pattern needs structural metavariables (`$X`,
 
 **Basic symbol search:**
 ```
-tilth_search(query: "handleAuth", scope: "src/")
+tilth_search(queries: [{query: "handleAuth"}], scope: "src/", root: "/checkout/root")
 ```
 
 **Output:**
@@ -246,7 +250,7 @@ tilth_search(query: "handleAuth", scope: "src/")
 Trace across files in one call:
 
 ```
-tilth_search(query: "ServeHTTP, HandlersChain, Next", scope: ".")
+tilth_search(queries: [{query: "ServeHTTP, HandlersChain, Next"}], scope: ".", root: "/checkout/root")
 ```
 
 Each symbol gets its own result block. The expand budget is shared — at least
@@ -260,7 +264,7 @@ Find all places that call a specific function using structural tree-sitter
 matching (not text search):
 
 ```
-tilth_search(query: "isTrustedProxy", kind: "callers", scope: ".")
+tilth_search(queries: [{query: "isTrustedProxy", kind: "callers"}], scope: ".", root: "/checkout/root")
 ```
 
 **Why this beats grep:** only finds actual calls, not comments or string literals.
@@ -273,7 +277,7 @@ Shows the calling function context.
 Search for text that isn't a code symbol:
 
 ```
-tilth_search(query: "TODO: fix", kind: "content", scope: ".")
+tilth_search(queries: [{query: "TODO: fix", kind: "content"}], scope: ".", root: "/checkout/root")
 ```
 
 Use content search for: TODOs, FIXMEs, NOTEs, error messages, specific literal strings.
@@ -285,8 +289,8 @@ Use content search for: TODOs, FIXMEs, NOTEs, error messages, specific literal s
 For patterns that aren't a single literal:
 
 ```
-tilth_search(query: "rate.?limit", kind: "regex", scope: ".")
-tilth_search(query: "FIXME\\(.*?\\):", kind: "regex", scope: "src/")
+tilth_search(queries: [{query: "rate.?limit", kind: "regex"}], scope: ".", root: "/checkout/root")
+tilth_search(queries: [{query: "FIXME\\(.*?\\):", kind: "regex"}], scope: "src/", root: "/checkout/root")
 ```
 
 - Full regex syntax — alternation, character classes, lookarounds depending on the engine.
@@ -300,7 +304,7 @@ tilth_search(query: "FIXME\\(.*?\\):", kind: "regex", scope: "src/")
 tilth covers names and text. For *shapes* with metavariables (`$X`, `$$$BODY`)
 that tilth cannot express, drop to `sg` (ast-grep) via Bash. This is the
 **only** sanctioned shell escape from cheez-search. The same escape covers
-structural codemods via `sg --rewrite` (dry-run first; `tilth_edit` remains
+structural codemods via `sg --rewrite` (dry-run first; `tilth_write` remains
 the default for one-off block edits).
 
 For metavar pattern syntax, the language matrix, hard rules for safe `sg`
@@ -315,13 +319,13 @@ codemod dry-run protocol, see
 
 ```
 # Only Rust files
-tilth_search(query: "handleAuth", scope: ".", glob: "*.rs")
+tilth_search(queries: [{query: "handleAuth"}], scope: ".", glob: "*.rs", root: "/checkout/root")
 
 # Exclude test files
-tilth_search(query: "handleAuth", scope: ".", glob: "!*.test.ts")
+tilth_search(queries: [{query: "handleAuth"}], scope: ".", glob: "!*.test.ts", root: "/checkout/root")
 
 # Multiple extensions
-tilth_search(query: "handleAuth", scope: ".", glob: "*.{go,rs}")
+tilth_search(queries: [{query: "handleAuth"}], scope: ".", glob: "*.{go,rs}", root: "/checkout/root")
 ```
 
 ---
@@ -331,7 +335,7 @@ tilth_search(query: "handleAuth", scope: ".", glob: "*.{go,rs}")
 When editing a file, pass it as context to boost related results:
 
 ```
-tilth_search(query: "validateToken", scope: ".", context: "src/auth.ts")
+tilth_search(queries: [{query: "validateToken"}], scope: ".", context: "src/auth.ts", root: "/checkout/root")
 ```
 
 ---
@@ -340,13 +344,13 @@ tilth_search(query: "validateToken", scope: ".", context: "src/auth.ts")
 
 ```
 # Default: 2 expansions
-tilth_search(query: "handleAuth", scope: ".")
+tilth_search(queries: [{query: "handleAuth"}], scope: ".", root: "/checkout/root")
 
 # More detail
-tilth_search(query: "handleAuth", scope: ".", expand: 5)
+tilth_search(queries: [{query: "handleAuth"}], scope: ".", expand: 5, root: "/checkout/root")
 
 # Compact (outlines only)
-tilth_search(query: "handleAuth", scope: ".", expand: 0)
+tilth_search(queries: [{query: "handleAuth"}], scope: ".", expand: 0, root: "/checkout/root")
 ```
 
 ---
@@ -376,22 +380,22 @@ tilth tracks what you've already seen:
 
 ```
 # "Where is X defined?"
-tilth_search(query: "AuthManager", scope: ".")
+tilth_search(queries: [{query: "AuthManager"}], scope: ".", root: "/checkout/root")
 # Look for [definition] results
 
 # "What calls X?"
-tilth_search(query: "validateToken", kind: "callers", scope: ".")
+tilth_search(queries: [{query: "validateToken", kind: "callers"}], scope: ".", root: "/checkout/root")
 
 # "What does X call?"
-tilth_search(query: "handleAuth", scope: ".", expand: 1)
+tilth_search(queries: [{query: "handleAuth"}], scope: ".", expand: 1, root: "/checkout/root")
 # Check the ── calls ── footer
 
 # "Find all implementations of an interface"
-tilth_search(query: "UserRepository", scope: ".", kind: "symbol")
+tilth_search(queries: [{query: "UserRepository", kind: "symbol"}], scope: ".", root: "/checkout/root")
 # Implementations show as [impl] tags
 
 # "Search error messages"
-tilth_search(query: "invalid token format", kind: "content", scope: ".")
+tilth_search(queries: [{query: "invalid token format", kind: "content"}], scope: ".", root: "/checkout/root")
 
 # "What depends on this module?"
 tilth_deps(path: "src/auth/index.ts")
@@ -416,7 +420,7 @@ tilth_deps(path: "src/auth/index.ts")
 ## DO NOT
 
 - **DO NOT use grep / rg / ripgrep / ag / ack** — use `tilth_search`. `sg` (ast-grep) is the *only* sanctioned shell escape, and only for AST-shape patterns with metavariables tilth can't express.
-- **DO NOT use find / fd to locate files by name pattern** — use `tilth_files` (cheez-read). `find` for non-name predicates (size, mtime, perms) is fine outside code work, but redirect anything code-related back through `cheez-*`.
+- **DO NOT use find / fd to locate files by name pattern** — use `tilth_list` (cheez-read). `find` for non-name predicates (size, mtime, perms) is fine outside code work, but redirect anything code-related back through `cheez-*`.
 - **DO NOT use ast-grep (`sg`) for name-shaped or text queries** — that's `tilth_search` territory. `sg` is for structural patterns with metavars (`$X`, `$$$BODY`) only.
 - **DO NOT blind text search** — use a semantic `kind` (`symbol`, `callers`, `content`, `regex`) before reaching for `sg`.
 - **DO NOT re-read expanded results** — they're already shown.

--- a/skills/cheez-search/references/sg-patterns.md
+++ b/skills/cheez-search/references/sg-patterns.md
@@ -4,7 +4,7 @@
 call to `JSON.parse(JSON.stringify(…))`", "any `for` loop with `time.Sleep` in
 its body" — drop to `sg` (ast-grep) via Bash. This is the **only** sanctioned
 shell escape from cheez-search. The same escape covers structural codemods
-via `sg --rewrite` (see "Structural codemods" below); `tilth_edit` remains
+via `sg --rewrite` (see "Structural codemods" below); `tilth_write` remains
 the default for one-off block edits.
 
 ## When `sg` is the right pick
@@ -79,7 +79,7 @@ match count. A wide `**/*` over a monorepo can be ~10× slower than a
 constrained scope. Two-stage workflow:
 
 1. **List candidates** with `tilth_search` (definitions, imports, content
-   hits) or `tilth_files` (glob/path predicates) to get the file set.
+   hits) or `tilth_list` (glob/path predicates) to get the file set.
 2. **Run `sg`** with `--globs` or explicit paths bounded to that set.
 
 This pattern beats one giant wildcard scan and keeps the JSON output small
@@ -101,8 +101,8 @@ enough to inspect.
 ## Structural codemods (`sg --rewrite`)
 
 `sg --rewrite '<template>'` plus `-U` (update files in place) is the
-sanctioned codemod path. It complements `tilth_edit` rather than replacing
-it: tilth_edit excels at "replace this specific block in this specific file"
+sanctioned codemod path. It complements `tilth_write` rather than replacing
+it: tilth_write excels at "replace this specific block in this specific file"
 with hash-anchor concurrency safety; `sg --rewrite` excels at "rewrite every
 instance of this shape across the repo" with structural-match safety.
 

--- a/skills/cheez-search/references/sg-patterns.md
+++ b/skills/cheez-search/references/sg-patterns.md
@@ -79,7 +79,7 @@ match count. A wide `**/*` over a monorepo can be ~10× slower than a
 constrained scope. Two-stage workflow:
 
 1. **List candidates** with `tilth_search` (definitions, imports, content
-   hits) or `tilth_list` (glob/path predicates) to get the file set.
+   hits) or `tilth_list` (glob patterns) to get the file set.
 2. **Run `sg`** with `--globs` or explicit paths bounded to that set.
 
 This pattern beats one giant wildcard scan and keeps the JSON output small

--- a/skills/cheez-write/SKILL.md
+++ b/skills/cheez-write/SKILL.md
@@ -31,7 +31,7 @@ rewriting whole files unless the size and change ratio justify it (see
 
 ### "Replace the body of `handleAuth` in `src/auth.ts`"
 
-Step 1 — read with edit mode to get anchors:
+Step 1 — read the line range to get anchors:
 
 ```
 tilth_read(paths: ["src/auth.ts#44-89"])
@@ -147,7 +147,7 @@ If no LSP is installed, or the rename touches a symbol the typechecker can't res
 
 ## Hash Anchor Format
 
-When you read a file with tilth_read in edit mode, lines have anchors:
+When you read a file with tilth_read (a line range, `#symbol`, or heading), lines have anchors:
 
 ```
 42:a3f|  let x = compute();

--- a/skills/cheez-write/SKILL.md
+++ b/skills/cheez-write/SKILL.md
@@ -3,25 +3,24 @@ name: cheez-write
 description: Edit code via hash-anchored tilth MCP edits — replaces sed / awk / perl -i / patch / tee / Edit / Write / shell redirects (`>`, `>>`). Use when the user asks to edit, replace, modify, update, change, delete, or insert code — phrases like "replace this function", "delete lines 44-89", "update validateToken", "change the implementation", "add this import", "fix this bug" (when fixing requires editing), or apply a cross-cutting structural change (codemod) like "rewrite every X to Y". Sanctions `sg --rewrite` (ast-grep) for structural codemods that span many files. Always read first via cheez-read to get hash anchors for anchored edits. Prefer surgical anchored edits over whole-file rewrites. If tilth MCP is unavailable, stop and report rather than fall back. Do NOT use for reading files (cheez-read first to get anchors), searching code (use cheez-search), or running tests/builds.
 license: MIT
 compatibility: Requires tilth MCP server. Optional ast-grep (`sg`) for structural codemods (`sg --rewrite`) that span many files.
-allowed-tools: mcp__tilth__tilth_edit, mcp__tilth__tilth_read, Bash
+allowed-tools: mcp__tilth__tilth_write, mcp__tilth__tilth_read, Bash
 ---
 
 # cheez-write
 
-> **Hard dependency**: If `mcp__tilth__tilth_edit` is unavailable, stop immediately and report
+> **Hard dependency**: If `mcp__tilth__tilth_write` is unavailable, stop immediately and report
 > "tilth MCP server is not loaded — cannot proceed." Do NOT fall back to `Edit`, `Write`,
-> or any host tool. Install via `tilth install <host> --edit` — the `--edit` flag is required
-> to expose `tilth_edit` (see README "Installing tilth MCP").
+> or any host tool. Install via `tilth install <host>` (see README "Installing tilth MCP").
 
 ## Capability detection
 
 Before the first call, verify tilth's edit tool is reachable:
 
-1. Check that `mcp__tilth__tilth_edit` is in your tool list. If only `tilth_read` and `tilth_search` are present, tilth was installed without `--edit`. Stop and report `"tilth MCP server is loaded but edit mode is disabled — re-install with 'tilth install <host> --edit'."`
+1. Check that `mcp__tilth__tilth_write` is in your tool list. If `tilth_write` is absent, stop and report `"tilth MCP server is loaded but edit mode is unavailable — re-install tilth."`
 2. The first edit call is a probe by definition — if it returns a JSON-RPC transport error (not a hash mismatch), stop and report `"tilth MCP server present but unhealthy: <error>"`.
 3. Hash mismatches, syntax errors in the new content, or anchor-not-found are **content** issues — recover via the protocol below, do not bail.
 
-Hash-anchored file editing via **tilth MCP** (`tilth_edit`).
+Hash-anchored file editing via **tilth MCP** (`tilth_write`).
 Use hash anchors from tilth_read to make precise, surgical edits. Avoid
 rewriting whole files unless the size and change ratio justify it (see
 "When full-file rewrite is acceptable" below).
@@ -35,21 +34,21 @@ rewriting whole files unless the size and change ratio justify it (see
 Step 1 — read with edit mode to get anchors:
 
 ```
-tilth_read(path: "src/auth.ts", section: "44-89", edit: true)
+tilth_read(paths: ["src/auth.ts#44-89"])
 # returns 44:b2c|... and 89:e1d|...
 ```
 
 Step 2 — apply with the captured anchors:
 
 ```json
-tilth_edit({
+tilth_write(files: [{
   "path": "src/auth.ts",
   "edits": [{
     "start": "44:b2c",
     "end":   "89:e1d",
     "content": "export function handleAuth(req, res, next) {\n  const token = extractToken(req);\n  if (!validateToken(token)) return res.status(401).end();\n  next();\n}"
   }]
-})
+}])
 ```
 
 Response confirms `Edit applied to src/auth.ts` and may list callers to
@@ -57,17 +56,17 @@ review.
 
 ### "Add an import without nuking the existing one on line 13"
 
-`tilth_edit` replaces — there is no native insert. Anchor on line 13 and put
+`tilth_write` replaces — there is no native insert. Anchor on line 13 and put
 the original line back at the top of `content`:
 
 ```json
-tilth_edit({
+tilth_write(files: [{
   "path": "src/auth.ts",
   "edits": [{
     "start": "13:abc",
     "content": "import { existingThing } from './existing';\nimport { newHelper } from './helpers';"
   }]
-})
+}])
 ```
 
 ### "Hash mismatch — file changed under me"
@@ -80,7 +79,7 @@ Found: f9a
 
 Re-read the section, capture the new anchors, retry once. If it mismatches
 again, **stop** — see "Hash Mismatch Handling → Repeated mismatches" below
-(`tilth_edit` has no fuzzy / search-replace mode, so blind retries lose
+(`tilth_write` has no fuzzy / search-replace mode, so blind retries lose
 races, not win them).
 
 ---
@@ -88,7 +87,7 @@ races, not win them).
 ## Core Principle: Anchors, Not Rewrites
 
 Traditional AI editing rewrites entire files, wasting tokens and risking data loss.
-tilth_edit uses **hash anchors** — unique identifiers for each line — to:
+tilth_write uses **hash anchors** — unique identifiers for each line — to:
 - Make precise, surgical changes
 - Reject edits if the file changed (hash mismatch)
 - Show you exactly what changed
@@ -96,53 +95,53 @@ tilth_edit uses **hash anchors** — unique identifiers for each line — to:
 **The protocol:**
 1. Read the file section with `tilth_read` (cheez-read) → get hash anchors
 2. Note start/end anchors for the block you'll change
-3. Call `tilth_edit` with those anchors and new content
+3. Call `tilth_write` with those anchors and new content
 
 ---
 
-## Scope: when tilth_edit, when not
+## Scope: when tilth_write, when not
 
-`tilth_edit` owns **block edits to tracked source code** — function bodies, signatures, imports, single-line tweaks, multi-edit batches, and cross-file specific changes. Hash anchors give concurrency safety; the read-edit protocol is mandatory for any code change that matters.
+`tilth_write` owns **block edits to tracked source code** — function bodies, signatures, imports, single-line tweaks, multi-edit batches, and cross-file specific changes. Hash anchors give concurrency safety; the read-edit protocol is mandatory for any code change that matters.
 
 For everything else, prefer the right tool:
 
 | Change | Use this instead | Why |
 |--------|------------------|-----|
-| Cross-cutting structural codemod (`JSON.parse(JSON.stringify($X))` → `structuredClone($X)`) across N files | `sg --rewrite` (dry-run-first protocol) | tilth_edit needs N reads-for-anchors; codemods template the variable parts |
+| Cross-cutting structural codemod (`JSON.parse(JSON.stringify($X))` → `structuredClone($X)`) across N files | `sg --rewrite` (dry-run-first protocol) | tilth_write needs N reads-for-anchors; codemods template the variable parts |
 | Lockfile changes (`Cargo.lock`, `package-lock.json`, `uv.lock`, etc.) | the package manager (`cargo update`, `npm i`, `uv lock`) | Hand-editing lockfiles loses checksum integrity |
 | Generated / build artifacts (compiled JS, transpiled output, `*.pb.go`) | regenerate from source | Editing the artifact rots on the next build |
-| Brand-new files, no prior content | `tilth_edit` (anchor on line 1, end-anchor on the last line for a single-edit insert) | Stay on one path; the anchor cost is negligible for new files |
+| Brand-new files, no prior content | `tilth_write` (anchor on line 1, end-anchor on the last line for a single-edit insert) | Stay on one path; the anchor cost is negligible for new files |
 | Files outside the repo or inside dependency caches (`node_modules`, `.cargo/registry`) | don't edit them | Modifying dependencies is almost always a mistake — fix the source or upstream |
-| Binary files, images, PDFs | the producing tool | tilth_edit is text-only |
+| Binary files, images, PDFs | the producing tool | tilth_write is text-only |
 
-If the question is "which tool for this specific source-code block edit?" → `tilth_edit`. If it's "rewrite this pattern everywhere" → `sg --rewrite` with the dry-run protocol.
+If the question is "which tool for this specific source-code block edit?" → `tilth_write`. If it's "rewrite this pattern everywhere" → `sg --rewrite` with the dry-run protocol.
 
-### When LSP rename beats tilth_edit (if your harness has one)
+### When LSP rename beats tilth_write (if your harness has one)
 
-**easy-cheese does not install LSP** — it is whatever language servers your harness already exposes. There is one editing operation where an available LSP materially outperforms `tilth_edit`: **type-aware rename** of a symbol across the project.
+**easy-cheese does not install LSP** — it is whatever language servers your harness already exposes. There is one editing operation where an available LSP materially outperforms `tilth_write`: **type-aware rename** of a symbol across the project.
 
 | Edit | Use this instead | Why LSP wins |
 |------|------------------|--------------|
-| Rename a function / class / variable across all type-correct usages, including aliased re-exports and generic instantiations | `textDocument/rename` (or the harness's rename refactor) | Returns a typechecker-validated `WorkspaceEdit`; covers aliased imports without textual collisions, and skips coincidental name matches in unrelated scopes. `tilth_edit` would need a separate read-edit cycle per call site, and `sg --rewrite` matches on syntax not type identity (overshoots on shadowed names, undershoots on aliased re-exports) |
+| Rename a function / class / variable across all type-correct usages, including aliased re-exports and generic instantiations | `textDocument/rename` (or the harness's rename refactor) | Returns a typechecker-validated `WorkspaceEdit`; covers aliased imports without textual collisions, and skips coincidental name matches in unrelated scopes. `tilth_write` would need a separate read-edit cycle per call site, and `sg --rewrite` matches on syntax not type identity (overshoots on shadowed names, undershoots on aliased re-exports) |
 
-For everything else — block edits, signature changes, body rewrites, hand-written codemods — `tilth_edit` (one-off) and `sg --rewrite` (cross-cutting) remain the right tools. LSP rename is narrowly the best fit for **identifier renames specifically**; nothing else in LSP's edit surface improves on the cheez-write protocol.
+For everything else — block edits, signature changes, body rewrites, hand-written codemods — `tilth_write` (one-off) and `sg --rewrite` (cross-cutting) remain the right tools. LSP rename is narrowly the best fit for **identifier renames specifically**; nothing else in LSP's edit surface improves on the cheez-write protocol.
 
 If no LSP is installed, or the rename touches a symbol the typechecker can't resolve (broken code, generated bindings), fall back to `sg --rewrite` with the dry-run-first protocol — see "Structural codemods" below.
 
-### When Serena beats `tilth_edit` for symbol-bounded edits (if your harness has it)
+### When Serena beats `tilth_write` for symbol-bounded edits (if your harness has it)
 
 [Serena](https://github.com/oraios/serena) is an LSP-driven MCP that exposes symbol-bounded edits as named tools. When Serena is configured for the codebase (`.serena/project.yml` present) and the edit is symbol-shaped, the **calling workflow skill** should route directly to Serena rather than entering `/cheez-write` — same pattern as the abstract LSP rename above, with a broader edit surface:
 
-| Edit | Serena tool | When to prefer over `tilth_edit` |
+| Edit | Serena tool | When to prefer over `tilth_write` |
 |------|-------------|----------------------------------|
 | Rename a symbol type-correctly across the project | `mcp__serena__rename_symbol` | The LSP rename case above — Serena gives it a concrete tool |
 | Replace a whole function / class body by name | `mcp__serena__replace_symbol_body` | Skips the "read for anchors → edit" round-trip when the boundary is a named symbol |
 | Insert before / after a named symbol (e.g. add a method to a class, or a function next to its sibling) | `mcp__serena__insert_before_symbol`, `mcp__serena__insert_after_symbol` | No anchor needed for a moving boundary |
-| Delete a symbol and check for orphaned references | `mcp__serena__safe_delete_symbol` | Validates xrefs before the cut — `tilth_edit` would happily strand callers |
+| Delete a symbol and check for orphaned references | `mcp__serena__safe_delete_symbol` | Validates xrefs before the cut — `tilth_write` would happily strand callers |
 
 `/cheez-write` itself stays tilth-only — its `allowed-tools` frontmatter does not include `mcp__serena__*` and shouldn't. The routing decision happens in the workflow skill *before* it enters `/cheez-write`, preserving the hash-anchor concurrency floor.
 
-**Caveat — no hash-anchor concurrency safety.** Serena's edits rely on LSP and file mtime, not the content-hash check that makes `tilth_edit` race-safe. The workflow skill should route to Serena only when the file is quiescent (no parallel writers, no in-flight `/cook` or `/cure` on the same path). Route back into `/cheez-write` whenever concurrency safety dominates, the symbol isn't LSP-resolvable (broken or generated code), the edit is sub-symbol (one line inside a function), or Serena is unavailable. The cheez-write floor — `tilth_edit` for everything that touches code from inside this skill — still applies; Serena is a routing alternative the caller chooses, not an in-skill acceleration.
+**Caveat — no hash-anchor concurrency safety.** Serena's edits rely on LSP and file mtime, not the content-hash check that makes `tilth_write` race-safe. The workflow skill should route to Serena only when the file is quiescent (no parallel writers, no in-flight `/cook` or `/cure` on the same path). Route back into `/cheez-write` whenever concurrency safety dominates, the symbol isn't LSP-resolvable (broken or generated code), the edit is sub-symbol (one line inside a function), or Serena is unavailable. The cheez-write floor — `tilth_write` for everything that touches code from inside this skill — still applies; Serena is a routing alternative the caller chooses, not an in-skill acceleration.
 
 ---
 
@@ -164,17 +163,17 @@ hashes change, and your edit is safely rejected.
 
 ## MCP Tool Reference
 
-### tilth_edit — Precise File Editing
+### tilth_write — Precise File Editing
 
 The minimal shape — single anchor, replacement content:
 
 ```json
-tilth_edit({
+tilth_write(files: [{
   "path": "src/auth.ts",
   "edits": [
     { "start": "42:a3f", "content": "  let x = recompute();" }
   ]
-})
+}])
 ```
 
 For range replacement, deletion, multi-edit, insert-after, cross-file
@@ -189,7 +188,7 @@ JSON cookbook; this body sticks to the protocol.
 ### Step 1: Read to Get Anchors
 
 ```
-tilth_read(path: "src/auth.ts", section: "44-89")
+tilth_read(paths: ["src/auth.ts#44-89"])
 ```
 
 Output:
@@ -209,14 +208,14 @@ Output:
 ### Step 3: Edit with Anchors
 
 ```json
-tilth_edit({
+tilth_write(files: [{
   "path": "src/auth.ts",
   "edits": [{
     "start": "44:b2c",
     "end": "89:e1d",
     "content": "export function handleAuth(req, res, next) {\n  const token = extractToken(req);\n  if (!validateToken(token)) {\n    return res.status(401).json({ error: 'Invalid token' });\n  }\n  req.user = decodeToken(token);\n  next();\n}"
   }]
-})
+}])
 ```
 
 ---
@@ -227,10 +226,10 @@ This is the most common use case. The pattern:
 
 1. **Read the function** (outline first if file is large):
    ```
-   tilth_read(path: "src/auth.ts")
+   tilth_read(paths: ["src/auth.ts"])
    # See: [44-89]  export fn handleAuth(req, res, next)
 
-   tilth_read(path: "src/auth.ts", section: "44-89")
+   tilth_read(paths: ["src/auth.ts#44-89"])
    # Get hash anchors
    ```
 
@@ -238,14 +237,14 @@ This is the most common use case. The pattern:
 
 3. **Replace the entire function body:**
    ```json
-   tilth_edit({
+   tilth_write(files: [{
      "path": "src/auth.ts",
      "edits": [{
        "start": "44:b2c",
        "end": "89:e1d",
        "content": "<your new function implementation>"
      }]
-   })
+   }])
    ```
 
 ---
@@ -274,7 +273,7 @@ This is a **safety feature**, not a bug.
 ### Repeated mismatches → bail out, don't loop
 
 If you hit **two consecutive mismatches** on the same anchor, you're racing a
-concurrent writer. `tilth_edit` has no fuzzy / search-replace mode — there
+concurrent writer. `tilth_write` has no fuzzy / search-replace mode — there
 is no "ignore the hash, just match this string" option. A third retry will
 likely lose the same race.
 
@@ -297,7 +296,7 @@ retry could overwrite real work.
 
 ## Caller Updates After Signature Changes
 
-When you edit a function signature, tilth_edit shows callers that may need updating:
+When you edit a function signature, tilth_write shows callers that may need updating:
 
 ```
 Edit applied to src/auth.ts
@@ -321,7 +320,7 @@ Check these locations and update if needed.
 | Delete a block | range with `content: ""` | [edit-patterns.md#delete-a-block](references/edit-patterns.md#delete-a-block) |
 | Insert after a line | anchor on that line, prepend its content | [edit-patterns.md#insert-after-a-line](references/edit-patterns.md#insert-after-a-line) |
 | Multi-edit in one file | `edits: [...]` ordered bottom-up | [edit-patterns.md#multiple-edits-in-one-call](references/edit-patterns.md#multiple-edits-in-one-call) |
-| Cross-file change | one `tilth_edit` call per file | [edit-patterns.md#edits-across-multiple-files](references/edit-patterns.md#edits-across-multiple-files) |
+| Cross-file change | one `tilth_write` call per file | [edit-patterns.md#edits-across-multiple-files](references/edit-patterns.md#edits-across-multiple-files) |
 
 ---
 
@@ -342,7 +341,7 @@ For large files, tilth_read shows an outline, not hashlined content:
 **To edit, drill into the specific section:**
 
 ```
-tilth_read(path: "src/giant.ts", section: "100-180")
+tilth_read(paths: ["src/giant.ts#100-180"])
 # Now you get hashlined content for fn process
 ```
 
@@ -364,7 +363,7 @@ published numbers, can.ac analysis, the Morph benchmark) showing full-file
 rewrites tie or beat diff-style on small files. The threshold keeps the
 spirit conservative — large files always stay anchored.
 
-When you do rewrite a small file in full, still use `tilth_edit` (anchor on
+When you do rewrite a small file in full, still use `tilth_write` (anchor on
 line 1, end-anchor on the last line). Do **not** drop to host `Write` —
 that bypasses tilth's hash-mismatch safety.
 
@@ -372,7 +371,7 @@ that bypasses tilth's hash-mismatch safety.
 
 ## Structural codemods — `sg --rewrite` escape
 
-`tilth_edit` excels at "replace this specific block in this specific file"
+`tilth_write` excels at "replace this specific block in this specific file"
 with hash-anchor concurrency safety. It handles cross-cutting structural
 changes awkwardly: one file at a time, one read-for-anchors per location.
 For codemods — "rewrite every `JSON.parse(JSON.stringify($X))` to
@@ -384,12 +383,12 @@ The two tools are **complementary, not redundant**:
 
 | Tool | Safety property | Best for |
 |------|------------------|----------|
-| `tilth_edit` | Hash-anchor (concurrency) | Specific-block edits, signature changes |
+| `tilth_write` | Hash-anchor (concurrency) | Specific-block edits, signature changes |
 | `sg --rewrite` | Structural match (CST) | Cross-cutting codemods over N files |
 
 When the change repeats across many locations and the surrounding text
 varies, `sg --rewrite` captures the variable parts via metavars and templates
-them back into the rewrite — `tilth_edit` cannot express that without N
+them back into the rewrite — `tilth_write` cannot express that without N
 reads.
 
 For invocation rules (`--lang`, `--json`, no `--interactive`), pitfalls
@@ -413,10 +412,10 @@ additional edits on top until the codemod is committed or reverted.
 - **DO NOT guess hash values** — always read first to get current anchors.
 - **DO NOT ignore hash mismatches** — re-read and retry (see Hash Mismatch Handling).
 - **DO NOT use sed / awk / perl -i** to edit code — they bypass hash anchors and structural safety, and have no mismatch detection. `sg --rewrite` is the *only* sanctioned shell escape, and only for structural codemods that follow the dry-run-first protocol.
-- **DO NOT use `patch`** to apply diffs to code — `tilth_edit`'s anchored ranges are the safe equivalent.
-- **DO NOT use `tee` or shell redirects (`>`, `>>`)** to overwrite/append code files — both bypass anchors. Use `tilth_edit`.
-- **DO NOT use the host Edit/Write tool** — use `tilth_edit` (or `sg --rewrite` for structural codemods) exclusively for code.
-- **DO NOT use `sg --rewrite` for one-off block edits** — that's `tilth_edit` territory. The codemod escape is only for cross-cutting structural changes; using it on a single location wastes its strength and skips hash-anchor safety.
+- **DO NOT use `patch`** to apply diffs to code — `tilth_write`'s anchored ranges are the safe equivalent.
+- **DO NOT use `tee` or shell redirects (`>`, `>>`)** to overwrite/append code files — both bypass anchors. Use `tilth_write`.
+- **DO NOT use the host Edit/Write tool** — use `tilth_write` (or `sg --rewrite` for structural codemods) exclusively for code.
+- **DO NOT use `sg --rewrite` for one-off block edits** — that's `tilth_write` territory. The codemod escape is only for cross-cutting structural changes; using it on a single location wastes its strength and skips hash-anchor safety.
 - **DO NOT skip the dry-run-first protocol for `sg --rewrite`** — search-only first, clean working tree, then `-U`. Never combine search+rewrite blindly.
 - **DO NOT edit without reading** — you need the anchors.
 - **DO NOT use for reading** — use cheez-read.

--- a/skills/cheez-write/references/edit-patterns.md
+++ b/skills/cheez-write/references/edit-patterns.md
@@ -1,8 +1,9 @@
-# `tilth_edit` JSON cookbook
+# `tilth_write` JSON cookbook
 
-Every edit follows the same shape: `{ path, edits: [...] }`. Each edit needs
-a `start` anchor; `end` is required only for range replacements. `content` is
-the new text (use `""` to delete).
+Every call is `tilth_write(files: [ … ])`; each entry in the `files` array has the
+shape `{ path, edits: [...] }` — the JSON blocks below show a single entry. Each
+edit needs a `start` anchor; `end` is required only for range replacements.
+`content` is the new text (use `""` to delete).
 
 ## Single-line replacement
 
@@ -15,8 +16,8 @@ the new text (use `""` to delete).
 }
 ```
 
-Replaces line 42 only. The hash `a3f` must match what `tilth_read` returned
-in edit mode.
+Replaces line 42 only. The hash `a3f` must match the `<line>:<hash>` prefix
+`tilth_read` returned for that line.
 
 ## Multi-line range replacement
 
@@ -66,22 +67,18 @@ earlier edits don't invalidate later anchors.
 
 ## Show diff in response
 
-```json
-{
-  "path": "src/auth.ts",
-  "diff": true,
-  "edits": [
-    { "start": "44:b2c", "end": "89:e1d", "content": "..." }
-  ]
-}
+```text
+tilth_write(files: [{ path: "src/auth.ts", edits: [{ start: "44:b2c", end: "89:e1d", content: "..." }] }], diff: true)
 ```
+
+`diff` is a top-level call argument (it diffs each file in the response), not a per-entry property.
 
 Useful when the change is non-trivial and you want to verify the diff before
 moving on.
 
 ## Insert "after" a line
 
-`tilth_edit` replaces the anchored line(s); there is no native insert. To
+`tilth_write` replaces the anchored line(s); there is no native insert. To
 insert after line 13, anchor on line 13 and prepend the original line content
 to your new content:
 
@@ -103,20 +100,24 @@ this — the original content goes back verbatim.
 
 ## Edits across multiple files
 
-`tilth_edit` is single-file. For multi-file changes, make one call per file:
+`tilth_write` is multi-file: batch every file into ONE call's `files` array
+(max 20). Never call `tilth_write` twice in a row.
 
 ```text
-tilth_edit({ path: "src/auth.ts",   edits: [...] })
-tilth_edit({ path: "src/routes.ts", edits: [...] })
+tilth_write(files: [
+  { path: "src/auth.ts",   edits: [...] },
+  { path: "src/routes.ts", edits: [...] },
+])
 ```
 
-There is no atomic cross-file edit. If the second call fails after the first
-succeeded, you have a partially applied change — read the second file and
-recover before moving on.
+Files are processed independently (best-effort): a failure on one does not block
+the others, and partial success still returns `isError: false` — scan the
+per-file results rather than the top-level status. There is no atomic cross-file
+edit, so on a partial failure read the unchanged file and recover before moving on.
 
 ## Caller-update notices
 
-When you change a function signature, `tilth_edit` may surface callers in
+When you change a function signature, `tilth_write` may surface callers in
 its response:
 
 ```text

--- a/skills/cook/SKILL.md
+++ b/skills/cook/SKILL.md
@@ -54,6 +54,8 @@ Code search, reading, and editing all go through the `cheez-*` skills (`/cheez-s
 | GitHub context | `gh` | local git history or user-provided links |
 | Merge assistance | mergiraf | manual conflict resolution with tests |
 | Task commands | `just`, package scripts | direct documented commands |
+| Code navigation | `/cheez-search` `kind:symbol` then `kind:callers` | `tilth_search` direct |
+| Read before edit | `/cheez-read` ranged/outline (`paths: ["f#n-m"]`, `mode:stripped`) | DO NOT `cat`/`sed -n`/host Read on code paths |
 
 When a preferred tool is unavailable, continue with the fallback and mention any loss of precision if it affects risk.
 

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -48,6 +48,8 @@ Beyond `cheez-*` there are cure-specific tools:
 | CI and PR context | `gh` | local test output or user-provided logs |
 | Diffs | `delta` | plain `git diff` |
 | Conflict resolution | mergiraf | manual resolution with targeted tests |
+| Code navigation | `/cheez-search` `kind:symbol` then `kind:callers` | `tilth_search` direct |
+| Read before edit | `/cheez-read` ranged/outline (`paths: ["f#n-m"]`, `mode:stripped`) | DO NOT `cat`/`sed -n`/host Read on code paths |
 
 **Freshness:** before the first code-review-graph query in a run, call `build_or_update_graph_tool`. See [`/cheez-search`](../cheez-search/SKILL.md#when-code-review-graph-beats-tilth-if-your-harness-has-it) for the full freshness contract and when semantic search beats tilth.
 

--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -181,7 +181,7 @@ If the chain stopped on a halt, replace "Next step" with the halt reason and the
 |-----------------------------------|-----------------------|-----------------------------------|
 | Spawning the per-phase worker     | `Agent()` / harness sub-agent primitive | none — without sub-agent spawn, the fresh-context property cannot be honoured |
 | Reading the handoff slug          | `cheez-read` / host file read | host file read                    |
-| Detecting existing handoffs       | host file glob / list | `cheez-search` `tilth_files` glob |
+| Detecting existing handoffs       | host file glob / list | `cheez-read` `tilth_list` glob     |
 
 If the host harness does not expose a sub-agent primitive at all, `/ultracook` is the wrong skill — recommend `/cook --auto` instead, which uses the same flag semantics in the parent's own context.
 


### PR DESCRIPTION
## Summary

Two ordered passes over the cheez-* skill docs (correctness first, then the AST-search steer), fixing the skills against the **current** tilth MCP API.

Closes #165
Closes #166

### #165 — correctness (stale tilth API)

The cheez-* skills targeted an older tilth API. Corrected to ground truth (verified against the live tilth tool schemas):

- `tilth_edit` → `tilth_write`, `tilth_files` → `tilth_list` (those verbs don't exist).
- `cheez-write` capability check now targets `mcp__tilth__tilth_write` — it previously checked for `tilth_edit`, which never registers, so a faithful agent always false-bailed "edit mode disabled".
- `tilth_read` examples use `paths: [...]` + suffix grammar (`#n-m`, `#symbol_name`); `tilth_search` uses `queries: [{query: ...}]`; `root` note added for relative scope/paths.
- Reference docs reconciled too: `edit-patterns.md` rewritten to `tilth_write`'s real multi-file `files: [...]` batch model (top-level `diff`, standard hashline reads), `sg-patterns.md` verb fixes.

### #166 — steer toward AST symbol/callers search

- Navigation-default steer (`kind:symbol` → `kind:callers`) above the `cheez-search` kind table.
- Ordering rule added to the shared `age/references/sub-agent-gate.md` (single home — not duplicated per phase skill).
- Code-navigation + read-before-edit rows added to the `cook` and `cure` preferred-tools tables.
- `cheez-read` documents the `#symbol_name` suffix and `mode:stripped`.

## Verification

- An agent following only the corrected skill text produces valid tilth calls (reviewed at opus tier against the live tilth schemas).
- `markdownlint` clean on all touched files.
- Skill validator: 16/16 pass.

## Out of scope (follow-up)

These carry the same `tilth_edit`/`tilth_files` staleness but sit outside the cheez-* skills and were deliberately left out:

- `README.md` tool-redirection table.
- `skills/ultracook/SKILL.md:184` (fallback description).
- `skills/cheez-search/references/tilth-deps.md:54` (singular `query:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<https://claude.ai/code/session_01VdxkuyL2GmTc653fVhBYox>
