### PR TITLE
docs(skills): name typed phase-agents in dispatch prose with fallback

### DIFF
--- a/skills/affinage/SKILL.md
+++ b/skills/affinage/SKILL.md
@@ -89,7 +89,7 @@ When `affinage.pyz pr-status` reports `merge.mergeable: CONFLICTING` or `merge.s
 
 ## Sub-agent context gate
 
-`/affinage` keeps dialogue, selection, approval state, and reply posting in the parent context. Spawn a read-only grading sub-agent — the `reviewer` phase-agent — only when the parent context would balloon (if the named `reviewer` isn't available, e.g. a harness that installs only easy-cheese, fall back to `general-purpose`):
+`/affinage` keeps dialogue, selection, approval state, and reply posting in the parent context. Spawn a read-only grading sub-agent — the `reviewer` phase-agent — only when the parent context would balloon (if the named `reviewer` isn't available, e.g. a harness that installs only easy-cheese, fall back to the read-only built-in `Explore` agent or inline grading — never `general-purpose`, which grants full write access):
 
 - Total input count (comments + CI failures) exceeds 10.
 - Diff exceeds ~25 KB.

--- a/skills/affinage/SKILL.md
+++ b/skills/affinage/SKILL.md
@@ -89,7 +89,7 @@ When `affinage.pyz pr-status` reports `merge.mergeable: CONFLICTING` or `merge.s
 
 ## Sub-agent context gate
 
