### PR TITLE
feat(mold): mold-parity cluster — glossary, spec-verify, EARS, concrete-seam, out-of-scope store

### DIFF
--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -57,7 +57,7 @@ Per-dimension base-severity tables, location-sensitivity, fix-cost-now / fix-cos
    python3 ${CLAUDE_SKILL_DIR}/scripts/common.pyz read_handoff_slug --phase press --slug <slug>
    ```
 
-   Include a `## Press findings` sub-section in the age report summarising unresolved items — `/cure` reads only `.cheese/age/<slug>.md` and cannot access the press report directly.
+   Include a `## Press findings` sub-section in the age report summarising unresolved items — `/cure` reads only `.cheese/age/<slug>.md` and cannot access the press report directly. If `.cheese/glossary/<slug>.md` exists, read it now so naming drift against the resolved glossary can be flagged as a deslop finding.
 3. Review every dimension; dimensions with no findings simply omit themselves.
 4. Compute severity per finding (base + location bump + compounding bump, capped at `blocker`). Group findings by severity (`## Blocker → ## High → ## Medium → ## Low`); within a severity group, order by file.
 5. Write the report:

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -57,7 +57,9 @@ Per-dimension base-severity tables, location-sensitivity, fix-cost-now / fix-cos
    python3 ${CLAUDE_SKILL_DIR}/scripts/common.pyz read_handoff_slug --phase press --slug <slug>
    ```
 
-   Include a `## Press findings` sub-section in the age report summarising unresolved items — `/cure` reads only `.cheese/age/<slug>.md` and cannot access the press report directly. If `.cheese/glossary/<slug>.md` exists, read it now so naming drift against the resolved glossary can be flagged as a deslop finding.
+   Include a `## Press findings` sub-section in the age report summarising unresolved items — `/cure` reads only `.cheese/age/<slug>.md` and cannot access the press report directly.
+
+   Independently of any press report, if `.cheese/glossary/<slug>.md` exists, read it now so naming drift against the resolved glossary can be flagged as a deslop finding.
 3. Review every dimension; dimensions with no findings simply omit themselves.
 4. Compute severity per finding (base + location bump + compounding bump, capped at `blocker`). Group findings by severity (`## Blocker → ## High → ## Medium → ## Low`); within a severity group, order by file.
 5. Write the report:

--- a/skills/cheese/SKILL.md
+++ b/skills/cheese/SKILL.md
@@ -59,7 +59,7 @@ Non-implementation intents bypass the escalation entirely. Their target skills o
 
 ## Rejected-directions check
 
-Before dispatching any `mold` intent, scan `.cheese/.out-of-scope/` for rejection records whose `Direction` line substantially matches the incoming request. If a match is found:
+Before dispatching any `mold` intent, scan `.cheese/.out-of-scope/` for rejection records whose `## Direction` section's one-line description substantially matches the incoming request. If a match is found:
 
 1. Surface the previously-rejected direction and its rationale in one line.
 2. Ask the user whether to proceed with the new request or take a different angle.

--- a/skills/cheese/SKILL.md
+++ b/skills/cheese/SKILL.md
@@ -57,6 +57,16 @@ For `cook` and `mold` intents, `/cheese` runs cook's fast-path check (§ "Standa
 
 Non-implementation intents bypass the escalation entirely. Their target skills own their own internal escalation: `/pasteurize` has its Phase 1 feedback-loop check, `/briesearch` clarifies missing version/scope inline, `/age` and `/cure` work directly against the supplied diff or report.
 
+## Rejected-directions check
+
+Before dispatching any `mold` intent, scan `.cheese/.out-of-scope/` for rejection records whose `Direction` line substantially matches the incoming request. If a match is found:
+
+1. Surface the previously-rejected direction and its rationale in one line.
+2. Ask the user whether to proceed with the new request or take a different angle.
+3. Do not suppress or re-propose the rejected direction silently.
+
+This check is lightweight — a glob + keyword scan over `.cheese/.out-of-scope/*.md`. Skip silently when the directory does not exist. Non-`mold` intents skip this check.
+
 ## --continue
 
 `/cheese --continue <slug-or-note-path>` is the manual fresh-context resumption path. Use it after compacting the conversation, after `/ultracook` has stopped on a halt, or whenever the user wants to drive the pipeline by hand from a cleared context.

