### PR TITLE
feat(wheypoint): wire next-session focus argument into the handoff write step

### DIFF
--- a/skills/wheypoint/SKILL.md
+++ b/skills/wheypoint/SKILL.md
@@ -19,7 +19,7 @@ license: MIT
 
 1. **Derive a slug** from the task (e.g. `auth-retry-backoff`). Reuse an existing slug if this session already owns one under `.cheese/`.
 2. **Inventory what already exists.** List the `.cheese/` artifacts, specs, PRs, issues, commits, and diffs this session produced or touched. These get referenced, never re-summarised.
-3. **Write the handoff document** to `.cheese/notes/<slug>.md` with the slug header (`## Handoff slug`) and body (`## Document`) below.
+3. **Write the handoff document** to `.cheese/notes/<slug>.md` with the slug header (`## Handoff slug`) and body (`## Document`) below. When a focus argument was given, apply it as the lens throughout: emphasise state and decisions that serve the focus, and compress everything else to a one-line pointer.
 4. **Redact** secrets on the way out (`## Redaction`).
 5. **Point at resumption.** End by telling the user how to resume with `/cheese --continue <slug>` from the original repo, and include an absolute clickable path to the handoff note so the user can find it from any working directory.
 


### PR DESCRIPTION
Closes #157.

The optional focus argument was already documented in Inputs and Suggested skills, but Flow step 3 (write the handoff document) never applied the lens. Adds one sentence directing the write step to emphasise focus-relevant state and compress the rest — a consistency tweak, not new machinery (verified the existing wiring first, per the issue).

Taste-test (orchestrator pre-handoff review, opus): **pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tn7CUsGkgs18kU7iZwVC86