### PR TITLE
docs(cheez): rationalization-rebuttal tables for cheez-read/write/search

### DIFF
--- a/skills/cheez-read/SKILL.md
+++ b/skills/cheez-read/SKILL.md
@@ -140,3 +140,11 @@ in cheez-search:
 - **DO NOT use to run code or tests** — use the project's build/test skills.
 - **DO NOT use to commit** — use git/gh skills.
 - **DO NOT ignore hash anchors** — they are required for edits.
+
+---
+
+## Discipline
+
+Iron Law, Red Flags, and the read Rationalization table live in
+[`references/cheez-read-discipline.md`](references/cheez-read-discipline.md).
+See [`../../shared/skill-authoring.md`](../../shared/skill-authoring.md) for the template these follow.

--- a/skills/cheez-read/references/cheez-read-discipline.md
+++ b/skills/cheez-read/references/cheez-read-discipline.md
@@ -1,0 +1,40 @@
+# cheez-read — Read Discipline
+
+See [`../../../shared/skill-authoring.md`](../../../shared/skill-authoring.md) for the
+Iron Law / Red Flags / Rationalization-table template that governs this section.
+
+---
+
+## Iron Law
+
+**No file read via host tools when tilth is available.**
+
+Every read of a tracked source file goes through `tilth_read` or `tilth_list`.
+Host `Read`, `Glob`, `cat`, `head`, `tail`, `ls`, and `find` are not used on
+code paths. If tilth is unavailable, stop and report; do not silently fall back.
+
+---
+
+## Red Flags
+
+Stop if you notice yourself thinking any of these:
+
+- "The file is small; host Read is faster than tilth."
+- "I already know the path and line range; I don't need tilth_read."
+- "tilth is slow right now; I'll just cat the file."
+- "The host Read tool is already open in my context; I'll use it this once."
+- "I only need one line; `sed -n` is simpler."
+
+Each of these is a rationalization. Name it and stop.
+
+---
+
+## Rationalization table
+
+| Rationalization | Why it fails | Required action |
+| --- | --- | --- |
+| "The file is small; I'll use host Read — it's equivalent." | Host Read emits no hash anchors, bypasses session deduplication, and cannot outline large files. Any subsequent edit will lack a safe anchor. | Use `tilth_read`. Small files are exactly the case where the cost is lowest. |
+| "I already know the line range; I'll skip the read." | Hash anchors are required by cheez-write. Without a read, the write step has no anchor and either guesses (unsafe) or fails. | Read the range first with `tilth_read` to capture current anchors. |
+| "tilth is unavailable; I'll fall back to `cat`/`sed -n`." | The fallback produces no anchors and silently breaks the read-edit protocol for every downstream edit. | Stop and report the tilth unavailability. Do not fall back. |
+| "I only need the directory listing; `ls` is fine." | `ls` lacks token estimates and `.gitignore` filtering. A tilth_list result informs budget decisions that `ls` cannot. | Use `tilth_list`. |
+| "I just read this file; I'll reuse the content from memory." | In-context content may have drifted if any edit occurred since the read. Anchors in memory are stale if the file changed. | Re-read if any edit occurred since the last read of that file. |

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -139,3 +139,11 @@ For shapes with metavars (`$X`, `$$$BODY`) drop to `sg` via Bash -- the only san
 - **Not for editing code** -- use cheez-write.
 - **Not for running tests** -- use test/build skills.
 - **Not for git operations** -- use git/gh skills.
+
+---
+
+## Discipline
+
+Iron Law, Red Flags, and the search Rationalization table live in
+[`references/cheez-search-discipline.md`](references/cheez-search-discipline.md).
+See [`../../shared/skill-authoring.md`](../../shared/skill-authoring.md) for the template these follow.

--- a/skills/cheez-search/references/cheez-search-discipline.md
+++ b/skills/cheez-search/references/cheez-search-discipline.md
@@ -25,7 +25,7 @@ Stop if you notice yourself thinking any of these:
 - "I already know the path; I'll skip the search and read directly."
 - "tilth search is slow; I'll grep for this one."
 - "It's a simple string; `rg` is faster than tilth_search."
-- "I'll use `find` to locate the file, then tilth_read."
+- "I'll use `find` to locate the file, then read it." (file discovery belongs to `cheez-read` / `tilth_list`, not `find`.)
 - Reaching for Bash `grep`/`rg` without first checking whether tilth can answer.
 
 Each of these is a rationalization. Name it and stop.