-`/affinage` keeps dialogue, selection, approval state, and reply posting in the parent context. Spawn a read-only grading sub-agent only when the parent context would balloon:
+`/affinage` keeps dialogue, selection, approval state, and reply posting in the parent context. Spawn a read-only grading sub-agent — the `reviewer` phase-agent — only when the parent context would balloon (if the named `reviewer` isn't available, e.g. a harness that installs only easy-cheese, fall back to `general-purpose`):
 
 - Total input count (comments + CI failures) exceeds 10.
 - Diff exceeds ~25 KB.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -95,7 +95,7 @@ Beyond `cheez-*` there are review-specific tools:
 
 ## Sub-agent context gate
 
-`/age` should fork a read-only review-context sub-agent — the `explorer` phase-agent, which gathers diff / caller / dependency evidence and returns a digest without grading — when evidence gathering is likely to exceed the parent context, especially for `--comprehensive` reviews. If the named `explorer` agent isn't available (e.g. a harness that installs only easy-cheese), fall back to `general-purpose` or an inline read.
+`/age` should fork a read-only review-context sub-agent — the `explorer` phase-agent, which gathers diff / caller / dependency evidence and returns a digest without grading — when evidence gathering is likely to exceed the parent context, especially for `--comprehensive` reviews. If the named `explorer` agent isn't available (e.g. a harness that installs only easy-cheese), fall back to the read-only built-in `Explore` agent or an inline read — never `general-purpose`, which grants full write access.
 
 **Scale threshold** — spawn when any of these are true:
 
@@ -114,7 +114,7 @@ Activates when **all** hold: the **scale threshold** (above) is met AND `/age` i
 
 **Seam 2 — Shared context packet.** The orchestrator assembles the packet once, writes it to `.cheese/age/<slug>-packet.md`, and each worker reads it. Eight components, and the reuse of the review-context digester as the orientation block, are documented in `references/packet.md`.
 
-**Seam 3 — Worker contract.** One worker per dimension — dispatch the `reviewer` phase-agent scoped to a single dimension (if the named `reviewer` isn't available, e.g. a harness that installs only easy-cheese, fall back to `general-purpose`). Each worker:
+**Seam 3 — Worker contract.** One worker per dimension — dispatch the `reviewer` phase-agent scoped to a single dimension (if the named `reviewer` isn't available, e.g. a harness that installs only easy-cheese, fall back to the read-only built-in `Explore` agent or the single-parent path — never `general-purpose`, which grants full write access). Each worker:
 - Reviews only its assigned dimension.
 - Computes **full per-finding severity** for that dimension (base + location bump + compounding bump).
 - Tags each finding with its dimension and an `also-relevant-to: [<dim>, ...]` field when cross-dimension overlap is suspected.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -95,7 +95,7 @@ Beyond `cheez-*` there are review-specific tools:
 
 ## Sub-agent context gate
 
-`/age` should fork a read-only review-context sub-agent when evidence gathering is likely to exceed the parent context, especially for `--comprehensive` reviews.
+`/age` should fork a read-only review-context sub-agent — the `explorer` phase-agent, which gathers diff / caller / dependency evidence and returns a digest without grading — when evidence gathering is likely to exceed the parent context, especially for `--comprehensive` reviews. If the named `explorer` agent isn't available (e.g. a harness that installs only easy-cheese), fall back to `general-purpose` or an inline read.
 
 **Scale threshold** — spawn when any of these are true:
 
@@ -114,7 +114,7 @@ Activates when **all** hold: the **scale threshold** (above) is met AND `/age` i
 
 **Seam 2 — Shared context packet.** The orchestrator assembles the packet once, writes it to `.cheese/age/<slug>-packet.md`, and each worker reads it. Eight components, and the reuse of the review-context digester as the orientation block, are documented in `references/packet.md`.
 
-**Seam 3 — Worker contract.** One worker per dimension. Each worker:
+**Seam 3 — Worker contract.** One worker per dimension — dispatch the `reviewer` phase-agent scoped to a single dimension (if the named `reviewer` isn't available, e.g. a harness that installs only easy-cheese, fall back to `general-purpose`). Each worker:
 - Reviews only its assigned dimension.
 - Computes **full per-finding severity** for that dimension (base + location bump + compounding bump).
 - Tags each finding with its dimension and an `also-relevant-to: [<dim>, ...]` field when cross-dimension overlap is suspected.

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -93,7 +93,7 @@ Optional tools accelerate the work; missing tools do not block the dialogue. Whe
 
 ## Sub-agent context gate
 
-`/mold` keeps the dialogue, contradictions, approval state, and the two-key handshake in the parent context — those never delegate. Offloading heavy work to a read-only sub-agent is the **default** (`references/context-budget.md`) — the `explorer` phase-agent for code reads and shape checks, the `researcher` phase-agent for deep `/briesearch`. Spawn one whenever the work would flood the conversation with raw evidence or graph output (if the named agent isn't available, e.g. a harness that installs only easy-cheese, fall back to `general-purpose`):
+`/mold` keeps the dialogue, contradictions, approval state, and the two-key handshake in the parent context — those never delegate. Offloading heavy work to a read-only sub-agent is the **default** (`references/context-budget.md`) — the `explorer` phase-agent for code reads and shape checks, the `researcher` phase-agent for deep `/briesearch`. Spawn one whenever the work would flood the conversation with raw evidence or graph output (if the named agent isn't available, e.g. a harness that installs only easy-cheese, fall back to the read-only built-in `Explore` agent — or an inline read — never `general-purpose`, which grants full write access):
 
 Triggers and digest constraints in `references/context-budget.md`.
 

--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -93,7 +93,7 @@ Optional tools accelerate the work; missing tools do not block the dialogue. Whe
 
 ## Sub-agent context gate
 
-`/mold` keeps the dialogue, contradictions, approval state, and the two-key handshake in the parent context — those never delegate. Offloading heavy work to a read-only sub-agent is the **default** (`references/context-budget.md`). Spawn one whenever the work would flood the conversation with raw evidence or graph output:
+`/mold` keeps the dialogue, contradictions, approval state, and the two-key handshake in the parent context — those never delegate. Offloading heavy work to a read-only sub-agent is the **default** (`references/context-budget.md`) — the `explorer` phase-agent for code reads and shape checks, the `researcher` phase-agent for deep `/briesearch`. Spawn one whenever the work would flood the conversation with raw evidence or graph output (if the named agent isn't available, e.g. a harness that installs only easy-cheese, fall back to `general-purpose`):
 
 Triggers and digest constraints in `references/context-budget.md`.
 

--- a/skills/mold/references/context-budget.md
+++ b/skills/mold/references/context-budget.md
@@ -9,14 +9,18 @@ the reliable one is sub-agent offload (ADR-003, Risks).
 ## Default: offload heavy work to sub-agents
 
 The sub-agent context gate (`SKILL.md` § Sub-agent context gate) is the **default**
-for heavy work, not an exception. Spawn a read-only sub-agent for:
+for heavy work, not an exception. Spawn a read-only sub-agent — name the typed
+phase-agent that fits the work, falling back to `general-purpose` where it isn't
+available (e.g. a harness that installs only easy-cheese):
 
-- **Reads / research:** deep `/briesearch` (3+ doc fetches or 2+ search angles).
+- **Reads / research:** deep `/briesearch` (3+ doc fetches or 2+ search angles) —
+  the `researcher` phase-agent.
 - **Shape check:** more than 5 symbols, wide module fan-out, large caller/dep
-  traversals.
+  traversals — the `explorer` phase-agent.
 - **Prototype Cycle:** the throwaway build always runs in a sub-agent
-  (`references/prototype-cycle.md`).
-- **Diagnose:** bulky logs/traces before a concise root-cause hypothesis.
+  (`references/prototype-cycle.md`) — the `explorer` phase-agent.
+- **Diagnose:** bulky logs/traces before a concise root-cause hypothesis — the
+  `explorer` phase-agent.
 
 The sub-agent returns a ≤2 KB digest; the raw evidence never enters the parent
 window. The parent keeps only the dialogue, contradictions, approval state, and

--- a/skills/mold/references/context-budget.md
+++ b/skills/mold/references/context-budget.md
@@ -10,10 +10,11 @@ the reliable one is sub-agent offload (ADR-003, Risks).
 
 The sub-agent context gate (`SKILL.md` § Sub-agent context gate) is the **default**
 for heavy work, not an exception. Spawn a read-only sub-agent — name the typed
-phase-agent that fits the work, falling back to `general-purpose` where it isn't
-available (e.g. a harness that installs only easy-cheese):
+phase-agent that fits the work, falling back to the read-only built-in `Explore`
+agent (or an inline read) where it isn't available (e.g. a harness that installs
+only easy-cheese) — never `general-purpose`, which grants full write access:
 
-- **Reads / research:** deep `/briesearch` (3+ doc fetches or 2+ search angles) —
+- **Research:** deep `/briesearch` (3+ doc fetches or 2+ search angles) —
   the `researcher` phase-agent.
 - **Shape check:** more than 5 symbols, wide module fan-out, large caller/dep
   traversals — the `explorer` phase-agent.


### PR DESCRIPTION
## What

Rewrite untyped read-only sub-agent **dispatch prose** in easy-cheese `SKILL.md`/reference files so each confirmed spawn site names the appropriate typed phase-agent. Context isolation improves without breaking bare easy-cheese installs.

Prose-only — no change to agent behavior, tools, models, or runtime/hook wiring.

## Split state

This PR now contains only the typed phase-agent dispatch prose. The cheez tools/MCP backend-contract prose was split to #209.

## Phase 0 — verified targets (4 sites, 4 files)

| Skill | file:line | spawn purpose | typed agent |
|---|---|---|---|
| age | `SKILL.md:98` | evidence-gathering review-context fork | `explorer` |
| age | `SKILL.md:117` (Seam 3 per-dim worker) | per-dimension code review | `reviewer` |
| affinage | `SKILL.md:92` | read-only grading fork | `reviewer` |
| mold | `SKILL.md:96` + `references/context-budget.md` | reads / shape / prototype / diagnose + deep briesearch | `explorer` + `researcher` |

Each rewrite names the typed agent and retains a portability fallback: if the named phase-agent is unavailable, fall back to the read-only built-in `Explore` agent or the inline/single-parent path. Do **not** fall back to `general-purpose` for read-only work because it grants write access.

## Exempt / not a target (verified, not presumed)

- **cook** — reference pattern already covers its TDD loop.
- **cheese-factory** — full-peer `general-purpose` by documented design; unchanged in this split.
- **ultracook** — full-peer by design (spawns whole-skill phase agents).
- **hard-cheese** — false positive: its judge grades a user's explanation against a SOLO rubric with a custom system prompt and no tools; no typed phase-agent matches, and renaming would change behavior (a spec non-goal).
- **age/references/sub-agent-gate.md** — shared model-tier-agnostic kernel serving both gathering and grading callers; naming one agent breaks its cross-skill role.
- **briesearch** — the research engine `researcher` wraps; naming it is circular.
- **press** — analytics count was stale pre-fix history; it dispatches no sub-agent (only spawned by ultracook).

## Verification

- `gh pr view 200 --json files --jq '[.files[].path]'` → exactly the 4 verified-target files.
- Per-file search confirmed typed-agent names and read-only fallback prose at each edited site.
- GitHub Actions for this PR: 10 checks passed, 0 failed.

Pipeline: `/cook` → `/press` (no hardening — prose-only) → `/age` (clean, no findings) → split cleanup.
