### PR TITLE
feat(ultracook): two-mode SKILL (wire the engine)

### DIFF
--- a/skills/ultracook/SKILL.md
+++ b/skills/ultracook/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: ultracook
-description: Pipeline one approved high-blast-radius spec sequentially through cook → press → age → cure → age → cure → age (all `--auto`), with fresh-context isolation per phase. Use when the user has such a spec — phrases like "/ultracook .cheese/specs/<slug>.md", "ultracook this", "run the full pipeline in isolation", "fresh-context auto chain", "send it through the cave", "pipeline with no contamination". Runs inline and spawns full-peer general-purpose sub-agents (one per phase), each invoking the phase skill with `--auto` and writing its handoff slug under `.cheese/<phase>/<slug>.md`. Sub-agents inherit the parent's model and full tool / MCP / skill access. Use when the user wants `/cook --auto`'s autonomous chain semantics but with each phase reasoning blind to prior phases. After `/mold`; ends after the third age spawn (or earlier on halt / early-stop).
+description: Pipeline one approved high-blast-radius spec through fresh-context sub-agents in one of two modes the decomposer picks. Linear mode runs cook → press → age → cure → age → cure → age (all `--auto`) for an indivisible spec. Parallel mode fans a decomposable spec into independent behavioural curds — each cooked, pressed, aged, and cured in its own worktree, then harvested for one post-merge review pass — ending in 1–N reviewable PRs. Use when the user has such a spec — phrases like "/ultracook .cheese/specs/<slug>.md", "ultracook this", "run the full pipeline in isolation", "parallelize this spec", "fan out the implementation", "many curds", "send it through the cave", "pipeline with no contamination". Spawns full-peer general-purpose sub-agents that invoke each phase skill with `--auto`, each reasoning in fresh context blind to prior phases and inheriting the parent's model and tools — `/cook --auto`'s autonomous chain in isolation. After `/mold`; the decomposer is the mode gate.
 license: MIT
 ---
 
 # /ultracook
 
-Use this skill when the user wants the whole `cook → press → age → cure → age → cure → age` chain to run forward without per-step approval, **and** wants each phase to reason in fresh context — blind to the previous phase's chain-of-thought.
+Use this skill when the user wants an approved high-blast-radius spec run forward without per-step approval, **and** wants each phase to reason in fresh context — blind to the previous phase's chain-of-thought. `/ultracook` carries two modes; the decomposer picks between them:
+
+- **Linear mode** — for an indivisible spec: the deep `cook → press → age → cure → age → cure → age` chain, all `--auto`, each phase a fresh sub-agent. This is the sub-agent-transport sibling of `/cook --auto`.
+- **Parallel mode** — for a decomposable spec: fan the spec out into independent behavioural curds, cook/press/age/cure each in its own worktree, harvest the curd branches onto the orchestrator branch, then run one post-merge press → age → cure over the merged diff. Ends in 1–N reviewable PRs. (This folds in the retired `/cheese-factory`.)
 
 Do not use it for short focused changes (`/cook --auto` is cheaper and continuous), for fuzzy planning (`/mold`), or for review-only work (`/age`).
-
-`/ultracook` is the sub-agent-transport sibling of `/cook --auto`: same chain and `--auto` semantics, but each phase runs in its own freshly-spawned sub-agent, so the parent context never accumulates phase-internal reasoning.
 
 ## Inputs
 
@@ -24,7 +25,17 @@ Accept one of:
 
 Optional flag: `--open-pr` — at the terminal, open a *new* PR when none exists (the default only pushes an already-open one). The phase-only cure sub-agents never push.
 
