### PR TITLE
docs(pasteurize): failed-fix escalation + seam-correctness check

### DIFF
--- a/skills/pasteurize/SKILL.md
+++ b/skills/pasteurize/SKILL.md
@@ -89,6 +89,8 @@ A correct seam is one where the test exercises the **real bug pattern** as it oc
 
 **If no correct seam exists, that itself is the finding.** Note it in the handoff slug as an architectural follow-up. The codebase is preventing the bug from being locked down. Skip the test write; do not paper over it. Phase 6's "what would have prevented this bug?" retrospective still applies.
 
+**Before writing the test, confirm the seam is correct:** verify that the test you're about to write targets the boundary where the bug actually occurs — the real call site, the real data path, the real failure mode. A test at the wrong seam (too shallow, wrong abstraction level, mocked-away side that hides the failure) will pass after the fix but won't catch a regression. If you discover the seam is wrong at this point, treat it as "no correct seam" and follow the halt path above.
+
 If a correct seam exists:
 
 1. Turn the minimised repro into a failing test at that seam.
@@ -96,6 +98,8 @@ If a correct seam exists:
 3. Apply the **smallest** production change that makes the test pass. No scope creep, no "while I'm here" cleanup.
 4. Watch the test pass.
 5. Re-run the Phase 1 feedback loop against the original (un-minimised) scenario to confirm the symptom is gone, not just the test seam.
+
+**After 3 failed fix attempts** (3 cycles of "apply change → watch test → revert because test still fails"), stop attempting fixes and re-question the approach: is the hypothesis from Phase 3 actually correct? Is the seam exposing the right failure? Is the bug at a different layer than assumed? Step back to Phase 3 and generate a fresh ranked hypothesis list — do NOT attempt a 4th blind fix. If the re-questioning produces a new hypothesis, restart from Phase 4. If all hypotheses are exhausted, write `status: halt: fix attempts exhausted — architectural re-examination needed` and route to `/mold`.
 
 Broader implementation (related cleanup, follow-on changes, anything beyond the minimal fix) is **not** pasteurize's job. Note it in the slug and let `/cook --auto` pick it up in Phase 6's handoff.
 

--- a/skills/pasteurize/SKILL.md
+++ b/skills/pasteurize/SKILL.md
@@ -89,13 +89,13 @@ A correct seam is one where the test exercises the **real bug pattern** as it oc
 
 **If no correct seam exists, that itself is the finding.** Note it in the handoff slug as an architectural follow-up. The codebase is preventing the bug from being locked down. Skip the test write; do not paper over it. Phase 6's "what would have prevented this bug?" retrospective still applies.
 
-**Before writing the test, confirm the seam is correct:** verify that the test you're about to write targets the boundary where the bug actually occurs — the real call site, the real data path, the real failure mode. A test at the wrong seam (too shallow, wrong abstraction level, mocked-away side that hides the failure) will pass after the fix but won't catch a regression. If you discover the seam is wrong at this point, treat it as "no correct seam" and follow the halt path above.
+**Before writing the test, confirm the seam is correct:** verify that the test you're about to write targets the boundary where the bug actually occurs — the real call site, the real data path, the real failure mode. A test at the wrong seam (too shallow, wrong abstraction level, mocked-away side that hides the failure) will pass after the fix but won't catch a regression. If you discover the seam is wrong at this point, treat it as "no correct seam": write `status: halt: no correct regression-test seam` and route to `/mold`, per the halt path above.
 
 If a correct seam exists:
 
 1. Turn the minimised repro into a failing test at that seam.
 2. Watch it fail.
-3. Apply the **smallest** production change that makes the test pass. No scope creep, no "while I'm here" cleanup.
+3. Apply the **smallest** production change that makes the test pass. No scope creep, no "while I'm here" cleanup. If the test still fails, revert and retry — but cap the retries (see **After 3 failed fix attempts** below).
 4. Watch the test pass.
 5. Re-run the Phase 1 feedback loop against the original (un-minimised) scenario to confirm the symptom is gone, not just the test seam.
 
@@ -190,6 +190,7 @@ When invoked with `--auto`, skip this host-routed question entirely and invoke `
 - Phase 3 disproves all hypotheses across two rounds (cap at two Phase 3 rounds, then halt).
 - Phase 5's seam check finds no correct seam — write `status: halt: no correct regression-test seam` and route to `/mold` instead of `/cook`.
 - The fix breaks an unrelated test that pasteurize cannot reconcile within scope.
+- Phase 5's fix loop exhausts all hypotheses after 3 failed fix attempts — write `status: halt: fix attempts exhausted — architectural re-examination needed` and route to `/mold` instead of `/cook`.
 
 In every early-stop case, write the halt slug and surface the report. Do not silently downgrade to "best guess".
 


### PR DESCRIPTION
Closes #163.

Two clauses added to Phase 5: (1) after 3 failed fix attempts, re-question the Phase 3 architecture/seam instead of attempting a 4th blind fix (routes to halt + /mold on exhaustion); (2) a seam-correctness check before the regression-test write step.

Taste-test (orchestrator pre-handoff review, opus): **pass** (one non-blocking note: minor prose overlap with the existing 'correct seam' definition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tn7CUsGkgs18kU7iZwVC86