@@ -39,5 +39,5 @@ Each of these is a rationalization. Name it and stop.
 | "I already know the path; I'll skip the search." | Knowing a path is not the same as knowing the current symbol location. Functions move, files are renamed. A skipped search leads to a stale read. | Run `tilth_search` to confirm the current definition location before reading or editing. |
 | "It's a simple string match; `grep`/`rg` is equivalent." | `grep`/`rg` return raw line matches with no semantic context (definition vs. usage, caller vs. string literal). tilth_search's `kind` parameter filters these correctly. | Use `tilth_search` with `kind: "content"` for literal matches, `kind: "callers"` for call sites. |
 | "tilth is unavailable; I'll fall back to `rg`." | The fallback produces no semantic tags and breaks the tool contract that callers depend on. | Stop and report the tilth unavailability. Do not fall back. |
-| "I'll use `find` to locate the file, then tilth_read to read it." | `find` bypasses `.gitignore` filtering and emits no token estimates. `tilth_list` does both correctly. | Use `tilth_list` for file discovery. |
+| "I'll use `find` to locate the file, then read it." | `find` bypasses `.gitignore` filtering and emits no token estimates. `cheez-read`'s `tilth_list` does both correctly. | Route file discovery to `cheez-read` (its `tilth_list`); `cheez-search` does not own listing or reading. |
 | "The result set will be huge; I'll scope with `grep` first, then tilth." | Scoping with grep before tilth breaks the semantic kind system and can miss definition-tagged results. | Pass a tighter `scope` or `glob` parameter to `tilth_search` instead. |

--- a/skills/cheez-search/references/cheez-search-discipline.md
+++ b/skills/cheez-search/references/cheez-search-discipline.md
@@ -1,0 +1,43 @@
+# cheez-search — Search Discipline
+
+See [`../../../shared/skill-authoring.md`](../../../shared/skill-authoring.md) for the
+Iron Law / Red Flags / Rationalization-table template that governs this section.
+
+---
+
+## Iron Law
+
+**No code search via host shell tools when tilth is available.**
+
+Every symbol lookup, caller query, or content search in tracked source files
+goes through `tilth_search`. Host `grep`, `rg`, `ripgrep`, `ag`, `ack`,
+`find`, `fd`, and `Glob` are not used for code search. `sg` (ast-grep) is
+the only sanctioned shell escape, and only for structural metavariable
+patterns tilth cannot express. If tilth is unavailable, stop and report;
+do not silently fall back.
+
+---
+
+## Red Flags
+
+Stop if you notice yourself thinking any of these:
+
+- "I already know the path; I'll skip the search and read directly."
+- "tilth search is slow; I'll grep for this one."
+- "It's a simple string; `rg` is faster than tilth_search."
+- "I'll use `find` to locate the file, then tilth_read."
+- Reaching for Bash `grep`/`rg` without first checking whether tilth can answer.
+
+Each of these is a rationalization. Name it and stop.
+
+---
+
+## Rationalization table
+
+| Rationalization | Why it fails | Required action |
+| --- | --- | --- |
+| "I already know the path; I'll skip the search." | Knowing a path is not the same as knowing the current symbol location. Functions move, files are renamed. A skipped search leads to a stale read. | Run `tilth_search` to confirm the current definition location before reading or editing. |
+| "It's a simple string match; `grep`/`rg` is equivalent." | `grep`/`rg` return raw line matches with no semantic context (definition vs. usage, caller vs. string literal). tilth_search's `kind` parameter filters these correctly. | Use `tilth_search` with `kind: "content"` for literal matches, `kind: "callers"` for call sites. |
+| "tilth is unavailable; I'll fall back to `rg`." | The fallback produces no semantic tags and breaks the tool contract that callers depend on. | Stop and report the tilth unavailability. Do not fall back. |
+| "I'll use `find` to locate the file, then tilth_read to read it." | `find` bypasses `.gitignore` filtering and emits no token estimates. `tilth_list` does both correctly. | Use `tilth_list` for file discovery. |
+| "The result set will be huge; I'll scope with `grep` first, then tilth." | Scoping with grep before tilth breaks the semantic kind system and can miss definition-tagged results. | Pass a tighter `scope` or `glob` parameter to `tilth_search` instead. |