-## Flow
+## Mode selection — the decomposer is the gate
+
+Before the phase loop runs, the decomposer picks the mode. This is the one authoritative gate; the `/mold` curd-count hint is advisory only.
+
+1. **Decompose** — spawn a full-peer decomposer sub-agent (`references/decomposer-prompt.md`) to produce `seed[]`, `curds[]`, and `wiring[]` from the spec, then validate with `python3 ${CLAUDE_SKILL_DIR}/scripts/ultracook.pyz validate_decomposition <manifest>`. Re-run on validation failure (max 2 retries).
+2. **Pick the mode** — `python3 ${CLAUDE_SKILL_DIR}/scripts/ultracook.pyz mode --count <curd-count>` → `linear | parallel`. The canonical `PARALLEL_THRESHOLD` (2) lives in the engine: a decomposition of **2 or more** curds routes to **parallel mode**; **1** curd stays **linear**. There is one threshold in the tree — the selector, `validate_decomposition`, and the mold hint all read it.
+3. **Probe the engine seam** — `python3 ${CLAUDE_SKILL_DIR}/scripts/ultracook.pyz milknado --tools "<available tool names>"` → `engine | tracker | none`. This decides how parallel mode runs curds (see `## Parallel mode`); linear mode ignores it.
+
+A 1-curd spec runs `## Flow` (linear mode) unchanged. A 2+-curd spec runs `## Parallel mode`.
+
+## Flow (linear mode)
 
 1. **Resolve slug** — derive `<slug>` from the input. If a spec path is given, the slug is the basename without `.md`; if a bare slug is given, confirm the spec exists at the durable path the spawned `/cook` resolves (`python3 ${CLAUDE_SKILL_DIR}/scripts/cook.pyz artifact-path specs <slug>`; see `shared/formatting.md` § Corpus location).
 2. **Guard against re-entry** — if any of `.cheese/{cook,press,age,cure}/<slug>.md` already exist, stop with a one-line list of the existing handoffs and tell the user to either run `/cheese --continue <slug>` to resume from the latest phase or `rm` the relevant files to start fresh.
@@ -71,7 +82,9 @@ Each phase's SKILL.md `## Auto mode` section honours this directive — see `ski
 
 ## Sub-agent contract
 
