### PR TITLE
chore: remove code-review-graph references

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -101,30 +101,6 @@ jobs:
           EC_SKILL_REF: ${{ github.event.pull_request.head.sha || github.sha }}
         run: bash scripts/install.sh --skip-mcp
 
-      # Real install of the code-review-graph CLI. Sourcing the script and
-      # calling the function directly skips the MCP-registration step that
-      # needs a claude CLI on the runner, while still exercising the actual
-      # pip/pipx/uv install path. EC_CRG_SPEC overrides the default
-      # 'code-review-graph[embeddings]' spec so CI installs the bare CLI;
-      # the [embeddings] extra pulls sentence-transformers, which builds
-      # the tokenizers Rust crate from source on macOS arm64 and burns
-      # minutes per run. Catches cases where 'code-review-graph' stops
-      # being a valid PyPI target; does not catch breakage in the
-      # [embeddings] extra specifically.
-      - name: CRG install smoke test
-        env:
-          EC_CRG_SPEC: code-review-graph
-        run: |
-          set -euo pipefail
-          # shellcheck disable=SC1091
-          source scripts/install.sh
-          ec_install_crg_cli
-          # Cover every install-path bin location: pipx + uv tool install
-          # land in $HOME/.local/bin; pip --user lands under the Python
-          # user-base bin dir.
-          export PATH="$HOME/.local/bin:$(python3 -m site --user-base)/bin:$PATH"
-          code-review-graph --version
-
   lint:
     name: lint markdown, yaml, python
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ before review.
 Easy-cheese is intentionally a small surface. What that means in practice:
 
 - **Skills only.** No agents, commands, eta templates, or compiled harness bundles. Each capability is a single `SKILL.md`.
-- **No repo-wide MCP requirement.** Workflow skills suggest tools (tilth, Context7, Tavily, code-review-graph) but have host-native fallbacks. The `cheez-*` tool skills are the exception: they require tilth MCP by design.
+- **No repo-wide MCP requirement.** Workflow skills suggest tools (tilth, Context7, Tavily) but have host-native fallbacks. The `cheez-*` tool skills are the exception: they require tilth MCP by design.
 - **One orchestrator skill, narrowly scoped.** `/ultracook` is the only orchestrator — it spawns full-peer sub-agents for the fixed `cook → press → age → cure → age → cure → age` chain on high-blast-radius specs. There is no large-feature decomposition, no PR-rescue convoy, no whole-repo NIH audit. Every other skill remains a single, scoped step a human can drive.
 - **No automatic re-age loop in `/cure`.** The skill describes the protocol; the human runs the next `/age` when ready.
 
@@ -172,7 +172,6 @@ Workflow skills name preferred tools when they help, with fallbacks for portabil
 | `sg` (ast-grep) | Structural pattern matching and codemods (`sg --rewrite`) with metavariables | `ripgrep`, `find`, targeted reads; `tilth_edit` for non-structural edits |
 | Context7 (MCP) | Library and API documentation | repo docs, package docs, vendor pages, web search |
 | Tavily (MCP) | Current web/vendor research | host web search or user-supplied sources |
