### PR TITLE
docs(ultracook): foreground-only spawn directive + timeout + 2-cap re-dispatch

### DIFF
--- a/skills/cheese-factory/references/spawn-primitive-reference.md
+++ b/skills/cheese-factory/references/spawn-primitive-reference.md
@@ -30,7 +30,7 @@ Agent(
            Run in the foreground — do not background yourself, spawn
            detached processes, or defer work to a later session.
            If you cannot complete the phase within your context window,
-           write a partial slug with status: halt and stop; do not
+           write a partial slug with status: halt: <reason> and stop; do not
            silently timeout."
 )
 ```
@@ -55,7 +55,8 @@ copilot fleet \
 
 Rules:
 
-- Each prompt in the prompt file must include the no-chain-forward directive and the foreground-only directive (run in the foreground; do not background yourself or defer work; write a partial slug with status: halt if the context window is exhausted, do not silently timeout).
+- Each prompt in the prompt file must include the no-chain-forward directive and the foreground-only directive (run in the foreground; do not background yourself or defer work; write a partial slug with `status: halt: <reason>` if the context window is exhausted, do not silently timeout).
+- `--return-on-completion` is mandatory; without it, control does not return to the orchestrator (invariant 4 fails).
 - Fleet agents inherit the same model and tool scope as the parent session, satisfying invariant 2.
 - Each agent must write the handoff slug to `.cheese/cheese-factory/<slug>/curds/<id>.md` per the per-curd prompt template.
 
@@ -76,7 +77,7 @@ Rules:
 - `--type general-purpose` (or equivalent) — never pass a scoped worker type.
 - `--inherit-tools` — full-peer inheritance per invariant 2.
 - `--wait` — synchronous return so the orchestrator can read the handoff slug.
-- The prompt file must include the no-chain-forward directive and the foreground-only directive (run in the foreground; do not background yourself or defer work; write a partial slug with status: halt if the context window is exhausted, do not silently timeout).
+- The prompt file must include the no-chain-forward directive and the foreground-only directive (run in the foreground; do not background yourself or defer work; write a partial slug with `status: halt: <reason>` if the context window is exhausted, do not silently timeout).
 
 ## Other / future harnesses
 

--- a/skills/cheese-factory/references/spawn-primitive-reference.md
+++ b/skills/cheese-factory/references/spawn-primitive-reference.md
@@ -26,7 +26,12 @@ Agent(
            .cheese/<phase>/<slug>.md with the handoff schema and stop.
            Do not chain forward to the next phase even though your
            auto-mode contract documents that. The /cheese-factory orchestrator
-           is driving the chain."
+           is driving the chain.
+           Run in the foreground — do not background yourself, spawn
+           detached processes, or defer work to a later session.
+           If you cannot complete the phase within your context window,
+           write a partial slug with status: halt and stop; do not
+           silently timeout."
 )
 ```
 
@@ -50,8 +55,7 @@ copilot fleet \
 
 Rules:
 
-- Each prompt in the prompt file must include the no-chain-forward directive.
-- `--return-on-completion` is mandatory; without it, control does not return to the orchestrator (invariant 4 fails).
+- Each prompt in the prompt file must include the no-chain-forward directive and the foreground-only directive (run in the foreground; do not background yourself or defer work; write a partial slug with status: halt if the context window is exhausted, do not silently timeout).
 - Fleet agents inherit the same model and tool scope as the parent session, satisfying invariant 2.
 - Each agent must write the handoff slug to `.cheese/cheese-factory/<slug>/curds/<id>.md` per the per-curd prompt template.
 
@@ -72,7 +76,7 @@ Rules:
 - `--type general-purpose` (or equivalent) — never pass a scoped worker type.
 - `--inherit-tools` — full-peer inheritance per invariant 2.
 - `--wait` — synchronous return so the orchestrator can read the handoff slug.
-- The prompt file must include the no-chain-forward directive.
+- The prompt file must include the no-chain-forward directive and the foreground-only directive (run in the foreground; do not background yourself or defer work; write a partial slug with status: halt if the context window is exhausted, do not silently timeout).
 
 ## Other / future harnesses
 