-Each phase spawns a **full peer** sub-agent. For the five-invariant specification, per-harness invocation examples, and the harness-evaluation checklist, see [`../cheese-factory/references/spawn-primitive-reference.md`](../cheese-factory/references/spawn-primitive-reference.md).
+Each phase (both modes) spawns a **full peer** sub-agent. For the five-invariant specification, per-harness invocation examples, and the harness-evaluation checklist, see [`references/spawn-primitive-reference.md`](references/spawn-primitive-reference.md).
+
+**Capability gate, not a type ban (issue #197).** The gate is *capability*, never the `subagent_type` label: a spawn qualifies when it inherits the parent's model, full tool access, full skill access, and full MCP access. A specialized `subagent_type` (e.g. a typed coder/reviewer, or the harness's `general-purpose`) is acceptable when it clears that bar; reject only diminutive workers — a downgraded model (haiku) or a scoped read-only type that lacks the tools a phase needs. This rule governs both /ultracook modes and /ultracook-fleet.
 
 ## Handoff slug schema
 
@@ -124,6 +137,39 @@ Next step:        review the diff, then /gh when ready
 
 If the chain stopped on a halt, replace "Next step" with the halt reason and the path of the phase that surfaced it.
 
+## Parallel mode
+
+Reached when the decomposer produces **2 or more** curds (`mode → parallel`). This mode mirrors `skills/age/SKILL.md`'s scale-triggered fan-out / inline-degrade split: the *topology* changes, the *output* does not. Parallel mode is **curd-light** — each curd runs its own review, then one integration pass reviews the merged diff. The per-run manifest lives at `.cheese/ultracook/<slug>/manifest.yaml`.
+
+### Topology
+
+1. **Seed (inline).** The orchestrator writes the small shared types/interfaces `seed[]` names (the one place the orchestrator writes code), runs the project gates, and commits.
+2. **Per-curd fan-out.** Spawn one full-peer sub-agent per curd (`references/curd-prompt.md`), each in its **own worktree**. Each curd runs the per-curd pipeline `cook → press → age → cure` — the `PARALLEL_CURD` phase table: `python3 ${CLAUDE_SKILL_DIR}/scripts/ultracook.pyz phase_decision --phase-index <i> --status <status> --table parallel-curd`. Inside a curd, `/age` runs **inline-degrade** (the spawn prompt carries `invoked-from: ultracook-curd`) because the curd worker already sits at the nesting-depth cap. Each curd commits on its worktree branch.
+   - **Worktree floor (no native primitive).** When the host lacks the native `Agent(isolation:"worktree")` primitive, the orchestrator first creates each curd's worktree with `python3 ${CLAUDE_SKILL_DIR}/scripts/ultracook.pyz worktree create --slug <id> --base <orchestrator-branch>` (returns `{path, branch}`), then spawns the sub-agent into that path; harvest (step 3) and teardown (step 4) proceed unchanged.
+3. **Harvest (fan-in).** Cherry-pick each curd branch onto the orchestrator branch with `python3 ${CLAUDE_SKILL_DIR}/scripts/ultracook.pyz worktree harvest --branch <curd-branch> --onto <orchestrator-branch>`. The parent and sub-agent share one `.git` object store, so this needs **no `git fetch`**. On conflict, invoke `/melt`; if it cannot resolve, fall back to per-curd PRs.
+4. **Teardown.** After harvesting each curd, `python3 ${CLAUDE_SKILL_DIR}/scripts/ultracook.pyz worktree teardown --path <worktree-path> --branch <curd-branch>` removes the worktree and deletes its branch. The engine owns teardown — worktrees leak otherwise; a completed run leaves no `worktree-agent-*` branch or `.claude/worktrees/agent-*` dir.
+5. **Wiring.** Dispatch the topo-sorted `wiring[]` integration tasks (`ultracook.pyz wiring_topo_sort`), sequentially within each wave.
+6. **Post-merge review (once).** Run exactly one `press → age → cure` over the merged diff — the `PARALLEL_POSTMERGE` table (`--table parallel-postmerge`). Single pass; the per-curd reviews already covered each slice.
+7. **PR plan + publish.** Plan the PR layout (`references/pr-planner-prompt.md`) and publish 1–N reviewable PRs via a discovered `/pr-stack` (or plain `gh`).
+
+### milknado engine seam (probe-and-use)
+
+The `milknado` probe from **Mode selection** decides how curds run:
+
+- **`engine`** (`milknado_todo_claim` + `milknado_node_verify` present) — milknado owns the DAG, per-node worktrees, and **verify-until-green**; the orchestrator spawns the agent per claimed node and lets milknado re-run the gates until they pass.
+- **`tracker` / `none`** — **native fan-out**: the orchestrator owns worktrees (via the `worktree` helper), and **curds self-verify by running the project gates in-worker**. Parallel mode runs to completion with milknado entirely absent.
+
+**This parity difference is intentional and load-bearing:** native curds self-verify (gates run once, in-worker), while milknado, when present, does verify-until-green (re-runs gates until they pass). See [`../../shared/optional-plugins.md`](../../shared/optional-plugins.md) for the detect-and-degrade contract; announce the absence once and proceed.
+
+### Recovery paths (issue #194)
+
+- **Worker exhaustion.** A curd worker that runs out of context or turns writes a partial `status: halt: <reason>` slug. Retry that curd **once** with the error folded into its context; if it halts again, mark it failed, keep harvesting the rest, and report the failed curd in the final summary. Never silently drop it.
+- **Aggregate-gate failure.** After harvesting all curds, run the project gates over the merged tree. On failure, distinguish a **real cross-curd conflict** (the curds passed individually but collide in aggregate — a decomposer error → halt and surface it) from **harmless drift** (a formatter or generated-file delta the post-merge cure can absorb → continue). Do not auto-resolve a real conflict.
+
+### Output mode-invariance
+
+Parallel mode's final report and every handoff slug use the **same schema** as linear mode (`## Handoff slug schema`, `## Output`). The output is mode-invariant: a reader of the summary or a downstream `/cheese --continue` cannot tell which mode produced it. Only the topology differs.
+
 ## Preferred tools and fallbacks
 
 The orchestrator only needs:
@@ -138,10 +184,11 @@ If the host harness does not expose a sub-agent primitive at all, `/ultracook` i
 
 ## Rules
 
-- Sub-agents are full peers, not diminutive workers. Do not downgrade the model, do not narrow `subagent_type`, do not restrict tools or MCP access.
-- The chain is fixed: cook → press → age → cure → age → cure → age, all `--auto`, cure severity floor `medium+` (the `--stake` flag literal is preserved across callers). Do not invent extra phases or skip phases.
+- Sub-agents are full peers, not diminutive workers. Do not downgrade the model, do not restrict tools or MCP access. Gate `subagent_type` on capability, not on the label (issue #197): a specialized type is fine when it is a full peer; reject only diminutive types.
+- In linear mode the chain is fixed: cook → press → age → cure → age → cure → age, all `--auto`, cure severity floor `medium+` (the `--stake` flag literal is preserved across callers). Do not invent extra phases or skip phases. Parallel mode's topology is per-curd `cook → press → age → cure` plus one post-merge `press → age → cure`.
 - Read each phase's handoff slug after the sub-agent returns. Do not infer success from the sub-agent's last line — read the file.
 - Surface halts verbatim. Do not paraphrase, do not soften, do not "retry" a halted phase silently.
+- In parallel mode, own worktree teardown: no `worktree-agent-*` branch or `.claude/worktrees/agent-*` dir may leak after a completed run. State the milknado parity difference (native self-verify vs milknado verify-until-green) when it applies.
 - At the terminal, push to an already-open PR via `/gh` (Rule 11); create a *new* PR only with `--open-pr`. Never push on a halt.
 - Never wipe existing handoffs. Stop and tell the user to use `/cheese --continue` or `rm` by hand.
 - Apply the shared voice kernel (lives at `skills/age/references/voice.md` in this repo): lead the final summary with what happened, flag residual risk as `certain | speculating | don't know`, do not manufacture follow-ups.

--- a/tests/python/test_ultracook_skills.py
+++ b/tests/python/test_ultracook_skills.py
@@ -1012,7 +1012,7 @@ class TestUltracookModeGate:
         assert "2 or more" in body_lower or "2+" in body, (
             "ultracook must state 2+ curds routes to parallel mode"
         )
-        assert "1" in body and "linear" in body_lower, (
+        assert "1-curd spec runs" in body and "linear mode" in body_lower, (
             "ultracook must state a 1-curd spec stays linear"
         )
 

--- a/tests/python/test_ultracook_skills.py
+++ b/tests/python/test_ultracook_skills.py
@@ -973,3 +973,194 @@ class TestUltracookDeterministicPhaseLoop:
             "ultracook must reference phase_decision in the phase loop so "
             "the next-action verdict is deterministic"
         )
+
+
+# ---------------------------------------------------------------------------
+# merge-cheese-factory-into-ultracook — parallel mode contract
+#
+# /cheese-factory folded into /ultracook as a second mode. These lock the
+# parallel-mode contract clauses so a future edit cannot silently drop the
+# mode gate, the worktree lifecycle, the milknado parity, the #197 capability
+# gate, the #194 recovery paths, or the output mode-invariance invariant.
+# ---------------------------------------------------------------------------
+
+
+class TestUltracookModeGate:
+    """The decomposer is the authoritative mode gate; the single canonical
+    PARALLEL_THRESHOLD (2) picks linear vs parallel."""
+
+    def test_mode_selection_section_present(self) -> None:
+        body = _skill("ultracook")
+        assert "Mode selection" in body, (
+            "ultracook must document a mode-selection gate"
+        )
+        assert "decomposer" in body.lower(), "the decomposer is the mode gate"
+
+    def test_mode_selector_and_threshold_referenced(self) -> None:
+        body = _skill("ultracook")
+        assert "PARALLEL_THRESHOLD" in body, (
+            "ultracook must name the canonical PARALLEL_THRESHOLD constant"
+        )
+        # The mode subcommand picks linear|parallel deterministically.
+        assert "ultracook.pyz mode" in body or "pyz mode --count" in body, (
+            "ultracook must invoke the deterministic mode selector"
+        )
+
+    def test_two_or_more_curds_is_parallel(self) -> None:
+        body = _skill("ultracook")
+        body_lower = body.lower()
+        assert "2 or more" in body_lower or "2+" in body, (
+            "ultracook must state 2+ curds routes to parallel mode"
+        )
+        assert "1" in body and "linear" in body_lower, (
+            "ultracook must state a 1-curd spec stays linear"
+        )
+
+
+class TestUltracookParallelTopology:
+    """Parallel mode is curd-light: per-curd cook/press/age/cure in a worktree,
+    then one post-merge press/age/cure over the merged diff (acceptance #2)."""
+
+    def test_parallel_mode_section_present(self) -> None:
+        body = _skill("ultracook")
+        assert "## Parallel mode" in body
+
+    def test_per_curd_pipeline_documented(self) -> None:
+        body = _skill("ultracook")
+        # Per-curd pipeline uses the parallel-curd phase table.
+        assert "parallel-curd" in body, (
+            "parallel mode must run each curd on the parallel-curd phase table"
+        )
+
+    def test_post_merge_single_pass_documented(self) -> None:
+        body = _skill("ultracook")
+        body_lower = body.lower()
+        assert "parallel-postmerge" in body, (
+            "parallel mode must run one post-merge pass on the parallel-postmerge table"
+        )
+        assert "post-merge" in body_lower or "merged diff" in body_lower
+
+
+class TestUltracookWorktreeLifecycle:
+    """The worktree helper harvests a curd branch with no fetch and tears the
+    worktree + branch down afterward — no leaks (acceptance #5)."""
+
+    def test_harvest_no_fetch(self) -> None:
+        body = _skill("ultracook")
+        body_lower = body.lower()
+        assert "worktree harvest" in body, "parallel mode must harvest curd branches"
+        assert "no `git fetch`" in body or "no git fetch" in body_lower or (
+            "shared" in body_lower and "object store" in body_lower
+        ), "harvest must state it needs no git fetch (shared object store)"
+
+    def test_teardown_leaves_no_leak(self) -> None:
+        body = _skill("ultracook")
+        body_lower = body.lower()
+        assert "worktree teardown" in body, "parallel mode must tear worktrees down"
+        assert "leak" in body_lower, (
+            "the teardown contract must state no worktree/branch leaks"
+        )
+        assert "worktree-agent-" in body or ".claude/worktrees/agent-" in body, (
+            "teardown must name the worktree/branch pattern that must not leak"
+        )
+
+
+class TestUltracookMilknadoSeam:
+    """milknado.probe() returns engine/tracker/none; parallel mode runs with
+    milknado absent (native fan-out), and the self-verify vs verify-until-green
+    parity is stated (acceptance #4)."""
+
+    def test_three_probe_roles_documented(self) -> None:
+        body = _skill("ultracook")
+        body_lower = body.lower()
+        assert "engine" in body_lower and "tracker" in body_lower, (
+            "the milknado seam must name the engine and tracker roles"
+        )
+        assert "ultracook.pyz milknado" in body, (
+            "ultracook must invoke the deterministic milknado probe"
+        )
+
+    def test_native_path_runs_without_milknado(self) -> None:
+        body = _skill("ultracook")
+        body_lower = body.lower()
+        assert "native fan-out" in body_lower, (
+            "parallel mode must document the native fan-out path when milknado is absent"
+        )
+
+    def test_parity_difference_stated(self) -> None:
+        body = _skill("ultracook")
+        body_lower = body.lower()
+        # The intentional parity difference must be explicit.
+        assert "self-verify" in body_lower, (
+            "native curds must be documented as self-verifying (gates in-worker)"
+        )
+        assert "verify-until-green" in body_lower, (
+            "milknado's verify-until-green must be named as the parity difference"
+        )
+
+
+class TestUltracookCapabilityGate:
+    """Sub-agent spawning is capability-gated (issue #197): a specialized
+    subagent_type with fresh context + full tools is permitted; only diminutive
+    workers are rejected (acceptance #6)."""
+
+    def test_capability_gate_documented(self) -> None:
+        body = _skill("ultracook")
+        body_lower = body.lower()
+        assert "#197" in body or "197" in body, (
+            "ultracook must cite issue #197 for the capability gate"
+        )
+        assert "capability" in body_lower, (
+            "the gate must be capability, not the subagent_type label"
+        )
+
+    def test_specialized_type_permitted_when_full_peer(self) -> None:
+        body = _skill("ultracook")
+        body_lower = body.lower()
+        # A specialized/typed subagent_type is acceptable when it is a full peer.
+        assert "specialized" in body_lower or "specialised" in body_lower or (
+            "typed" in body_lower
+        ), "a specialized subagent_type must be permitted when it is a full peer"
+        assert "diminutive" in body_lower or "downgrade" in body_lower, (
+            "only diminutive / downgraded workers may be rejected"
+        )
+
+
+class TestUltracookRecoveryPaths:
+    """Parallel mode surfaces a worker-exhaustion recovery path and an
+    aggregate-gate failure path (issue #194, acceptance #7)."""
+
+    def test_worker_exhaustion_recovery(self) -> None:
+        body = _skill("ultracook")
+        body_lower = body.lower()
+        assert "#194" in body or "194" in body, (
+            "ultracook must cite issue #194 for the recovery paths"
+        )
+        assert "exhaust" in body_lower and "retry" in body_lower, (
+            "parallel mode must document worker-exhaustion recovery (retry once)"
+        )
+
+    def test_aggregate_gate_failure_distinguishes_conflict_from_drift(self) -> None:
+        body = _skill("ultracook")
+        body_lower = body.lower()
+        assert "aggregate" in body_lower, (
+            "parallel mode must document the aggregate-gate failure path"
+        )
+        assert "cross-curd conflict" in body_lower or "cross-curd" in body_lower, (
+            "aggregate-gate handling must distinguish a real cross-curd conflict"
+        )
+        assert "drift" in body_lower, (
+            "aggregate-gate handling must distinguish harmless drift from a conflict"
+        )
+
+
+class TestUltracookOutputModeInvariance:
+    """Parallel mode's output uses the same schema as linear mode — a reader
+    cannot tell which mode produced the summary (mirrors /age's invariant)."""
+
+    def test_output_mode_invariance_stated(self) -> None:
+        body = _skill("ultracook")
+        body_lower = body.lower()
+        assert "mode-invariant" in body_lower or "mode invariance" in body_lower, (
+            "ultracook must state the output is mode-invariant across linear/parallel"
+        )


### PR DESCRIPTION
Adds the two-mode `/ultracook` SKILL prose that wires the `src/fanout/` engine from the parent PR: a curd-light parallel mode with automatic mode selection, alongside the existing linear pipeline. Implements curds 7–8 of the merge-cheese-factory-into-ultracook spec.

Pure SKILL prose + reference prompt templates — no engine code (that's #221).

### Stack (supersedes #220)
- #221 `feat(fanout): extract engine` · base `main`
  - **#222 `feat(ultracook): two-mode SKILL`** ← this PR · base #221
    - #223 `feat(ultracook): retire cheese-factory + docs/CI` · base #222
    - #225 `feat(ultracook): --resume + manifest advancement` · base #222
  - #224 `refactor(fanout): graphlib topo-sort` · base #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)