-| code-review-graph (MCP) | Review impact radius, architecture framing, and embeddings-backed semantic / cross-repo search | import searches, caller searches, tests |
 | LSP / [Serena](https://github.com/oraios/serena) (MCP) | Type-aware xrefs (`find_referencing_symbols`, `find_implementations`), symbol-bounded edits (`rename_symbol`, `replace_symbol_body`, `safe_delete_symbol`), and LSP diagnostics — concrete tools for the abstract "if your harness has an LSP" sections in `cheez-*` skills | `sg`, `tilth_search`, targeted reads via tilth |
 | hallouminate (MCP) | Per-repo wiki for cross-session design rationale, ADR grounding, and `/mold` evidence | Skip wiki grounding; proceed with diff + code evidence only; cap at `speculating` when design rationale is central |
 | milknado (MCP) | Mikado task-graph backend for `/cheese-factory` curd prerequisite tracking | In-report curd decomposition in manifest YAML; no external task-graph backend needed |
@@ -416,34 +415,6 @@ TAVILY_API_KEY=your-key npx -y tavily-mcp
 ```
 
 Requires Node.js v18+.
-
-</details>
-
-<details>
-<summary><strong>code-review-graph</strong> — impact radius, architecture framing, semantic search for <code>/age</code>, <code>/press</code>, <code>/cure</code></summary>
-
-[code-review-graph](https://github.com/tirth8205/code-review-graph) builds a persistent call graph of your codebase with Tree-sitter, Louvain communities, betweenness-centrality, and optional vector embeddings. Used by `/age`, `/press`, and `/cure` for risk-scored impact (`get_impact_radius_tool`, `detect_changes_tool`), curated review context (`get_review_context_tool`, `get_minimal_context_tool`), affected flows (`get_affected_flows_tool`), architecture framing (`get_architecture_overview_tool`, `get_hub_nodes_tool`, `get_bridge_nodes_tool`), and cross-repo / semantic search (`cross_repo_search_tool`, `semantic_search_nodes_tool`). Tilth handles AST search, callers, and hash-anchored edits; code-review-graph covers the graph-algorithmic and cross-repo dimensions tilth does not.
-
-```sh
-# Install with the local sentence-transformers embeddings extra (Python 3.10+ required)
-pip install 'code-review-graph[embeddings]'   # or: pipx install 'code-review-graph[embeddings]'
-
-# Auto-detect and configure your harness
-code-review-graph install
-
-# Target a specific harness
-code-review-graph install --platform claude-code
-code-review-graph install --platform cursor
-code-review-graph install --platform codex
-
-# Build the graph for the current project (re-run after large changes)
-code-review-graph build
-
-# Compute embeddings for semantic_search_nodes_tool (one-time, then incremental)
-code-review-graph embed
-```
-
-The `[embeddings]` extra pulls in `sentence-transformers` so `semantic_search_nodes_tool` works out of the box with the default `all-MiniLM-L6-v2` model. Override with `CRG_EMBEDDING_MODEL=<model-id>`. Other embedding providers (Google Gemini, MiniMax, OpenAI-compatible endpoints) are also supported — see the upstream README for `[google-embeddings]` and the `CRG_OPENAI_*` env vars.
 
 </details>
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,7 +69,7 @@ Options:
                                 just, mergiraf, tilth
   --mcp <list>         Comma-separated MCP servers to register. Default:
                        tilth,context7. Choices: tilth, context7, tavily,
-                       code-review-graph, hallouminate, milknado, none
+                       hallouminate, milknado, none
   --skip-mcp           Same as --mcp none.
   --skip-tools         Skip CLI tool installs (useful for MCP-only runs).
   --harness <selection> Harness to register skills + MCP servers with.
@@ -91,8 +91,6 @@ Environment:
   EC_NPX               Override npx (used to launch context7 / tavily MCP).
   EC_UVX               Override uvx (used to launch milknado MCP).
   EC_HALLOUMINATE      Override hallouminate binary (used to launch hallouminate MCP).
-  EC_UV     EC_PIPX    Override uv / pipx for code-review-graph install.
-  EC_PIP    EC_CRG     Override pip / code-review-graph binaries.
   EC_SKILL_REF         Pin skill installs to a git tag or commit SHA
                        (passes --pin to 'gh skill install'). Used by CI
                        to test against the commit under review.
@@ -226,9 +224,6 @@ ec_install_mcp() {
         tavily)
             ec_install_mcp_tavily "$harness"
             ;;
-        code-review-graph)
-            ec_install_mcp_crg "$harness"
-            ;;
         hallouminate)
             ec_install_mcp_hallouminate "$harness"
             ;;
@@ -310,80 +305,6 @@ ec_install_mcp_tavily() {
     "$claude" mcp add tavily -- "$npx" -y tavily-mcp
 }
 
-# Install the code-review-graph CLI with the local sentence-transformers
-# embeddings extra so 'code-review-graph embed' works out of the box.
-# Prefers an isolated tool install (uv → pipx) so we don't poke at the
-# system Python. Falls back to 'pip install --user' with a warning so it
-# still works on minimal boxes.
-#
-# The package spec is quoted because '[embeddings]' contains shell glob
-# characters; inside an array invocation the quoting is implicit, but the
-# dry-run log line uses a literal single-quoted form to match.
-ec_install_crg_cli() {
-    local uv="${EC_UV:-uv}"
-    local pipx="${EC_PIPX:-pipx}"
-    local pip="${EC_PIP:-pip}"
-    local spec="${EC_CRG_SPEC:-code-review-graph[embeddings]}"
-
-    if ec_cmd_exists "$uv"; then
-        if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-            ec_log "code-review-graph: would run '$uv tool install $spec'"
-            return 0
-        fi
-        ec_log "code-review-graph: installing via '$uv tool install $spec'"
-        "$uv" tool install "$spec"
-        return $?
-    fi
-
-    if ec_cmd_exists "$pipx"; then
-        if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-            ec_log "code-review-graph: would run '$pipx install $spec'"
-            return 0
-        fi
-        ec_log "code-review-graph: installing via '$pipx install $spec'"
-        "$pipx" install "$spec"
-        return $?
-    fi
-
-    if ec_cmd_exists "$pip"; then
-        ec_warn "code-review-graph: uv/pipx not found; falling back to 'pip install --user'."
-        if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-            ec_log "code-review-graph: would run '$pip install --user $spec'"
-            return 0
-        fi
-        ec_log "code-review-graph: installing via '$pip install --user $spec'"
-        "$pip" install --user "$spec"
-        return $?
-    fi
-
-    ec_err "code-review-graph: needs uv, pipx, or pip; none found."
-    ec_err "Install uv from https://docs.astral.sh/uv or pipx from https://pipx.pypa.io and re-run."
-    return 1
-}
-
-ec_install_mcp_crg() {
-    local harness="$1"
-    local crg="${EC_CRG:-code-review-graph}"
-    if ! ec_cmd_exists "$crg"; then
-        ec_install_crg_cli || return 1
-        # 'pip install --user' and 'pipx ensurepath' can leave the binary
-        # in a directory that isn't on PATH yet (the pipx user bin or the
-        # Python user-site bin). Re-check explicitly so the user gets a
-        # targeted hint instead of a generic "command not found" later.
-        if [[ "${EC_DRY_RUN:-0}" != "1" ]] && ! ec_cmd_exists "$crg"; then
-            ec_err "code-review-graph: install succeeded but '$crg' is not on PATH."
-            ec_err "Add the install location to PATH (run 'pipx ensurepath', or"
-            ec_err "add the Python user-site bin dir for pip --user) and re-run."
-            return 1
-        fi
-    fi
-    if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-        ec_log "code-review-graph: would run '$crg install --platform $harness'"
-        return 0
-    fi
-    ec_log "code-review-graph: registering with $harness"
-    "$crg" install --platform "$harness"
-}
 
 ec_install_mcp_hallouminate() {
     local harness="$1"
@@ -653,7 +574,7 @@ ec_parse_args() {
     done
 
     ec_validate_selection "$EC_TOOLS" "$EC_KNOWN_TOOLS" || return 2
-    ec_validate_selection "$EC_MCP" "tilth context7 tavily code-review-graph hallouminate milknado none" || return 2
+    ec_validate_selection "$EC_MCP" "tilth context7 tavily hallouminate milknado none" || return 2
 }
 
 ec_main() {

--- a/shared/optional-plugins.md
+++ b/shared/optional-plugins.md
@@ -1,6 +1,6 @@
 # Optional plugins — detect-and-degrade contract
 
-Three optional MCP servers extend the skill stack beyond the required tilth + Context7 baseline; they share one contract: probe at skill entry, use when present, degrade to a documented fallback when absent. **Never block on absence.**
+Two optional MCP servers extend the skill stack beyond the required tilth + Context7 baseline; they share one contract: probe at skill entry, use when present, degrade to a documented fallback when absent. **Never block on absence.**
 
 This document is the single source of truth for the contract. Every skill that references an optional plugin points here rather than duplicating the wording.
 
@@ -14,7 +14,6 @@ This document is the single source of truth for the contract. Every skill that r
 
 | MCP | Key tool(s) to probe | Fallback when absent | Confidence impact |
 | --- | --- | --- | --- |
-| code-review-graph | `build_or_update_graph_tool`, `get_review_context_tool` | `tilth_deps` + `cheez-search kind: "callers"` for blast radius; skip cross-repo, semantic search, and architecture framing | Cap at `speculating` for cross-repo or large-architecture questions |
 | hallouminate | `mcp__hallouminate__list_corpora`, `mcp__hallouminate__ground` | Skip wiki grounding; note absence once; proceed with diff + code evidence only | Cap at `speculating` when design rationale is central |
 | milknado | `mcp__milknado__milknado_todo_add`, `mcp__milknado__milknado_graph_summary` | Use the in-report curd decomposition (manifest YAML in `.cheese/cheese-factory/<slug>/manifest.yaml`); no external task-graph backend | No confidence impact — the decomposition itself is unchanged |
 
@@ -33,7 +32,6 @@ Do not retry. Do not ask the user to install the MCP during the run. Do not sile
 
 Detection is instruction-level, not code. At the relevant phase entry, check whether the tool name is in the agent's available toolset:
 
-- **code-review-graph** — look for `build_or_update_graph_tool` in available tools.
 - **hallouminate** — look for `mcp__hallouminate__list_corpora` in available tools.
 - **milknado** — look for `mcp__milknado__milknado_todo_add` in available tools.
 
@@ -41,4 +39,4 @@ If the tool is present, it is available. If absent, skip and note once.
 
 ## Install
 
-See `scripts/install.sh --help` and `README.md § Optional tools` for install instructions for each MCP. All three are opt-in — they are not in `EC_DEFAULT_MCP`.
+See `scripts/install.sh --help` and `README.md § Optional tools` for install instructions for each MCP. Both are opt-in — they are not in `EC_DEFAULT_MCP`.

--- a/shared/optional-plugins.md
+++ b/shared/optional-plugins.md
@@ -1,6 +1,6 @@
 # Optional plugins — detect-and-degrade contract
 
-Two optional MCP servers extend the skill stack beyond the required tilth + Context7 baseline; they share one contract: probe at skill entry, use when present, degrade to a documented fallback when absent. **Never block on absence.**
+Two optional MCP servers extend the skill stack beyond the default tilth + Context7 baseline; they share one contract: probe at skill entry, use when present, degrade to a documented fallback when absent. **Never block on absence.**
 
 This document is the single source of truth for the contract. Every skill that references an optional plugin points here rather than duplicating the wording.
 

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -85,15 +85,13 @@ Beyond `cheez-*` there are review-specific tools:
 | Need | Prefer | Fallback |
 | --- | --- | --- |
 | Diff inspection | `delta` | `git diff --unified=3` |
-| Risk-scored impact + curated review context | code-review-graph: `get_review_context_tool`, `get_impact_radius_tool`, `detect_changes_tool` | `tilth_deps` + manual scoping |
-| Architecture / hotspot framing for large diffs | code-review-graph: `get_architecture_overview_tool`, `get_hub_nodes_tool`, `get_bridge_nodes_tool` | skip and note in confidence |
+| Caller/dependency impact + curated review context | `tilth_deps` + `/cheez-search` `kind: "callers"` | manual scoping |
+| Architecture / hotspot framing for large diffs | changed-file map + caller/dependency evidence | skip and note in confidence |
 | Design rationale for encapsulation/spec dimensions (optional) | `mcp__hallouminate__list_corpora` / `mcp__hallouminate__ground` on `repo:<repo>:wiki` corpus — if available, ground design intent before grading encapsulation and spec findings | skip; proceed with diff + code evidence only; cap at `speculating` when rationale is the primary evidence |
 | GitHub/PR context | `gh` | local git commands or user-provided PR data |
 | Merge/conflict awareness | mergiraf | manual conflict checks |
 
-**Freshness:** before the first code-review-graph query in a run, call `build_or_update_graph_tool`. The graph is persistent and goes stale between sessions. See [`/cheez-search`](../cheez-search/references/routing.md#when-code-review-graph-beats-tilth-if-your-harness-has-it) for the full freshness contract and when semantic search beats tilth — steel threads across renamed layers, concepts under divergent names, spec-vs-code vocabulary mismatch.
-
-**Optional MCPs:** code-review-graph, hallouminate, and milknado follow the detect-and-degrade contract in [`../../shared/optional-plugins.md`](../../shared/optional-plugins.md) — state absence once, fall back, reduce confidence only if evidence quality suffers, never block.
+**Optional MCPs:** hallouminate and milknado follow the detect-and-degrade contract in [`../../shared/optional-plugins.md`](../../shared/optional-plugins.md) — state absence once, fall back, reduce confidence only if evidence quality suffers, never block.
 
 ## Sub-agent context gate
 
@@ -104,7 +102,7 @@ Beyond `cheez-*` there are review-specific tools:
 - The diff spans more than 15 files.
 - Touched code or generated review context is larger than roughly 25 KB (about 5 K tokens of raw output the parent would not read line-by-line).
 - Caller / dependency graph expansion crosses multiple subsystems.
-- code-review-graph or `tilth_deps` output is needed for hotspot, bridge-node, or blast-radius framing.
+- Caller/dependency evidence from `tilth_deps` or `/cheez-search` crosses multiple subsystems.
 
 For the digest contract, harness-agnostic selection rules, and what the parent never delegates, see `references/sub-agent-gate.md`.
 
@@ -125,7 +123,7 @@ Activates when **all** hold: the **scale threshold** (above) is met AND `/age` i
 
 **Seam 4 — Orchestrator reconciliation.** After all workers return, apply the `## Dimension boundaries` table (`references/dimensions.md:319-340`) verbatim to any line meeting EITHER condition: (1) flagged by two or more workers at the same `file:line`; (2) tagged `also-relevant-to: [d]` by any worker — the orchestrator re-evaluates dimension `d` against that line and applies the tiebreaker (keep the higher-base finding / suppress / emit-both-with-cross-reference per the 15 rules). This consumes the `also-relevant-to` signal and provides the cross-dimension coverage single-parent gets for free. Lines neither flagged by ≥2 workers nor tagged `also-relevant-to` need no reconciliation. Group by severity. The parent owns the canonical artifact. After reconciliation, continue at step 5 (write + print the report path) and `## Handoff` exactly as the single-parent path does.
 
-**Seam 5 — Graph freshness.** The orchestrator calls `build_or_update_graph_tool` **once** before fan-out (per `## Preferred tools and fallbacks` above). The packet carries a "graph fresh as of this run" marker. Workers never call `build_or_update_graph_tool`, but they MAY issue read-only code-review-graph queries (e.g. `get_impact_radius_tool`, `get_review_context_tool`, `get_hub_nodes_tool`, `get_bridge_nodes_tool`) against the pre-built graph for impact and hotspot framing — the same evidence the single-parent path uses for large diffs.
+**Seam 5 — Shared impact evidence.** The packet carries the caller/dependency notes assembled through `tilth_deps` and `/cheez-search`. Workers use that packet instead of rebuilding impact context independently.
 
 **Output mode-invariance (invariant).** The findings report (`.cheese/age/<slug>.md`) is identical in shape — same dedup rule, same severity grouping, same finding format — whether produced by the single-parent path or fan-out mode. Only the internal execution path differs. This invariant also holds for inline-degrade mode (see `### Inline-degrade mode`).
 

--- a/skills/age/references/dimensions.md
+++ b/skills/age/references/dimensions.md
@@ -94,10 +94,9 @@ python3 shared/scripts/severity.py bucket --files <N> [--modules <M>]
 Source priority for the raw count:
 
 1. **`tilth_deps`** — primary. Returns the file set that would need to change.
-2. **CRG `get_impact_radius_tool`** — when code-review-graph is wired. Equivalent blast-radius output.
-3. **LSP `find-references` / `find-callers`** — fallback when neither tilth nor CRG is available.
+2. **LSP `find-references` / `find-callers`** — fallback when tilth is unavailable.
 
-**Worked recipe.** Given a finding at `path:line`, run `tilth_deps` on the *containing file*. Count the **distinct files** in the imported-by set as `--files` — use the `<N> dependents` header count, since the `Used by` list emits one entry per call site and several entries can map to one file (counting raw entries overcounts). Count the **distinct slice/module roots** among them as `--modules` — the directory immediately under `src/` (so `src/melt` and `src/affinage` are two modules, not the shared `src` parent). Then run `python3 shared/scripts/severity.py bucket --files <N> --modules <M>`. Falling back to CRG `get_impact_radius_tool` or LSP callers, count the same way (distinct touched files, distinct module dirs) so buckets stay comparable across tools.
+**Worked recipe.** Given a finding at `path:line`, run `tilth_deps` on the *containing file*. Count the **distinct files** in the imported-by set as `--files` — use the `<N> dependents` header count, since the `Used by` list emits one entry per call site and several entries can map to one file (counting raw entries overcounts). Count the **distinct slice/module roots** among them as `--modules` — the directory immediately under `src/` (so `src/melt` and `src/affinage` are two modules, not the shared `src` parent). Then run `python3 shared/scripts/severity.py bucket --files <N> --modules <M>`. Falling back to LSP callers, count the same way (distinct touched files, distinct module dirs) so buckets stay comparable across tools.
 
 Fix-cost-now is **reported, not bumped**. Severity decides what to fix; fix-cost-now explains effort and lets triage schedule.
 

--- a/skills/briesearch/references/unavailable.md
+++ b/skills/briesearch/references/unavailable.md
@@ -1,6 +1,6 @@
 # Unavailable sources
 
-Optional MCP servers (Context7, Tavily, code-review-graph, tilth) are not always present. Fallbacks exist, but evidence quality drops — surface that honestly.
+Optional MCP servers (Context7, Tavily, tilth) are not always present. Fallbacks exist, but evidence quality drops — state that explicitly.
 
 ## Per-source fallbacks
 
@@ -9,7 +9,6 @@ Optional MCP servers (Context7, Tavily, code-review-graph, tilth) are not always
 | Context7 | Read repo docs, package README, vendor pages, then web search | Cap at `speculating` for version-specific questions |
 | Tavily | WebFetch (host fetch) for verify/extract; host web search or user-provided links for discovery | Cap at `speculating` when freshness matters |
 | Codebase (`cheez-*`) | Fall back to Serena or LSP, `sg`, `ripgrep`, `find`, and targeted reads | Cap at `speculating` when local precedent is central |
-| code-review-graph (full tool list in [README → Optional tools](../../../README.md#optional-tools)) | Use `tilth_deps` + `cheez-search` callers (`tilth_search kind: "callers"`) for blast radius; skip cross-repo, semantic search, and architecture framing | Cap at `speculating` for cross-repo or large-architecture questions |
 | GitHub (`gh`) | Note absence; user-supplied URLs are acceptable | Skip with a confidence note |
 
 ## Reporting an unavailable source

--- a/skills/cheez-read/SKILL.md
+++ b/skills/cheez-read/SKILL.md
@@ -85,7 +85,7 @@ The tilth MCP server is launched against **one repository** — whatever directo
 
 - Always fresh: no index, no rebuild — reads disk on demand.
 - Cannot reach files outside that one tree (sibling worktrees, `~/...`, system paths, dependency caches like `node_modules`, `.cargo/registry`, `site-packages`).
-- For multi-repo reads, the calling workflow skill must use host `Read` per file directly, or use code-review-graph's cross-repo tools — see cheez-search's [When code-review-graph beats tilth](../cheez-search/references/routing.md#when-code-review-graph-beats-tilth-if-your-harness-has-it) section.
+- For multi-repo reads, the calling workflow skill must use host `Read` per file directly; tilth is scoped to one tree per MCP session.
 
 For when another tool fits better than cheez-read, see [`references/routing.md`](references/routing.md).
 

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -80,7 +80,7 @@ The tilth MCP server is launched against **one repository** — whatever directo
 
 - No startup wait, no rebuild step, no staleness — your last save is what tilth sees on the next call.
 - Cannot reach files outside that one tree (sibling worktrees, `~/...`, system paths, dependency caches like `node_modules` or `.cargo/registry`).
-- Cannot answer cross-repo questions in one call. For that, see [*When code-review-graph beats tilth*](references/routing.md#when-code-review-graph-beats-tilth-if-your-harness-has-it).
+- Cannot answer cross-repo questions in one call; route those before entering cheez-search.
 
 ### When NOT to invoke `/cheez-search`
 
@@ -93,9 +93,9 @@ These questions are **out of scope** -- don't enter cheez-search for them; the t
 | Plain non-code text at scale (logs, build outputs, large CSVs) | host `Bash` with `rg`, `jq`, `awk`, `head`/`tail` from the calling workflow skill | Tree-sitter parsing wastes tokens here; format-specific tools win |
 | Files outside the repo (system paths, `~/Library`, `/etc`) | host `Grep` / `Bash` from the calling workflow skill | tilth is repo-scoped (see above) |
 
-### Route out before entering (type / concept / cross-repo)
+### Route out before entering (type-grounded)
 
-Name-shaped queries stay in tilth. For type-grounded, concept-shaped, or cross-repo questions, route out before entering cheez-search -- see [`references/routing.md`](references/routing.md) for LSP, Serena, and code-review-graph routing tables.
+Name-shaped queries stay in tilth. For type-grounded questions, route out before entering cheez-search -- see [`references/routing.md`](references/routing.md) for LSP and Serena routing tables.
 
 ---
 

--- a/skills/cheez-search/references/routing.md
+++ b/skills/cheez-search/references/routing.md
@@ -1,6 +1,6 @@
 # Routing out of tilth
 
-Name-shaped or text-shaped -> stay in `tilth_search`. Type-grounded, concept-shaped, or cross-repo -> route out before entering cheez-search.
+Name-shaped or text-shaped -> stay in `tilth_search`. Type-grounded -> route to LSP/Serena before entering cheez-search. Cross-repo questions are outside cheez-search's single-repo scope.
 
 ---
 
@@ -34,39 +34,3 @@ If no LSP is installed for the language, or the file is in a broken / incomplete
 `/cheez-search` itself stays tilth-only -- the `allowed-tools` frontmatter does not (and should not) include `mcp__serena__*`. The routing decision happens in the workflow skill *before* it enters `/cheez-search`, matching the redirection-map pattern above. If Serena is unavailable, `.serena/project.yml` is missing, or the symbol isn't LSP-resolvable (broken or generated code), the workflow skill enters `/cheez-search` and uses `tilth_search` -- note "Serena unavailable" in evidence so confidence calibration reflects that the xref wasn't type-validated. tilth also remains the right call for polyglot one-call queries, content / regex search, and any case where speed at scale matters more than type fidelity.
 
 ---
-
-## When code-review-graph beats tilth (if your harness has it)
-
-[`code-review-graph`](https://github.com/tirth8205/code-review-graph) is a separate, optional MCP that builds a **persistent** call graph of one or more repositories with Tree-sitter, Louvain communities, betweenness-centrality, and (with the `[embeddings]` extra) vector embeddings. Where tilth answers "where is `handleAuth`?", code-review-graph answers "what code is *about* authentication, ranked by importance and reach across all my repos?"
-
-It wins on five questions tilth structurally cannot answer:
-
-| Question | code-review-graph tool | Why tilth can't |
-|----------|------------------------|------------------|
-| Find code by *meaning*, not name ("rate-limiting logic", "session expiry handling") | `semantic_search_nodes_tool` | Embeddings rank by concept; tilth only matches identifiers and literal text |
-| Search across *multiple* repos in one call | `cross_repo_search_tool` | tilth is scoped to one tree per MCP session |
-| Risk-weighted blast radius (which callers actually matter, by centrality) | `get_impact_radius_tool`, `get_review_context_tool` | `tilth_deps` returns raw imports; code-review-graph weights them by graph centrality |
-| Architecture framing for a large diff (hubs, bridges, communities) | `get_architecture_overview_tool`, `get_hub_nodes_tool`, `get_bridge_nodes_tool`, `list_communities_tool` | tilth has no global graph view |
-| Affected execution flows for a change | `get_affected_flows_tool` | tilth follows callers one hop at a time; this returns full flows |
-
-**Before the first query -- refresh the graph via MCP.** code-review-graph keeps a persistent graph that goes stale between sessions. From inside an agent, prefer the MCP tools over the CLI:
-
-- Call `build_or_update_graph_tool` once at the start of a run. It's incremental -- on a warm repo this is fast.
-- `semantic_search_nodes_tool` needs embeddings. Current server versions handle embedding without a separate tool call; if your server's tool list includes `embed_graph_tool`, call it once after build (embedding is the slow step -- skip it otherwise).
-
-The CLI equivalents (`code-review-graph build` / `embed`) are for first-time setup; inside a run, the MCP tools let the agent own the lifecycle.
-
-**When `semantic_search_nodes_tool` beats tilth.** Reach for it when the question is concept-shaped, not name-shaped:
-
-- **Steel threads** -- trace a feature end-to-end when each layer names the concept differently (controller -> service -> repo -> migration -> telemetry). tilth makes you guess the next layer's vocabulary; embeddings surface the chain.
-- **Shared concepts under divergent names** -- "where do we handle idempotency?" when the code uses `dedupeKey`, `requestSig`, `OnceToken`. Grep is blind to the concept; embeddings find it.
-- **Vocabulary mismatch between spec and code** -- product says "session continuity", code says `KeepaliveToken`. Map the stakeholder term to the implementation without an SME.
-- **Analog mining** -- before adding another retry / rate-limit / cache layer, ask what already exists under different names.
-- **Cross-repo concept discovery** -- pair with `cross_repo_search_tool` to find auth (or any concept) across services that named it differently.
-- **Onboarding orientation** -- "what's in this repo for observability?" returns conceptually adjacent nodes ranked by graph centrality. Faster first read than walking imports.
-
-**Stay on tilth when** you know the symbol name; you need literal text or regex; you're doing a one-hop caller walk; the branch is hot and you haven't re-embedded; or the change is a mechanical rename or move.
-
-**Two gotchas.** Ranking blends similarity with graph centrality -- `semantic_search_nodes_tool` biases toward hub nodes, sometimes against the leaf where the bug actually lives; after a hit, follow callers in tilth. Default embedding model is `all-MiniLM-L6-v2` (384-dim), which blurs nuanced distinctions like "session timeout" vs "session revocation" -- override via `CRG_EMBEDDING_MODEL` if your domain needs it.
-
-If code-review-graph is unavailable, the cheez-search fallbacks are: name-shaped questions stay on tilth; semantic / cross-repo / architecture questions either degrade to a manual `tilth_deps` + `kind: "callers"` walk or get noted as unavailable evidence (cap confidence at `speculating`).

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -47,14 +47,12 @@ Beyond `cheez-*` there are cure-specific tools:
 
 | Need | Prefer | Fallback |
 | --- | --- | --- |
-| Understanding findings | `/age` report plus code-review-graph: `get_minimal_context_tool`, `get_review_context_tool` | diff, touched files, tests |
+| Understanding findings | `/age` report plus touched diff/test context | diff, touched files, tests |
 | CI and PR context | `gh` | local test output or user-provided logs |
 | Diffs | `delta` | plain `git diff` |
 | Conflict resolution | mergiraf | manual resolution with targeted tests |
 | Code navigation | `/cheez-search` `kind:symbol` then `kind:callers` | `tilth_search` direct |
 | Read before edit | `/cheez-read` ranged/outline (`paths: ["f#n-m"]`, `mode:stripped`) | DO NOT `cat`/`sed -n`/host Read on code paths |
-
-**Freshness:** before the first code-review-graph query in a run, call `build_or_update_graph_tool`. See [`/cheez-search`](../cheez-search/references/routing.md#when-code-review-graph-beats-tilth-if-your-harness-has-it) for the full freshness contract and when semantic search beats tilth.
 
 If a preferred tool is missing, continue with the fallback. If a missing tool prevents safe application, stop and explain the blocker.
 

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -32,9 +32,7 @@ Beyond `cheez-*` there are press-specific tools:
 | Need | Prefer | Fallback |
 | --- | --- | --- |
 | Diff review | `delta` | plain `git diff` |
-| Affected execution flows + risk scoring | code-review-graph: `get_affected_flows_tool`, `get_impact_radius_tool` | manual flow tracing from callers |
-
-**Freshness:** before the first code-review-graph query in a run, call `build_or_update_graph_tool`. See [`/cheez-search`](../cheez-search/references/routing.md#when-code-review-graph-beats-tilth-if-your-harness-has-it) for the full freshness contract and when semantic search beats tilth.
+| Affected execution flows + risk scoring | caller/dependency tracing from `/cheez-search` and `tilth_deps` | manual flow tracing from changed files |
 
 If optional tools are missing, press a narrower surface and state the residual risk.
 

--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -53,16 +53,6 @@ Every spawn uses the canonical `/<phase> <slug> --auto` form. Cook accepts a bar
 | 6 | `/cure <slug> --auto --stake medium+`     | `.cheese/cure/<slug>.md` (overwritten) |
 | 7 | `/age <slug> --auto`                      | `.cheese/age/<slug>.md` (final report) |
 
-### Optional: code-review-graph pre-build
-
-Before spawning phase 3 (first `/age`), if code-review-graph MCP is available, call `build_or_update_graph_tool` once from the orchestrator context so the three age sub-agents reuse the warmed graph. If absent, skip — each age sub-agent degrades per `shared/optional-plugins.md`.
-
-```
-if build_or_update_graph_tool in available_tools:
-    build_or_update_graph_tool()   # warm the graph once; age sub-agents reuse it
-# then spawn phase 3
-```
-
 ### Cap enforcement
 
 The two-cure-pass cap is enforced by **chain length, not by age** — age boots in fresh context and cannot count prior passes. So:

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -90,7 +90,7 @@ count_skills() {
 }
 
 @test "ec_validate_selection accepts the special 'none' MCP token" {
-    run ec_validate_selection "none" "tilth context7 tavily code-review-graph none"
+    run ec_validate_selection "none" "tilth context7 tavily hallouminate milknado none"
     [ "$status" -eq 0 ]
 }
 
@@ -360,7 +360,7 @@ STUB
     grep -q "^tilth install claude-code --edit$" "$STUB_LOG"
 }
 
-# -- ec_install_mcp_context7 / tavily / crg ----------------------------------
+# -- ec_install_mcp_context7 / tavily ----------------------------------------
 
 @test "ec_install_mcp_context7 warns and skips for non-claude harness" {
     run ec_install_mcp_context7 cursor
@@ -423,98 +423,6 @@ STUB
     [[ "$output" == *"$STUB_BIN/claude mcp add tavily -- $STUB_BIN/npx -y tavily-mcp"* ]]
 }
 
-# -- ec_install_crg_cli -------------------------------------------------------
-
-@test "ec_install_crg_cli prefers uv over pipx and pip" {
-    make_stub uv
-    make_stub pipx
-    make_stub pip
-    EC_UV="$STUB_BIN/uv" EC_PIPX="$STUB_BIN/pipx" EC_PIP="$STUB_BIN/pip" \
-        EC_DRY_RUN=1 run ec_install_crg_cli
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"uv tool install code-review-graph[embeddings]"* ]]
-    [[ "$output" != *"pipx install"* ]]
-    [[ "$output" != *"pip install"* ]]
-}
-
-@test "ec_install_crg_cli falls back to pipx when uv missing" {
-    make_stub pipx
-    make_stub pip
-    EC_PIPX="$STUB_BIN/pipx" EC_PIP="$STUB_BIN/pip" \
-        EC_DRY_RUN=1 run ec_install_crg_cli
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"pipx install code-review-graph[embeddings]"* ]]
-    [[ "$output" != *"uv tool"* ]]
-}
-
-@test "ec_install_crg_cli falls back to 'pip install --user' last with a warning" {
-    make_stub pip
-    EC_PIP="$STUB_BIN/pip" EC_DRY_RUN=1 run ec_install_crg_cli
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"falling back to 'pip install --user'"* ]]
-    [[ "$output" == *"pip install --user code-review-graph[embeddings]"* ]]
-}
-
-@test "ec_install_crg_cli fails clearly when uv, pipx, and pip are all missing" {
-    PATH="$STUB_BIN" run ec_install_crg_cli
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"needs uv, pipx, or pip"* ]]
-}
-
-@test "ec_install_crg_cli invokes uv tool install with embeddings extra when not dry-run" {
-    make_stub uv
-    export EC_UV="$STUB_BIN/uv"
-    run ec_install_crg_cli
-    [ "$status" -eq 0 ]
-    grep -q "^uv tool install code-review-graph\[embeddings\]$" "$STUB_LOG"
-}
-
-@test "ec_install_crg_cli honors EC_CRG_SPEC override (bare CLI, no extras)" {
-    make_stub uv
-    EC_UV="$STUB_BIN/uv" EC_CRG_SPEC="code-review-graph" EC_DRY_RUN=1 \
-        run ec_install_crg_cli
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"uv tool install code-review-graph"* ]]
-    [[ "$output" != *"code-review-graph[embeddings]"* ]]
-}
-
-# -- ec_install_mcp_crg -------------------------------------------------------
-
-@test "ec_install_mcp_crg installs CLI then registers when binary missing" {
-    make_stub uv
-    EC_UV="$STUB_BIN/uv" EC_CRG="$STUB_BIN/code-review-graph-not-real" \
-        EC_DRY_RUN=1 run ec_install_mcp_crg claude-code
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"uv tool install code-review-graph[embeddings]"* ]]
-    [[ "$output" == *"install --platform claude-code"* ]]
-}
-
-@test "ec_install_mcp_crg invokes crg install for present binary" {
-    make_stub code-review-graph
-    export EC_CRG="$STUB_BIN/code-review-graph"
-    run ec_install_mcp_crg claude-code
-    [ "$status" -eq 0 ]
-    grep -q "^code-review-graph install --platform claude-code$" "$STUB_LOG"
-}
-
-@test "ec_install_mcp_crg fails with PATH hint when binary still missing after install" {
-    # Simulate the common 'pip install --user' case: pip succeeds but the
-    # binary lands in a directory that's not on PATH, so the post-install
-    # ec_cmd_exists check still fails.
-    make_stub pip
-    export EC_PIP="$STUB_BIN/pip"
-    # EC_CRG points at a path that will never exist on PATH.
-    export EC_CRG="$BATS_TEST_TMPDIR/nope/code-review-graph"
-    run ec_install_mcp_crg claude-code
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"install succeeded but"* ]]
-    [[ "$output" == *"not on PATH"* ]]
-    [[ "$output" == *"pipx ensurepath"* ]]
-    # Crucially, the registration step must NOT fire when the binary is
-    # still missing — otherwise the user gets the generic shell error we're
-    # trying to replace with a targeted hint.
-    ! grep -q " install --platform " "$STUB_LOG" || false
-}
 
 # -- ec_install_mcp_hallouminate -----------------------------------------------
 


### PR DESCRIPTION
## What changed

Removed code-review-graph from documentation, installation instructions, and skill references. The tool is no longer a required or suggested component of the workflow.

## Why

Simplifying the dependency footprint and documentation to remove code-review-graph as a suggested or optional tool.

## How to verify

Review the diff for removed code-review-graph documentation, installation steps, and tool references in README.md and skill docs.

## Risk / rollout notes

None. This is a documentation and reference removal only.

## Checklist

- [x] Conventional Commits PR title (`feat:`, `fix:`, `chore:`, `docs:`, ...)
- [x] Tests added or updated (N/A — documentation only)
- [x] Documentation updated
- [x] No secrets or credentials added