--- a/skills/cheez-write/SKILL.md
+++ b/skills/cheez-write/SKILL.md
@@ -211,3 +211,11 @@ that bypasses tilth's hash-mismatch safety.
 - **DO NOT edit without reading** — you need the anchors.
 - **DO NOT run tests, commit, or review from this skill** — use the project's test/build, git/gh, and `/age` skills.
 - **DO NOT use for reading or searching** — read with `/cheez-read`, search with `/cheez-search`.
+
+---
+
+## Discipline
+
+Iron Law, Red Flags, and the write Rationalization table live in
+[`references/cheez-write-discipline.md`](references/cheez-write-discipline.md).
+See [`../../shared/skill-authoring.md`](../../shared/skill-authoring.md) for the template these follow.

--- a/skills/cheez-write/references/cheez-write-discipline.md
+++ b/skills/cheez-write/references/cheez-write-discipline.md
@@ -1,0 +1,43 @@
+# cheez-write — Write Discipline
+
+See [`../../../shared/skill-authoring.md`](../../../shared/skill-authoring.md) for the
+Iron Law / Red Flags / Rationalization-table template that governs this section.
+
+---
+
+## Iron Law
+
+**No code edit without reading for hash anchors first.**
+
+Every edit to a tracked source file goes through `tilth_write` with anchors
+obtained from a preceding `tilth_read`. Host `Edit`, `Write`, `sed`, `awk`,
+`perl -i`, `patch`, `tee`, and shell redirects are not used on code paths.
+If tilth is unavailable, stop and report; do not silently fall back.
+
+---
+
+## Red Flags
+
+Stop if you notice yourself thinking any of these:
+
+- "The file is small; I'll just use the host Edit tool."
+- "I already read this file earlier; I can skip the re-read."
+- "tilth is unavailable; I'll fall back to sed."
+- "It's a one-line fix; I'll guess the anchor."
+- "The host Write tool is simpler for this new file."
+- Reaching for `sed -i`, `awk -i`, or `patch` without first checking tilth availability.
+
+Each of these is a rationalization. Name it and stop.
+
+---
+
+## Rationalization table
+
+| Rationalization | Why it fails | Required action |
+| --- | --- | --- |
+| "The file is small; host Edit is equivalent." | Host Edit bypasses hash anchors, so a concurrent change or an earlier stale read produces a silently incorrect edit. | Use `tilth_write` with anchors from `tilth_read`. |
+| "I read this file earlier; the anchors are still valid." | Any edit — by any agent or tool — since the last read invalidates anchors. Stale anchors silently corrupt a different line. | Re-read the target range immediately before writing. |
+| "tilth is unavailable; I'll fall back to `sed`/`awk`/`perl -i`." | These tools have no mismatch detection. A file changed between read and write produces a corrupted result with no error. | Stop and report the tilth unavailability. Do not fall back. |
+| "It's a one-line fix; I can guess the line number." | Line numbers shift with every edit. A guessed line number edits the wrong content without warning. | Read the range with `tilth_read` to confirm the current anchor before writing. |
+| "This is a new file; I'll use host Write to create it." | Host Write bypasses tilth's write path. Even new files should go through `tilth_write` (overwrite mode) to stay on the safe path. | Use `tilth_write` with `mode: "overwrite"` for new files. |
+| "The edit is mechanical; I don't need to verify the diff." | Mechanical edits fail anchor checks at the same rate as complex ones. "Mechanical" describes the intent, not the risk. | Read the target, confirm the anchor, then write. |


### PR DESCRIPTION
Closes #152.

Extends the rationalization-rebuttal tables (added to cook/cure in PR #138) to the three cheez-* skills via new `references/<skill>-discipline.md` files plus a `## Discipline` pointer in each SKILL.md, matching the cook/cure format. Rationalizations are specific to each skill's silent-degrade traps (host Read/Edit/grep fallbacks, skipping reads, guessing anchors). The #153 verification clause is intentionally excluded (separate PR).

Taste-test (orchestrator pre-handoff review, opus): **pass**. Note: the new files inherit a *pre-existing* repo-wide dead link (`shared/skill-authoring.md`) verbatim from the cook/cure template they were required to match — flagged for a separate repo-wide cleanup, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tn7CUsGkgs18kU7iZwVC86