### PR TITLE
Narrow cheese-factory Phase 0 spec validation to decomposition needs

### DIFF
--- a/skills/cheese-factory/SKILL.md
+++ b/skills/cheese-factory/SKILL.md
@@ -81,7 +81,7 @@ If milknado MCP is available (`mcp__milknado__milknado_todo_add` in toolset), pe
 
 Read the spec from the argument (or, if `--resume <slug>`, read the manifest and skip to the next incomplete phase).
 
-Validate the spec has: (a) an enumerable acceptance criteria or user stories list — at least one bullet the decomposer can map 1:1 to a curd; and (b) quality gates — at least one runnable command. Heading names are not enforced; check for presence of the content. Fail fast if either is absent.
+Validate the input spec's **structure** (distinct from the five-criteria curd check the validator applies to the decomposer's *output* manifest). The spec must have: (a) an enumerable acceptance criteria or user stories list — at least one list item (bulleted or numbered) the decomposer can map 1:1 to a curd; and (b) quality gates — at least one runnable command. Heading names are not enforced; check for presence of the content. Fail fast if either is absent.
 
 **Hard worktree gate**: detect the host's worktree mechanism (Conductor, git worktrees, plain branches) and prompt if working on the default branch. Never skipped.
 

--- a/skills/cheese-factory/SKILL.md
+++ b/skills/cheese-factory/SKILL.md
@@ -81,7 +81,7 @@ If milknado MCP is available (`mcp__milknado__milknado_todo_add` in toolset), pe
 
 Read the spec from the argument (or, if `--resume <slug>`, read the manifest and skip to the next incomplete phase).
 
-Validate the spec has: Executive Summary, Problem Statement, User Stories, Acceptance Criteria, Quality Gates. Fail fast if any is missing.
+Validate the spec has: (a) an enumerable acceptance criteria or user stories list — at least one bullet the decomposer can map 1:1 to a curd; and (b) quality gates — at least one runnable command. Heading names are not enforced; check for presence of the content. Fail fast if either is absent.
 
 **Hard worktree gate**: detect the host's worktree mechanism (Conductor, git worktrees, plain branches) and prompt if working on the default branch. Never skipped.
 

--- a/skills/cheese-factory/references/decomposer-prompt.md
+++ b/skills/cheese-factory/references/decomposer-prompt.md
@@ -23,8 +23,9 @@ Every curd you produce must satisfy ALL FIVE criteria. Token budgets are NOT a c
 1. **One behaviour per curd.** Describable in a single declarative sentence ("adds X",
    "extracts Y", "renames Z", "fixes A"). If the description needs "and" between two
    distinct behaviours, split into two curds.
-2. **One acceptance criterion.** Maps to exactly one bullet in the spec's Acceptance
-   Criteria / User Story list. Curds collectively cover every acceptance criterion 1:1.
+2. **One acceptance criterion.** Maps to exactly one list item (bulleted or numbered) in
+   the spec's Acceptance Criteria / User Story list. Curds collectively cover every
+   acceptance criterion 1:1.
 3. **One test target.** A single focused test command verifies this curd alone. If the
    curd needs N test commands, it's N curds.
 4. **File-disjoint.** No two curds list the same file. HARD CONSTRAINT.


### PR DESCRIPTION
## Summary

- Replaces the exact-heading check (`Executive Summary`, `Problem Statement`, `User Stories`, `Acceptance Criteria`, `Quality Gates`) with a content-based check
- Now requires: (a) an enumerable acceptance criteria or user stories list — for 1:1 curd mapping; and (b) at least one quality gate command
- Heading names are no longer enforced, so mold-produced specs pass without requiring non-standard section titles

## Why

The old check was a false gate — it enforced heading *names* that the decomposer never actually needs. The decomposer only needs an enumerable acceptance list (to map 1:1 to curds) and a quality gate command (for the per-curd pass criterion). `Executive Summary` and `Problem Statement` are contextual and structurally irrelevant to decomposition. The new check matches what `references/decomposer-prompt.md` actually uses.

## Test plan

- [ ] Run `/cheese-factory` against a mold-produced spec (`## Acceptance`, `## Quality gates`) — should pass Phase 0 validation
- [ ] Run against a spec with no acceptance criteria list — should fail fast with clear message
- [ ] Run against a spec with no quality gates — should fail fast with clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)