--- a/skills/cook/SKILL.md
+++ b/skills/cook/SKILL.md
@@ -36,7 +36,7 @@ When the fast-path applies, derive a slug from the task (e.g. `tail-trailing-new
 
 ## Flow
 
-1. **Contract** — confirm behaviour, non-goals, likely scope, quality gates. For standalone fast-path tasks, the contract is the user's request restated in one sentence.
+1. **Contract** — confirm behaviour, non-goals, likely scope, quality gates. For standalone fast-path tasks, the contract is the user's request restated in one sentence. If `.cheese/glossary/<slug>.md` exists, read it before implementation so naming follows the resolved canonical terms.
 2. **Cut** — write failing tests for the changed behaviour. See `references/tdd-loop.md`.
 3. **Implement** — make the cut tests pass with the smallest production change.
 4. **Taste-test** — check spec drift, readability, scope, plus three fresh-context lenses (production path, wired callers, locked-decision). Dispatch the fresh-context `reviewer` for multi-file or public-surface diffs; keep the inline check otherwise. Two-round cap. Cost gate, reviewer-model pin, and the coder-nested degrade live in `references/tdd-loop.md`.

--- a/skills/mold/references/curdle.md
+++ b/skills/mold/references/curdle.md
@@ -161,16 +161,9 @@ This store is consulted by `/cheese` before re-proposing a direction (see `skill
 
 ## Spec-verify pass (optional)
 
-Before the hand-off, if the skill `/spec-verify` is available in the harness, run it as an independent spec-review pass:
+Before the hand-off, if the `/spec-verify` skill is available in the harness, run it as an independent spec-review pass. If absent, skip silently and note once — this pass is optional and must not block curdle in environments where the skill is not bundled. Never hard-depend on it.
 
-```
-spec_verify_available=$(command -v spec-verify 2>/dev/null || echo '')
-if [ -n "$spec_verify_available" ]; then
-  /spec-verify "$SPEC"
-fi
-```
-
-If `/spec-verify` is absent, skip silently — this pass is optional and must not block curdle in environments where the skill is not bundled. Never hard-depend on it.
+Detection is instruction-level, not code: check whether `/spec-verify` appears in the agent's available toolset (the same pattern as `shared/optional-plugins.md` § Probe pattern). Do not use `command -v` or any shell probe — `/spec-verify` is a skill, not a `$PATH` executable.
 
 ## Atomic write
 

--- a/skills/mold/references/curdle.md
+++ b/skills/mold/references/curdle.md
@@ -60,6 +60,17 @@ entity_referent_bindings: []   # list of binding records {noun, verdict, referen
 ## Decisions
 - <one-line decision> — <one-line rationale>
 
+## Acceptance
+
+Write acceptance criteria in **EARS form** by default:
+```
+WHEN <trigger> THE SYSTEM SHALL <response>
+```
+If the trigger cannot be stated precisely (e.g. pure internal utilities with no external event), use prose with a `[prose-fallback]` marker.
+
+- WHEN <trigger> THE SYSTEM SHALL <response>
+- WHEN <trigger> THE SYSTEM SHALL <response>
+
 ## Interface sketches
 ```pseudocode
 <signatures, schemas, seams>
@@ -112,6 +123,54 @@ outlive it. The corpus is resolved **dynamically** — probe for the consumer's
 `repo:<their-repo>:wiki` hallouminate corpus and write there if present, else fall
 back to a tracked `docs/adr/<slug>-NNN.md`. Never hardcode a corpus name. Full
 resolution rule and ADR format in [`adr.md`](adr.md).
+
+## Durable glossary (by-product)
+
+Write resolved canonical terms to `.cheese/glossary/<slug>.md` in the same atomic step as the spec and ADRs. Downstream skills (`/cook`, `/age`, `/press`) read this file for naming consistency. The glossary is the output of the Ground phase's term resolution; it is not reconstructed from the spec.
+
+Format:
+```markdown
+# Glossary — <slug>
+
+| Term | Canonical meaning | Code referent (file:line or NEW ENTITY) |
+| --- | --- | --- |
+| <term> | <one-line definition> | <referent> |
+```
+
+Omit the file if no terms were resolved during Ground (no overloaded-term dialogue occurred).
+
+## Rejected-directions store (by-product)
+
+When the agent-introduced-scope audit or the two-key handshake explicitly **rejects** a direction (the user says "drop <term>", "not that approach", "make X a follow-up"), write the rejection to `.cheese/.out-of-scope/<slug>-NNN.md`.
+
+Format:
+```markdown
+# Rejected direction — <slug>-<NNN>
+
+## Direction
+<one-line description of what was rejected>
+
+## Rationale
+<why it was rejected, in 1–2 sentences>
+
+## Context
+Session: <slug>; rejected at: <handshake | scope-audit>
+```
+
+This store is consulted by `/cheese` before re-proposing a direction (see `skills/cheese/SKILL.md` § Rejected-directions check). Do not write to this store for normal out-of-scope bugs or follow-ups (those go to `.cheese/issues/`); write only for **direction-level** rejections (approaches, design knobs, named features the user explicitly declined).
+
+## Spec-verify pass (optional)
+
+Before the hand-off, if the skill `/spec-verify` is available in the harness, run it as an independent spec-review pass:
+
+```
+spec_verify_available=$(command -v spec-verify 2>/dev/null || echo '')
+if [ -n "$spec_verify_available" ]; then
+  /spec-verify "$SPEC"
+fi
+```
+
+If `/spec-verify` is absent, skip silently — this pass is optional and must not block curdle in environments where the skill is not bundled. Never hard-depend on it.
 
 ## Atomic write
 

--- a/skills/mold/references/curdle.md
+++ b/skills/mold/references/curdle.md
@@ -141,7 +141,7 @@ Omit the file if no terms were resolved during Ground (no overloaded-term dialog
 
 ## Rejected-directions store (by-product)
 
-When the agent-introduced-scope audit or the two-key handshake explicitly **rejects** a direction (the user says "drop <term>", "not that approach", "make X a follow-up"), write the rejection to `.cheese/.out-of-scope/<slug>-NNN.md`.
+When the agent-introduced-scope audit or the two-key handshake explicitly **rejects a direction** (the user says "drop <term>" for an approach or design knob, or "not that approach"), write the rejection to `.cheese/.out-of-scope/<slug>-NNN.md`. Deferrals ("make X a follow-up") are not direction rejections — route those to `.cheese/issues/`.
 
 Format:
 ```markdown
@@ -157,7 +157,7 @@ Format:
 Session: <slug>; rejected at: <handshake | scope-audit>
 ```
 
-This store is consulted by `/cheese` before re-proposing a direction (see `skills/cheese/SKILL.md` § Rejected-directions check). Do not write to this store for normal out-of-scope bugs or follow-ups (those go to `.cheese/issues/`); write only for **direction-level** rejections (approaches, design knobs, named features the user explicitly declined).
+This store is consulted by `/cheese` before re-proposing a direction (see `skills/cheese/SKILL.md` § Rejected-directions check). Do not write to this store for normal out-of-scope bugs or follow-ups (those go to `.cheese/issues/`); write only for **direction-level** rejections (approaches, design knobs, named features the user explicitly declined). Note: this store is dot-prefixed (`.out-of-scope`) while its sibling stores (`glossary/`, `issues/`, `specs/`) are not — any scan must target the dotted path explicitly; a bare `.cheese/*` glob will not match it.
 
 ## Spec-verify pass (optional)
 

--- a/skills/mold/references/handshake.md
+++ b/skills/mold/references/handshake.md
@@ -64,7 +64,8 @@ Procedure:
    ```
 
 4. **The user must explicitly approve each row** before the handshake fires. Acceptable approvals: "yes keep <term>", "drop <term>", "make <term> a follow-up". Vague "looks good" is not approval.
-5. If any flagged term came from a research citation (briesearch sub-agent, fetched doc, MCP result), it cannot be silently promoted into a design knob — the citation is evidence, not a mandate. See `skills/briesearch/references/synthesis.md` § Alternatives are open questions.
+5. **For any term the user explicitly drops or defers**, write a rejection record to `.cheese/.out-of-scope/<slug>-NNN.md` (format in `curdle.md` § Rejected-directions store). This makes direction-level rejections durable so `/cheese` can consult them before re-proposing the same direction in a later session.
+6. If any flagged term came from a research citation (briesearch sub-agent, fetched doc, MCP result), it cannot be silently promoted into a design knob — the citation is evidence, not a mandate. See `skills/briesearch/references/synthesis.md` § Alternatives are open questions.
 
 This gate exists because research sub-agents have historically over-synthesised: a Tavily snippet mentioning "X or Y" became a shipped `[setting].knob = "x" | "y"` flag, copied through curdle → cook without the user typing the distinguishing noun once. The grep heuristic catches that class of drift early.
 

--- a/skills/mold/references/handshake.md
+++ b/skills/mold/references/handshake.md
@@ -64,7 +64,7 @@ Procedure:
    ```
 
 4. **The user must explicitly approve each row** before the handshake fires. Acceptable approvals: "yes keep <term>", "drop <term>", "make <term> a follow-up". Vague "looks good" is not approval.
-5. **For any term the user explicitly drops or defers**, write a rejection record to `.cheese/.out-of-scope/<slug>-NNN.md` (format in `curdle.md` § Rejected-directions store). This makes direction-level rejections durable so `/cheese` can consult them before re-proposing the same direction in a later session.
+5. **When the user explicitly drops a direction** — an approach, design knob, or named feature they decline — write a rejection record to `.cheese/.out-of-scope/<slug>-NNN.md` (format in `curdle.md` § Rejected-directions store). This makes direction-level rejections durable so `/cheese` can consult them before re-proposing the same direction in a later session. Deferrals ("make <term> a follow-up") are not direction rejections — route those to `.cheese/issues/`, not the out-of-scope store.
 6. If any flagged term came from a research citation (briesearch sub-agent, fetched doc, MCP result), it cannot be silently promoted into a design knob — the citation is evidence, not a mandate. See `skills/briesearch/references/synthesis.md` § Alternatives are open questions.
 
 This gate exists because research sub-agents have historically over-synthesised: a Tavily snippet mentioning "X or Y" became a shipped `[setting].knob = "x" | "y"` flag, copied through curdle → cook without the user typing the distinguishing noun once. The grep heuristic catches that class of drift early.

--- a/skills/mold/references/modes.md
+++ b/skills/mold/references/modes.md
@@ -23,7 +23,7 @@ Mold has no fixed entry point. Inspect the input shape and pick a starting mode.
 
 ### Ground — anti-hallucination
 
-**Job:** anchor every claim to evidence — code, docs, prior research. When the user uses overloaded terms ("account", "session", "user"), pause and resolve with a canonical-term question. Resolved terms are written to the session's durable glossary at `.cheese/glossary/<slug>.md` so downstream skills (`/cook`, `/age`, `/press`) can read them for naming consistency.
+**Job:** anchor every claim to evidence — code, docs, prior research. When the user uses overloaded terms ("account", "session", "user"), pause and resolve with a canonical-term question. Terms resolved here are written to the session's durable glossary at `.cheese/glossary/<slug>.md` at the curdle atomic step (see `curdle.md` § Durable glossary), so downstream skills (`/cook`, `/age`, `/press`) can read them for naming consistency.
 
 **Invariant:** never say "I think the code does X" without a `cheez-search` call.
 

--- a/skills/mold/references/modes.md
+++ b/skills/mold/references/modes.md
@@ -23,7 +23,7 @@ Mold has no fixed entry point. Inspect the input shape and pick a starting mode.
 
 ### Ground — anti-hallucination
 
-**Job:** anchor every claim to evidence — code, docs, prior research. When the user uses overloaded terms ("account", "session", "user"), pause and resolve with a canonical-term question. Resolved terms get logged in the state file.
+**Job:** anchor every claim to evidence — code, docs, prior research. When the user uses overloaded terms ("account", "session", "user"), pause and resolve with a canonical-term question. Resolved terms are written to the session's durable glossary at `.cheese/glossary/<slug>.md` so downstream skills (`/cook`, `/age`, `/press`) can read them for naming consistency.
 
 **Invariant:** never say "I think the code does X" without a `cheez-search` call.
 
@@ -39,7 +39,11 @@ Mold has no fixed entry point. Inspect the input shape and pick a starting mode.
 
 **Job:** lock modules, responsibilities, I/O contracts, and seams in pseudocode signatures. Before drafting, when the change touches more than one module or introduces a new public interface, run the shape check (`shape-check.md`) — signatures, callers (via `cheez-search`, i.e. `tilth_search kind: "callers"`), and `tilth_deps` blast radius — on the touched symbols so new seams fit existing convention and the impact is bounded. Print the shape-check summary block before any pseudocode. Single-module, internals-only sketches may skip the gate; note "shape check skipped: single-module change" instead.
 
-**Exit when:** every public seam has a pseudocode signature; every cross-module call goes through public interfaces, not internals; shape-check verdict is recorded (or explicitly skipped per the gate above).
+**Acceptance notation (EARS):** for every public seam, emit acceptance criteria in EARS form: `WHEN <trigger> THE SYSTEM SHALL <response>`. If the trigger cannot be stated precisely (e.g. pure internal utilities), fall back to prose with a `[prose-fallback]` marker.
+
+**Concrete-seam rule:** when a seam is small enough to write completely (a function body that fits in roughly 20 lines), write the full implementation rather than pseudocode. Reserve abbreviated signatures only for seams where the body is genuinely too large or depends on design unknowns not yet resolved in the dialogue.
+
+**Exit when:** every public seam has a pseudocode signature or full implementation per the concrete-seam rule; every acceptance criterion is in EARS form (or marked `[prose-fallback]`); every cross-module call goes through public interfaces, not internals; shape-check verdict is recorded (or explicitly skipped per the gate above).
 
 ### Grill — adversarial clarification
 

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -14,7 +14,7 @@ Press may add or strengthen tests and make tiny corrective fixes only when a tes
 
 ## Flow
 
-1. **Read** — load the spec or acceptance criteria and the cooked diff.
+1. **Read** — load the spec or acceptance criteria and the cooked diff. If `.cheese/glossary/<slug>.md` exists, read it for naming consistency when hardening tests.
 2. **Map** — for each changed behaviour, find the test(s) that cover it via `cheez-search`.
 3. **Gap analysis** — identify weak assertions, missing boundaries, and uncovered integration seams. See `references/gap-analysis.md` for what counts as a gap and the priority order.
 4. **Add focused tests** — observe red first when behaviour changes. Use `cheez-write` for precise edits.


### PR DESCRIPTION
Closes #151, closes #143, closes #144, closes #162, closes #161.

Five mold-parity issues in one coherent pass:
- **#151** — durable resolved-term glossary written at Ground/curdle (`.cheese/glossary/<slug>.md`) and **read** (existence-conditioned) by cook (pre-impl naming), age (naming-drift → deslop dimension), and press (hardening-test naming).
- **#143** — optional `/spec-verify` pass wired into curdle, using **instruction-level toolset detection** (per `shared/optional-plugins.md`), portable graceful-skip when the skill is absent.
- **#144** — EARS acceptance notation (`WHEN … THE SYSTEM SHALL …`) as the default in Sketch + the spec template, with prose fallback.
- **#162** — concrete-seam rule in Sketch (write the full impl when a seam is small).
- **#161** — `.out-of-scope/` rejected-directions store: format in curdle.md, written by handshake's agent-scope audit, consulted by the `/cheese` router before re-proposing a direction.

Taste-test (orchestrator pre-handoff review): initial **halt** on two blockers — #151's read side was unwired and #143 used a `command -v` probe that can never match a slash-command skill. Both fixed in a corrective pass (commit f9d8a16) and re-verified clear.

⚠️ **Merge order:** this branch's cook/age edits sit in different sections than #186 (cook) and #182 (age), so it should auto-merge — but **merge this PR last**, and run `/melt` if those two hunks land close together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tn7CUsGkgs18kU7iZwVC86