--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -75,7 +75,7 @@ The two-cure-pass cap is enforced by **chain length, not by age** — age boots 
 
 Each phase's existing `--auto` contract chains forward in-session — `/cook --auto` invokes `/press --auto`, which invokes `/age --auto`, etc. `/ultracook` overrides that behaviour: every spawn must run only its own phase, write the slug, and stop. The orchestrator owns the chain.
 
-The override travels in the spawn prompt as the explicit no-chain directive: `Do not chain forward to the next phase even though your auto-mode contract documents that. Write your handoff slug and stop. The /ultracook orchestrator is driving the chain. Run in the foreground — do not background yourself, spawn detached processes, or defer work to a later session. If you cannot complete the phase within your context window, write a partial slug with status: halt and stop; do not silently timeout.`
+The override travels in the spawn prompt as the explicit no-chain directive: `Do not chain forward to the next phase even though your auto-mode contract documents that. Write your handoff slug and stop. The /ultracook orchestrator is driving the chain. Run in the foreground — do not background yourself, spawn detached processes, or defer work to a later session. If you cannot complete the phase within your context window, write a partial slug with status: halt: <reason> and stop; do not silently timeout.`
 
 Each phase's SKILL.md `## Auto mode` section honours this directive — see `skills/<phase>/SKILL.md` `### When invoked from /ultracook` for the per-phase contract amendment.
 

--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -75,7 +75,7 @@ The two-cure-pass cap is enforced by **chain length, not by age** — age boots 
 
 Each phase's existing `--auto` contract chains forward in-session — `/cook --auto` invokes `/press --auto`, which invokes `/age --auto`, etc. `/ultracook` overrides that behaviour: every spawn must run only its own phase, write the slug, and stop. The orchestrator owns the chain.
 
-The override travels in the spawn prompt as the explicit no-chain directive: `Do not chain forward to the next phase even though your auto-mode contract documents that. Write your handoff slug and stop. The /ultracook orchestrator is driving the chain.`
+The override travels in the spawn prompt as the explicit no-chain directive: `Do not chain forward to the next phase even though your auto-mode contract documents that. Write your handoff slug and stop. The /ultracook orchestrator is driving the chain. Run in the foreground — do not background yourself, spawn detached processes, or defer work to a later session. If you cannot complete the phase within your context window, write a partial slug with status: halt and stop; do not silently timeout.`
 
 Each phase's SKILL.md `## Auto mode` section honours this directive — see `skills/<phase>/SKILL.md` `### When invoked from /ultracook` for the per-phase contract amendment.
 
@@ -102,7 +102,7 @@ For phases that already write rich reports (`/age`, `/press`, `/cure` once exten
 
 Beyond the halt and age `next: done` cases in Flow step 3, one more early-stop case is an error, not a clean stop:
 
-- A phase's slug file is missing after the sub-agent returns (the sub-agent did not write its handoff — print "phase did not write handoff — check sub-agent logs").
+- A phase's slug file is missing after the sub-agent returns (the sub-agent did not write its handoff). Before surfacing this as a hard stop, attempt a **re-dispatch** with the foreground-only directive reinforced in the prompt. Cap re-dispatches at **2** per phase. After the second failed re-dispatch with no slug, print: `"<phase> did not write handoff after 2 re-dispatch attempts — check sub-agent logs"` and stop. Track the attempt count per phase in the orchestrator loop; reset to 0 when advancing to a new phase.
 
 In every early-stop case, surface the slug file path so the user can read the full report. The natural terminal case (chain table exhausted after spawn #7) does not need an explicit early-stop signal — the orchestrator simply runs out of entries to spawn.
 


### PR DESCRIPTION
Closes #132.

Adds a foreground-only directive + timeout guidance to ultracook's spawn prompt (SKILL.md:78) and all three harness sections of spawn-primitive-reference.md, plus a slug-liveness re-dispatch path capped at 2 attempts per phase (with a diagnostic after the second failure and counter reset on phase advance). Stays out of common.pyz, so no conflation with the subprocess timeout=5.

Taste-test (orchestrator pre-handoff review, opus): **pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tn7CUsGkgs18kU7iZwVC86