### PR TITLE
build(tilth): install @paulnsorensen/tilth-nightly and align docs to 0.8.4 schema

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -86,7 +86,7 @@ jobs:
         run: bats tests/fanout/bash/test_pr_plan_to_branches.bats
 
       # Real (un-stubbed) smoke test: actually resolve every brew formula,
-      # exercise the cargo-or-npm tilth install path, and run the gh-skill
+      # exercise the npm tilth install path, and run the gh-skill
       # install on a fresh macos-latest runner. Catches "phantom formula"
       # / "tap doesn't exist" / "this skill doesn't publish" bugs that the
       # bats suite (which stubs everything) cannot. --skip-mcp avoids

--- a/README.md
+++ b/README.md
@@ -176,32 +176,24 @@ When a preferred tool is unavailable, workflow skills say so once, fall back, an
 
 ### skills.sh (recommended)
 
-Install with the [skills.sh](https://skills.sh) installer:
+Install every skill with the [skills.sh](https://skills.sh) installer. The
+skills form one pipeline (`/cheese → /mold → /cook → /press → /age → /cure`),
+so install them together rather than cherry-picking:
 
 ```sh
-npx skills@latest add paulnsorensen/easy-cheese
+npx skills@latest add paulnsorensen/easy-cheese --all
 ```
 
-Install all currently published skills in this repo's manifest without prompts:
+`--all` is shorthand for `--skill "*" --agent "*" -y`: every published skill,
+into every detected agent, no prompts. It uses project-level scope (recorded
+under `.agents/skills/`), so run it from the repo you want easy-cheese
+recorded in.
+
+For a user-wide install available across every repo, add `--global`:
 
 ```sh
-npx skills@latest add paulnsorensen/easy-cheese --skill "*" -y
+npx skills@latest add paulnsorensen/easy-cheese --all --global
 ```
-
-Without `--global`, the skills CLI uses project-level scope. Run those
-commands from the repo where you want easy-cheese recorded under
-`.agents/skills/`. The `-y` flag only skips confirmation prompts; it does not
-make a project install global.
-
-For a user-wide Codex install that is available across repos, pass the Codex
-agent and global scope explicitly:
-
-```sh
-npx skills@latest add paulnsorensen/easy-cheese --skill "*" --agent codex --global -y
-```
-
-The installer reads this repo's published skill manifest, lets you pick the
-skills you want, and installs them into the coding agents you select.
 
 After install, start with `/cheese` if you're not sure which wheel to cut into
 first, or jump straight to a specific skill like `/cook`, `/age`, or

--- a/README.md
+++ b/README.md
@@ -181,18 +181,18 @@ skills form one pipeline (`/cheese → /mold → /cook → /press → /age → /
 so install them together rather than cherry-picking:
 
 ```sh
-npx skills@latest add paulnsorensen/easy-cheese --all
+npx skills@latest add paulnsorensen/easy-cheese --all --global
 ```
 
 `--all` is shorthand for `--skill "*" --agent "*" -y`: every published skill,
-into every detected agent, no prompts. It uses project-level scope (recorded
-under `.agents/skills/`), so run it from the repo you want easy-cheese
-recorded in.
+into every detected agent, no prompts. `--global` installs them user-wide, so
+they are available across every repo.
 
-For a user-wide install available across every repo, add `--global`:
+To scope the install to just the current repo instead (recorded under
+`.agents/skills/`), drop `--global` and run it from that repo:
 
 ```sh
-npx skills@latest add paulnsorensen/easy-cheese --all --global
+npx skills@latest add paulnsorensen/easy-cheese --all
 ```
 
 After install, start with `/cheese` if you're not sure which wheel to cut into

--- a/README.md
+++ b/README.md
@@ -298,14 +298,13 @@ The `cheez-*` tool skills and several workflow skills benefit from MCP servers. 
 <details>
 <summary><strong>tilth</strong> (preferred for `cheez-*` skills) — AST-aware code search, smart reading, tag-anchored edits</summary>
 
-[tilth](https://github.com/jahala/tilth) provides AST-aware code search, smart file reading, and tag-anchored edits. It is the preferred backend for `/cheez-search`, `/cheez-read`, and `/cheez-write`; equivalent native AST/LSP/anchored-edit backends satisfy the same contract when Tilth is unavailable.
+[tilth](https://www.npmjs.com/package/@paulnsorensen/tilth-nightly) provides AST-aware code search, smart file reading, and tag-anchored edits. It is the preferred backend for `/cheez-search`, `/cheez-read`, and `/cheez-write`; equivalent native AST/LSP/anchored-edit backends satisfy the same contract when Tilth is unavailable.
 
 ```sh
-# Install tilth CLI — pick one (no Homebrew formula upstream)
-cargo install tilth        # via Cargo (Rust) — preferred, native binary
-npm install -g tilth       # via npm (Node 18+) — no Rust toolchain needed
-# or run via npx — no global install needed (Node.js v18+):
-#   npx -y tilth install claude-code --edit
+# Install tilth CLI via npm (Node.js v18+) — no Homebrew formula upstream
+npm install -g @paulnsorensen/tilth-nightly@latest
+# or run via npx — no global install needed:
+#   npx -y @paulnsorensen/tilth-nightly@latest install claude-code --edit
 
 # Register as an MCP server — include --edit only if you plan to use cheez-write
 tilth install claude-code --edit   # Claude Code
@@ -419,7 +418,7 @@ flow above; this script is the fast lane for the wider ecosystem.
 
 It does the following in one shot:
 
-1. Installs every CLI tool listed below — Homebrew for the eight brew-core formulas, plus `cargo install tilth` (or `npm install -g tilth` if Rust isn't available) for tilth, which has no Homebrew formula upstream.
+1. Installs every CLI tool listed below — Homebrew for the eight brew-core formulas, plus `npm install -g @paulnsorensen/tilth-nightly@latest` for tilth, which has no Homebrew formula upstream.
 2. Auto-detects installed Claude Code, Cursor, and Codex CLIs, then installs every easy-cheese skill into each detected harness at user scope as a convenience bootstrap.
 3. Registers the `tilth`, `context7`, and `hallouminate` MCP servers with those harnesses where supported. hallouminate is delivered as a plugin: on `claude-code` and `codex` the installer adds the `paulnsorensen/hallouminate` plugin marketplace and installs the plugin (which ships its own MCP server and bootstraps the binary); on other harnesses it warns and you register the MCP manually. Other servers (`tavily`, `milknado`) are also selectable with `--mcp`.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The workflow skills can delegate code search, reading, and editing to these back
 | Skill path | Command | Purpose |
 | --- | --- | --- |
 | `skills/cheez-search/SKILL.md` | `/cheez-search` | AST-aware code/text/regex/caller search via tilth MCP, harness-native AST search, or LSP. Replaces grep / rg / find. |
-| `skills/cheez-read/SKILL.md` | `/cheez-read` | Smart file/directory reading through a freshness-aware backend; tilth MCP is preferred because it emits hash anchors. Replaces cat / head / tail / ls. |
+| `skills/cheez-read/SKILL.md` | `/cheez-read` | Smart file/directory reading through a freshness-aware backend; tilth MCP is preferred because it emits stale-write-safe edit tags. Replaces cat / head / tail / ls. |
 | `skills/cheez-write/SKILL.md` | `/cheez-write` | Anchored, surgical edits through tilth MCP or an equivalent harness-native stale-snapshot edit tool. Never rewrites whole files blindly. |
 
 The `cheez-*` skills tell the model which source-code backend to use when the harness has one. Prefer tilth MCP by name; use LSP for type-grounded definitions/references/renames/code actions, `ast_grep`/`sg` for structural patterns and codemods, and anchored/stale-checking edits for ordinary block changes. Plain text shell tools are fallback evidence only, not equivalent source-code backends.
@@ -296,9 +296,9 @@ Each `SKILL.md` must have YAML frontmatter with at least `name` and `description
 The `cheez-*` tool skills and several workflow skills benefit from MCP servers. Install the ones you need.
 
 <details>
-<summary><strong>tilth</strong> (preferred for `cheez-*` skills) — AST-aware code search, smart reading, hash-anchored edits</summary>
+<summary><strong>tilth</strong> (preferred for `cheez-*` skills) — AST-aware code search, smart reading, tag-anchored edits</summary>
 
-[tilth](https://github.com/jahala/tilth) provides AST-aware code search, smart file reading, and hash-anchored edits. It is the preferred backend for `/cheez-search`, `/cheez-read`, and `/cheez-write`; equivalent native AST/LSP/anchored-edit backends satisfy the same contract when Tilth is unavailable.
+[tilth](https://github.com/jahala/tilth) provides AST-aware code search, smart file reading, and tag-anchored edits. It is the preferred backend for `/cheez-search`, `/cheez-read`, and `/cheez-write`; equivalent native AST/LSP/anchored-edit backends satisfy the same contract when Tilth is unavailable.
 
 ```sh
 # Install tilth CLI — pick one (no Homebrew formula upstream)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,8 +15,9 @@
 # file so sourcing (e.g. from the bats suite) does not mutate the caller's
 # shell options.
 
-# All known CLI tools. tilth is included but installed via cargo/npm (not
-# brew — upstream jahala/tilth does not ship a Homebrew formula).
+# All known CLI tools. tilth is included but installed via npm from the
+# @paulnsorensen/tilth-nightly package (not brew — tilth has no Homebrew
+# formula upstream).
 EC_KNOWN_TOOLS="gh ripgrep fd jq ast-grep git-delta just mergiraf tilth"
 
 # Repository the installer pulls skills from. Centralized so discovery and
@@ -85,7 +86,7 @@ Options:
 
 Environment:
   EC_BREW   EC_GH      Override the brew / gh binaries (used by tests).
-  EC_CARGO  EC_NPM     Override the cargo / npm binaries used to install tilth.
+  EC_NPM               Override the npm binary used to install tilth.
   EC_TILTH  EC_CLAUDE  Override the tilth / claude binaries (used by tests).
   EC_CURSOR EC_CODEX   Override cursor / codex binaries for detection.
   EC_NPX               Override npx (used to launch context7 / tavily MCP).
@@ -159,11 +160,10 @@ ec_brew_install_if_missing() {
     ec_brew install "$tool"
 }
 
-# tilth has no Homebrew formula. Install via cargo (preferred — native
-# binary) or fall back to 'npm install -g tilth' (jahala/tilth ships a
-# proper bin entry on npm). Errors out clearly if neither is available.
+# tilth has no Homebrew formula. Install via npm from the
+# @paulnsorensen/tilth-nightly package (ships a proper `tilth` bin entry).
+# Errors out clearly if npm is unavailable.
 ec_install_tilth() {
-    local cargo="${EC_CARGO:-cargo}"
     local npm="${EC_NPM:-npm}"
 
     if ec_cmd_exists tilth; then
@@ -171,28 +171,18 @@ ec_install_tilth() {
         return 0
     fi
 
-    if ec_cmd_exists "$cargo"; then
-        if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-            ec_log "tilth: would run '$cargo install tilth'"
-            return 0
-        fi
-        ec_log "tilth: installing via 'cargo install tilth'"
-        "$cargo" install tilth
-        return $?
-    fi
-
     if ec_cmd_exists "$npm"; then
         if [[ "${EC_DRY_RUN:-0}" == "1" ]]; then
-            ec_log "tilth: would run '$npm install -g tilth' (cargo not found)"
+            ec_log "tilth: would run '$npm install -g @paulnsorensen/tilth-nightly@latest'"
             return 0
         fi
-        ec_log "tilth: installing via 'npm install -g tilth' (cargo not found)"
-        "$npm" install -g tilth
+        ec_log "tilth: installing via '$npm install -g @paulnsorensen/tilth-nightly@latest'"
+        "$npm" install -g @paulnsorensen/tilth-nightly@latest
         return $?
     fi
 
-    ec_err "tilth: needs cargo (Rust) or npm (Node 18+); neither was found."
-    ec_err "Install Rust from https://rustup.rs or Node.js from https://nodejs.org and re-run."
+    ec_err "tilth: needs npm (Node 18+), which was not found."
+    ec_err "Install Node.js from https://nodejs.org and re-run."
     return 1
 }
 

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -324,7 +324,7 @@ Inline-degrade is forced when the marker is present (no opt-out); it takes prece
 - Do not invent evidence. Cite files, diffs, commands, or unavailable-source notes.
 - Agree when the diff is fine. Do not manufacture findings to fill a dimension; an empty dimension is a valid outcome.
 - Keep confidence qualitative (`certain | speculating | don't know`); never emit a numeric score. This covers both the report-level `## Confidence` line and the per-finding `confidence:` label.
-- Findings carry location + recommendation. Do not write JSON sidecars or hash-anchored fix payloads — `/cure` reads the markdown directly.
+- Findings carry location + recommendation. Do not write JSON sidecars or tag-anchored fix payloads — `/cure` reads the markdown directly.
 - Apply `references/voice.md` (output discipline, reasoning posture, confidence vocabulary).
 
 ## References

--- a/skills/cheez-read/SKILL.md
+++ b/skills/cheez-read/SKILL.md
@@ -97,7 +97,7 @@ For when another tool fits better than cheez-read, see [`references/routing.md`]
 
 ## Edit tags
 
-Reads emit a `[path#TAG]` header above `N:content` numbered lines. Reading before editing is mandatory to get the current tag — copy the 4-hex TAG verbatim into cheez-write's `tag`, which binds the edit to the content you read: a drifted write is 3-way-merged or rejected safely, never applied blind. Never invent a tag.
+Edit-mode (non-stripped) reads emit a `[path#TAG]` header above `N:content` numbered lines; stripped reads carry no tag header and cannot round-trip into a write. Reading before editing is mandatory to get the current tag — copy the 4-hex TAG verbatim into cheez-write's `tag`, which binds the edit to the content you read: a drifted write is 3-way-merged or rejected safely, never applied blind. Never invent a tag.
 
 ---
 

--- a/skills/cheez-read/SKILL.md
+++ b/skills/cheez-read/SKILL.md
@@ -45,7 +45,7 @@ The `#symbol_name` suffix resolves to the symbol's line range. Use this when you
 tilth_read(paths: ["src/auth.ts"], mode: "stripped")
 ```
 
-`mode:stripped` returns the whole file with plain comments and debug logs removed — useful for surveying structure without hash anchors before deciding what to read in full.
+`mode:stripped` returns the whole file with plain comments and debug logs removed — useful for surveying structure before deciding what to read in full. Stripped reads carry no edit tag and cannot round-trip into `tilth_write`.
 
 ### "Read lines 44-89 of `src/auth.ts` to get edit anchors"
 
@@ -54,13 +54,14 @@ tilth_read(paths: ["src/auth.ts#44-89"])
 ```
 
 ```text
-44:b2c|export function handleAuth(req, res, next) {
-45:c3d|  const token = req.headers.authorization?.split(' ')[1];
+[src/auth.ts#b2c4]
+44:export function handleAuth(req, res, next) {
+45:  const token = req.headers.authorization?.split(' ')[1];
 ...
-89:e1d|}
+89:}
 ```
 
-Hash anchors are emitted automatically — copy `44:b2c` and `89:e1d` and pass them to cheez-write.
+The `[path#TAG]` header binds the numbered lines to the file's current content — copy `b2c4` into cheez-write's `tag` and reference lines 44–89 in its ops.
 
 ### "List every TypeScript file under `src/handlers/`"
 
@@ -94,9 +95,9 @@ For when another tool fits better than cheez-read, see [`references/routing.md`]
 
 ---
 
-## Hash anchors
+## Edit tags
 
-Drilled reads (line range, `#symbol`, or heading) emit `<line>:<hash>|<content>` anchors; plain full-file reads use a `│` (U+2502) separator instead. Reading before editing is mandatory to get current hashes — copy the `<line>:<hash>` portion into cheez-write, where the hash uniquely identifies the line so a stale edit is rejected safely.
+Reads emit a `[path#TAG]` header above `N:content` numbered lines. Reading before editing is mandatory to get the current tag — copy the 4-hex TAG verbatim into cheez-write's `tag`, which binds the edit to the content you read: a drifted write is 3-way-merged or rejected safely, never applied blind. Never invent a tag.
 
 ---
 
@@ -140,4 +141,4 @@ in cheez-search:
 - **DO NOT re-read files** shown earlier — reference the prior read.
 - **DO NOT use to run code or tests** — use the project's build/test skills.
 - **DO NOT use to commit** — use git/gh skills.
-- **DO NOT ignore hash anchors** — they are required for edits.
+- **DO NOT ignore the `[path#TAG]` header** — the tag is required for edits.

--- a/skills/cheez-read/references/routing.md
+++ b/skills/cheez-read/references/routing.md
@@ -14,7 +14,7 @@ Inside `/cheez-read`, the contract is backend-aware rather than tilth-only: use 
 | Files outside the repo (system paths, sibling worktrees, `~/...`) | host `Read` from the calling workflow skill | tilth is repo-scoped (see above) |
 | Dependency source (`node_modules`, `.cargo/registry`, `site-packages`, vendor caches) | LSP `textDocument/definition` from the calling workflow skill if a server is reachable; otherwise don't read by hand | Reading dependency source by hand is almost always wrong; the LSP resolves the right module version |
 
-If the file is code in this repo, **always enter cheez-read first** so it can choose a freshness-aware backend. Prefer tilth when hash anchors are available; otherwise use the harness-native snapshot/read path when it preserves stale-write safety for the next edit.
+If the file is code in this repo, **always enter cheez-read first** so it can choose a freshness-aware backend. Prefer tilth when edit tags are available; otherwise use the harness-native snapshot/read path when it preserves stale-write safety for the next edit.
 
 ## When LSP beats broad read backends (if the harness has one)
 
@@ -27,7 +27,7 @@ LSP availability: easy-cheese does not install LSP — it's whatever language se
 | Open the file declaring the *type* of a value | `textDocument/typeDefinition` | Walks through type aliases and generics |
 | Browse symbols across the whole project, semantically ranked | `workspace/symbol` | LSP indexes the project's type graph; syntax/read backends parse the tree |
 
-If no LSP is installed for the language, or the file is in a broken / incomplete state where the server cannot resolve, use the selected freshness-aware read backend. Tilth remains preferred when present because it provides outline reading, hash-anchored prep for edits, polyglot directory listings, and `.gitignore`-aware token estimates in one backend.
+If no LSP is installed for the language, or the file is in a broken / incomplete state where the server cannot resolve, use the selected freshness-aware read backend. Tilth remains preferred when present because it provides outline reading, tag-anchored prep for edits, polyglot directory listings, and `.gitignore`-aware token estimates in one backend.
 
 ## When Serena beats broad read backends for symbol-table reads (if your harness has it)
 

--- a/skills/cheez-search/SKILL.md
+++ b/skills/cheez-search/SKILL.md
@@ -20,7 +20,7 @@ Pick the backend by question type:
 
 Do not present plain shell search as equivalent source-code evidence; use it only for non-code paths or data/log inspection.
 
-**Note:** pass `root` (your absolute checkout directory) whenever tilth `scope` is relative — the server's cwd is frozen at startup and cannot resolve relative paths without an explicit `root`.
+**Note:** every tilth tool takes `cwd` — your absolute checkout directory (the server's own cwd is frozen at startup). In Claude Code a hook injects `cwd` automatically; do not set it. On harnesses without the hook, pass `cwd` explicitly so relative paths and scopes resolve. There is no `root` parameter.
 
 ---
 
@@ -29,7 +29,7 @@ Do not present plain shell search as equivalent source-code evidence; use it onl
 ### "Where is `handleAuth` defined?"
 
 ```
-tilth_search(queries: [{query: "handleAuth"}], scope: "src/", root: "/checkout/root")
+tilth_search(queries: [{query: "handleAuth"}], scope: "src/")
 ```
 
 ```text
@@ -46,7 +46,7 @@ The `[definition]` tag answers the question; usages come along for free.
 ### "What calls `validateToken`?"
 
 ```
-tilth_search(queries: [{query: "validateToken", kind: "callers"}], scope: ".", root: "/checkout/root")
+tilth_search(queries: [{query: "validateToken", kind: "callers"}])
 ```
 
 ```text
@@ -64,7 +64,7 @@ tilth_search(queries: [{query: "validateToken", kind: "callers"}], scope: ".", r
 ### "Find any TODO that mentions retries"
 
 ```
-tilth_search(queries: [{query: "TODO.*retry", kind: "regex"}], scope: "src/", root: "/checkout/root")
+tilth_search(queries: [{query: "TODO.*retry", kind: "regex"}], scope: "src/")
 ```
 
 Use `kind: "regex"` for pattern matches across content; bound the scope to
@@ -109,7 +109,7 @@ For code navigation (where is X / what calls Y / blast radius): start with `kind
 
 | Goal | Example backend | Example |
 |------|-----------------|---------|
-| Find where a symbol is defined / used | `tilth_search` symbol kind, native AST symbol search, or LSP definition when type-grounded | `tilth_search(queries: [{query: "handleAuth", kind: "symbol"}], scope: "src/", root: "/checkout/root")` |
+| Find where a symbol is defined / used | `tilth_search` symbol kind, native AST symbol search, or LSP definition when type-grounded | `tilth_search(queries: [{query: "handleAuth", kind: "symbol"}], scope: "src/")` |
 | Find every call site of a function | `tilth_search` callers kind, native AST caller search, or LSP references when type-grounded | `tilth_search(queries: [{query: "validateToken", kind: "callers"}])` |
 | Find literal strings, TODOs, error messages | content search in the semantic backend | `tilth_search(queries: [{query: "error message", kind: "content"}])` |
 | Find lines matching a regex | bounded regex search in the semantic backend | `tilth_search(queries: [{query: "rate.?limit", kind: "regex"}])` |

--- a/skills/cheez-search/references/tilth-deps.md
+++ b/skills/cheez-search/references/tilth-deps.md
@@ -51,7 +51,7 @@ this one.
 - `tilth_deps` is path-scoped, not symbol-scoped. It tells you which files
   import the target file, not which functions inside those files use a
   specific export. For that, follow up with
-  `tilth_search(query: "<symbol>", kind: "callers")`.
+  `tilth_search(queries: [{query: "<symbol>", kind: "callers"}])`.
 - External dependencies are listed without versions. If you need version
   context, check the lockfile or `package.json` / `Cargo.toml` separately.
 - Generated, vendored, or `.gitignore`d files may not appear — tilth indexes

--- a/skills/cheez-search/references/tilth-search-reference.md
+++ b/skills/cheez-search/references/tilth-search-reference.md
@@ -3,13 +3,18 @@
 Detailed invocation shapes, output format, and per-kind parameter reference.
 For which kind to pick, see the **Choose your search kind** table in `SKILL.md`.
 
+All examples omit `cwd`: every tilth tool requires it (your absolute checkout
+directory), but the Claude Code hook injects it automatically — set it only on
+harnesses without the hook. There is no `root` parameter. Omit `scope` to
+search the whole checkout; pass it only to narrow to a subdirectory.
+
 ---
 
 ## tilth_search - Symbol and Content Search
 
 **Basic symbol search:**
 ```
-tilth_search(queries: [{query: "handleAuth"}], scope: "src/", root: "/checkout/root")
+tilth_search(queries: [{query: "handleAuth"}], scope: "src/")
 ```
 
 **Output:**
@@ -48,7 +53,7 @@ tilth_search(queries: [{query: "handleAuth"}], scope: "src/", root: "/checkout/r
 Trace across files in one call:
 
 ```
-tilth_search(queries: [{query: "ServeHTTP, HandlersChain, Next"}], scope: ".", root: "/checkout/root")
+tilth_search(queries: [{query: "ServeHTTP, HandlersChain, Next"}])
 ```
 
 Each symbol gets its own result block. The expand budget is shared - at least
@@ -62,7 +67,7 @@ Find all places that call a specific function using structural tree-sitter
 matching (not text search):
 
 ```
-tilth_search(queries: [{query: "isTrustedProxy", kind: "callers"}], scope: ".", root: "/checkout/root")
+tilth_search(queries: [{query: "isTrustedProxy", kind: "callers"}])
 ```
 
 **Why this beats grep:** only finds actual calls, not comments or string literals.
@@ -75,7 +80,7 @@ Shows the calling function context.
 Search for text that isn't a code symbol:
 
 ```
-tilth_search(queries: [{query: "error: retry limit exceeded", kind: "content"}], scope: ".", root: "/checkout/root")
+tilth_search(queries: [{query: "error: retry limit exceeded", kind: "content"}])
 ```
 
 Use content search for code-comment annotations, error messages, and specific
@@ -88,7 +93,7 @@ literal strings — any text that isn't a code symbol.
 For patterns that aren't a single literal:
 
 ```
-tilth_search(queries: [{query: "rate.?limit", kind: "regex"}], scope: ".", root: "/checkout/root")
+tilth_search(queries: [{query: "rate.?limit", kind: "regex"}])
 ```
 
 - Full regex syntax -- alternation, character classes, lookarounds depending on the engine.
@@ -101,13 +106,13 @@ tilth_search(queries: [{query: "rate.?limit", kind: "regex"}], scope: ".", root:
 
 ```
 # Only Rust files
-tilth_search(queries: [{query: "handleAuth"}], scope: ".", glob: "*.rs", root: "/checkout/root")
+tilth_search(queries: [{query: "handleAuth"}], glob: "*.rs")
 
 # Exclude test files
-tilth_search(queries: [{query: "handleAuth"}], scope: ".", glob: "!*.test.ts", root: "/checkout/root")
+tilth_search(queries: [{query: "handleAuth"}], glob: "!*.test.ts")
 
 # Multiple extensions
-tilth_search(queries: [{query: "handleAuth"}], scope: ".", glob: "*.{go,rs}", root: "/checkout/root")
+tilth_search(queries: [{query: "handleAuth"}], glob: "*.{go,rs}")
 ```
 
 ---
@@ -117,7 +122,7 @@ tilth_search(queries: [{query: "handleAuth"}], scope: ".", glob: "*.{go,rs}", ro
 When editing a file, pass it as context to boost related results:
 
 ```
-tilth_search(queries: [{query: "validateToken"}], scope: ".", context: "src/auth.ts", root: "/checkout/root")
+tilth_search(queries: [{query: "validateToken"}], context: "src/auth.ts")
 ```
 
 ---
@@ -126,13 +131,13 @@ tilth_search(queries: [{query: "validateToken"}], scope: ".", context: "src/auth
 
 ```
 # Default: 2 expansions
-tilth_search(queries: [{query: "handleAuth"}], scope: ".", root: "/checkout/root")
+tilth_search(queries: [{query: "handleAuth"}])
 
 # More detail
-tilth_search(queries: [{query: "handleAuth"}], scope: ".", expand: 5, root: "/checkout/root")
+tilth_search(queries: [{query: "handleAuth"}], expand: 5)
 
 # Compact (outlines only)
-tilth_search(queries: [{query: "handleAuth"}], scope: ".", expand: 0, root: "/checkout/root")
+tilth_search(queries: [{query: "handleAuth"}], expand: 0)
 ```
 
 ---
@@ -162,7 +167,7 @@ tilth tracks what you've already seen:
 
 ```
 # "Find all implementations of an interface"
-tilth_search(queries: [{query: "UserRepository", kind: "symbol"}], scope: ".", root: "/checkout/root")
+tilth_search(queries: [{query: "UserRepository", kind: "symbol"}])
 # Implementations show as [impl] tags
 
 # "What depends on this module?"

--- a/skills/cheez-write/SKILL.md
+++ b/skills/cheez-write/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: cheez-write
-description: Edit code through the safest stale-checking backend — prefer code-intelligence backends (tilth MCP hash-anchored edits, LSP workspace edits, `sg --rewrite` for structural codemods); fall back to native anchored edits only when no code-intel backend matches. Use when the user asks to edit, replace, modify, update, change, delete, or insert code — phrases like "replace this function", "delete lines 44-89", "update validateToken", "add this import", "fix this bug" (when fixing requires editing), or apply a cross-cutting codemod like "rewrite every X to Y". Do NOT use for reading files (use cheez-read), searching code (use cheez-search), or running tests/builds.
+description: Edit code through the safest stale-checking backend — prefer code-intelligence backends (tilth MCP tag-anchored edits, LSP workspace edits, `sg --rewrite` for structural codemods); fall back to native anchored edits only when no code-intel backend matches. Use when the user asks to edit, replace, modify, update, change, delete, or insert code — phrases like "replace this function", "delete lines 44-89", "update validateToken", "add this import", "fix this bug" (when fixing requires editing), or apply a cross-cutting codemod like "rewrite every X to Y". Do NOT use for reading files (use cheez-read), searching code (use cheez-search), or running tests/builds.
 license: MIT
 compatibility: Prefers code-intelligence backends — tilth MCP edit mode, LSP workspace edits, AST rewrites. Harness-native anchored edits are acceptable fallbacks when they match the requested edit shape and reject or bound stale writes.
 ---
 
 # cheez-write
 
-> **Backend contract**: use a stale-safe edit backend. The backend must anchor the current file state (tilth hash, snapshot tag, or LSP workspace edit) or be a deliberate AST codemod over a clean tree.
+> **Backend contract**: use a stale-safe edit backend. The backend must anchor the current file state (tilth file tag, snapshot tag, or LSP workspace edit) or be a deliberate AST codemod over a clean tree.
 
 ## Backend detection
 
@@ -15,12 +15,12 @@ Pick the backend by edit shape, preferring code-intelligence backends (LSP, AST 
 
 1. **LSP wins for semantic workspace edits:** rename/code actions when the server can identify the symbol or fix.
 2. **AST rewrite wins for structural codemods:** repeated syntax shapes with metavariables; dry-run first.
-3. **tilth MCP wins for anchored block/range edits:** `tilth_read` captures hashes, then `tilth_write` applies known blocks/ranges via `files: [...]`.
+3. **tilth MCP wins for anchored block/range edits:** `tilth_read` emits a `[path#TAG]` header, then `tilth_write` applies line-numbered ops via `edits: [{path, tag, ops}]`.
 4. **Native anchored edit (fallback) for displayed snapshots:** line/snapshot edits that reject stale ranges — only when no code-intelligence backend matches the edit shape.
 
 Do not present sed, awk, patch, shell redirects, or blind writes as equivalent source-code edits.
 
-Hash mismatches and anchor-not-found are **content** issues — see [Hash Mismatch Handling](#hash-mismatch-handling).
+Stale tags and rejected sections are **content** issues — see [Stale Tag Handling](#stale-tag-handling).
 
 ---
 
@@ -28,42 +28,43 @@ Hash mismatches and anchor-not-found are **content** issues — see [Hash Mismat
 
 ### "Replace the body of `handleAuth` in `src/auth.ts`"
 
-Step 1 — read the line range to get anchors:
+Step 1 — read the line range to capture the file tag:
 
 ```
 tilth_read(paths: ["src/auth.ts#44-89"])
-# returns 44:b2c|... and 89:e1d|...
+# returns a [src/auth.ts#b2c4] header, then numbered lines 44:... to 89:...
 ```
 
-Step 2 — apply with the captured anchors:
+Step 2 — apply ops against those line numbers, quoting the tag verbatim:
 
 ```json
-tilth_write(files: [{
+tilth_write(edits: [{
   "path": "src/auth.ts",
-  "edits": [{
-    "start": "44:b2c",
-    "end":   "89:e1d",
+  "tag": "b2c4",
+  "ops": [{
+    "op": "replace",
+    "start": 44,
+    "end": 89,
     "content": "export function handleAuth(req, res, next) {\n  const token = extractToken(req);\n  if (!validateToken(token)) return res.status(401).end();\n  next();\n}"
   }]
 }])
 ```
 
-Response confirms `Edit applied to src/auth.ts` and may list callers to
-review.
+The response reports per `## src/auth.ts` and may list callers to review.
 
-### "Hash mismatch — file changed under me"
+### "Stale tag — file changed under me"
 
-See [Hash Mismatch Handling](#hash-mismatch-handling) for recovery steps.
+See [Stale Tag Handling](#stale-tag-handling) for recovery steps.
 
 ---
 
 ## Core Principle: Anchors, Not Rewrites
 
-The edit backend must identify the current file state — tilth hash anchors, harness snapshot tags, or LSP workspace edits — and reject the write if the file changed.
+The edit backend must identify the current file state — tilth file tags, harness snapshot tags, or LSP workspace edits — and bound or reject the write if the file changed.
 
 **The protocol:**
-1. Read the file section with cheez-read → get current anchors or snapshot ids
-2. Note start/end anchors for the block you'll change
+1. Read the file section with cheez-read → get the current `[path#TAG]` header or snapshot id
+2. Note the line numbers of the block you'll change
 3. Apply the edit through the anchored backend
 
 ---
@@ -80,7 +81,7 @@ For everything else, prefer the right tool:
 | Semantic rename or server-known refactor | LSP rename/code action | LSP follows scope, overloads, re-exports, and imports |
 | Lockfile changes (`Cargo.lock`, `package-lock.json`, `uv.lock`, etc.) | the package manager (`cargo update`, `npm i`, `uv lock`) | Hand-editing lockfiles loses checksum integrity |
 | Generated / build artifacts (compiled JS, transpiled output, `*.pb.go`) | regenerate from source | Editing the artifact rots on the next build |
-| Brand-new files, no prior content | anchored create/write backend | Stay stale-safe even when creating files |
+| Brand-new files, no prior content | anchored create/write backend (tilth: a `tilth_write` section with `tag` omitted) | Stay stale-safe even when creating files |
 | Files outside the repo or inside dependency caches (`node_modules`, `.cargo/registry`) | don't edit them | Modifying dependencies is almost always a mistake — fix the source or upstream |
 | Binary files, images, PDFs | the producing tool | code edit backends are text-only |
 
@@ -96,7 +97,7 @@ Pre-entry routing — when a workflow skill should prefer LSP rename or Serena s
 
 Use whatever anchor format the selected backend emits:
 
-- tilth: `<line>:<hash>|<content>`; pass `<line>:<hash>` into `tilth_write`.
+- tilth: a `[path#TAG]` header above `N:content` numbered lines; copy the 4-hex TAG into `tilth_write`'s `tag` and reference those line numbers in `ops`. Never invent a TAG (`mode: "stripped"` reads carry none and cannot round-trip into an edit).
 - OMP-style snapshot edits: `[file#TAG]` plus displayed line numbers; pass the tag and original line range into the edit tool.
 - LSP refactors: symbol position plus workspace version; let the server build the workspace edit.
 
@@ -108,57 +109,57 @@ Do not translate between anchor systems. Read with the same backend family that 
 
 ### tilth_write — Precise File Editing
 
-The minimal shape — single anchor, replacement content:
+The minimal shape — one file section, one op:
 
 ```json
-tilth_write(files: [{
+tilth_write(edits: [{
   "path": "src/auth.ts",
-  "edits": [
-    { "start": "42:a3f", "content": "  let x = recompute();" }
+  "tag": "a3f9",
+  "ops": [
+    { "op": "replace", "start": 42, "end": 42, "content": "  let x = recompute();" }
   ]
 }])
 ```
 
-For range replacement, deletion, multi-edit, insert-after, cross-file
-batches, and the `diff: true` response option, see
+`edits` is a JSON array of `{path, tag?, ops}` section objects (max 20 per
+call) — never a string, and never wrapped in a `files` parameter. Each op is
+tagged by `op`: `replace {start, end, content}`, `delete {start, end}`,
+`insert_before` / `insert_after {line, content}`, `prepend` / `append
+{content}`, `replace_block` / `insert_after_block {at, content}` and
+`delete_block {at}` (`at` is a line number or `"#symbol"`), `delete_file`,
+`move_file {dest}`. Omit `tag` only to seed a brand-new file.
+
+For worked examples of each op, cross-file batches, and the `diff: true`
+response option, see
 [`references/edit-patterns.md`](references/edit-patterns.md).
 
 ---
 
-## Hash Mismatch Handling
+## Stale Tag Handling
 
-If the file changed since you read it:
-
-```
-Error: Hash mismatch at line 44
-Expected: b2c
-Found: f9a
-
-Current content:
-44:f9a|export async function handleAuth(req, res, next) {
-...
-```
+The TAG binds your ops to the content you read. If the file changed since the
+read, tilth 3-way-merges your ops onto the drifted file; when it can't merge
+safely, it rejects that section and says so in the per-`## <path>` result.
 
 **Recovery:**
-1. Read the section again → get new anchors.
+1. Read the section again → get the current `[path#TAG]` and content.
 2. Review the current content (someone else may have made changes).
-3. Edit with new anchors.
+3. Re-apply the ops against the fresh line numbers with the new tag.
 
-### Repeated mismatches → bail out, don't loop
+### Repeated rejections → bail out, don't loop
 
-If you hit **two consecutive mismatches** on the same anchor, you're racing a
-concurrent writer. `tilth_write` has no fuzzy / search-replace mode — there
-is no "ignore the hash, just match this string" option. A third retry will
-likely lose the same race.
+If you hit **two consecutive rejections** on the same file, you're racing a
+concurrent writer. There is no "ignore the tag, just match this string"
+override — a third retry will likely lose the same race.
 
 The correct move is to bail and report:
 
 1. Read the latest section one final time and capture the current content.
 2. Prepare the new content as a unified diff or full block, but **do not
    apply** it.
-3. Report `"hash-anchor race on <path>:<line>; current content and proposed
-   replacement attached. Retry once the file is quiescent or apply manually."`
-   along with the captured anchors and proposed content.
+3. Report `"tag race on <path>; current content and proposed replacement
+   attached. Retry once the file is quiescent or apply manually."` along
+   with the captured tag and proposed content.
 4. Stop. Let the orchestrator (or a human) decide whether to apply the change
    or escalate.
 
@@ -177,7 +178,8 @@ When changing a signature, use LSP references or the edit backend's caller notic
 | Replace one line | [edit-patterns.md#single-line-replacement](references/edit-patterns.md#single-line-replacement) |
 | Replace a range | [edit-patterns.md#multi-line-range-replacement](references/edit-patterns.md#multi-line-range-replacement) |
 | Delete a block | [edit-patterns.md#delete-a-block](references/edit-patterns.md#delete-a-block) |
-| Insert after a line | [edit-patterns.md#insert-after-a-line](references/edit-patterns.md#insert-after-a-line) |
+| Insert before / after a line | [edit-patterns.md#insert-before-or-after-a-line](references/edit-patterns.md#insert-before-or-after-a-line) |
+| Replace / delete a whole symbol | [edit-patterns.md#symbol-anchored-block-ops](references/edit-patterns.md#symbol-anchored-block-ops) |
 | Multi-edit in one file | [edit-patterns.md#multiple-edits-in-one-file](references/edit-patterns.md#multiple-edits-in-one-file) |
 | Cross-file change | [edit-patterns.md#edits-across-multiple-files](references/edit-patterns.md#edits-across-multiple-files) |
 
@@ -206,8 +208,8 @@ Anchored edits own known blocks, one read-for-anchors per location. For cross-cu
 
 ## DO NOT
 
-- **DO NOT guess anchors** — always read first to get current anchors or snapshot ids.
-- **DO NOT ignore stale-anchor failures** — re-read and retry (see Hash Mismatch Handling).
+- **DO NOT invent tags** — always read first and copy the `[path#TAG]` header verbatim.
+- **DO NOT ignore rejected sections** — re-read and retry (see Stale Tag Handling).
 - **DO NOT use sed / awk / perl -i** to edit code — they bypass anchors and structural safety, and have no mismatch detection. `sg --rewrite` is the only sanctioned shell escape — see `## Structural codemods — sg --rewrite escape`.
 - **DO NOT use `patch`** to apply diffs to code — anchored range edits are the safe equivalent.
 - **DO NOT use `tee` or shell redirects (`>`, `>>`)** to overwrite/append code files — both bypass anchors. Use an anchored edit backend.

--- a/skills/cheez-write/references/edit-patterns.md
+++ b/skills/cheez-write/references/edit-patterns.md
@@ -1,100 +1,135 @@
 # `tilth_write` JSON cookbook
 
-Each block below is one file entry — wrap one or more in `tilth_write(files: [ … ])`. Every edit needs a `start` anchor; `end` is required only for range replacements, and `content` is the new text (use `""` to delete).
+Each block below is one section object — wrap one or more in
+`tilth_write(edits: [ … ])` (max 20 sections per call). A section is
+`{path, tag, ops}`: `path` names the file, `tag` is the 4-hex tag copied
+verbatim from the `[path#TAG]` header of a `tilth_read`, and `ops` is an
+array of op objects, each tagged by `op`. Line numbers (`start`, `end`,
+`line`, numeric `at`) are the 1-based `N:` prefixes from that same read.
+Omit `tag` only to seed a brand-new file.
 
 ## Single-line replacement
 
 ```json
 {
   "path": "src/auth.ts",
-  "edits": [
-    { "start": "42:a3f", "content": "  let x = recompute();" }
+  "tag": "a3f9",
+  "ops": [
+    { "op": "replace", "start": 42, "end": 42, "content": "  let x = recompute();" }
   ]
 }
 ```
 
-Replaces line 42 only. The hash `a3f` must match the `<line>:<hash>` prefix
-`tilth_read` returned for that line.
+Replaces line 42 only. The tag binds the line numbers to the content you
+read; if the file drifted, tilth 3-way-merges or rejects the section.
 
 ## Multi-line range replacement
 
 ```json
 {
   "path": "src/auth.ts",
-  "edits": [
+  "tag": "b2c4",
+  "ops": [
     {
-      "start": "44:b2c",
-      "end": "89:e1d",
+      "op": "replace",
+      "start": 44,
+      "end": 89,
       "content": "export function handleAuth(req, res, next) {\n  const token = extractToken(req);\n  if (!token) return res.status(401).end();\n  next();\n}"
     }
   ]
 }
 ```
 
-Replaces lines 44–89 inclusive. Both anchors must match.
+Replaces lines 44–89 inclusive.
 
 ## Delete a block
 
 ```json
 {
   "path": "src/auth.ts",
-  "edits": [
-    { "start": "44:b2c", "end": "89:e1d", "content": "" }
+  "tag": "b2c4",
+  "ops": [
+    { "op": "delete", "start": 44, "end": 89 }
   ]
 }
 ```
 
-Empty `content` deletes the range.
+`delete` takes no `content`. To remove a whole named symbol instead, use
+`{ "op": "delete_block", "at": "#handleAuth" }`.
+
+## Insert before or after a line
+
+```json
+{
+  "path": "src/auth.ts",
+  "tag": "a1b7",
+  "ops": [
+    { "op": "insert_after", "line": 13, "content": "import { newHelper } from './helpers';" }
+  ]
+}
+```
+
+`insert_before` / `insert_after` are native ops — do not rewrite the anchor
+line to fake an insert. `prepend` / `append` (`{content}` only) cover the
+file head and tail.
+
+## Symbol-anchored block ops
+
+```json
+{
+  "path": "src/auth.ts",
+  "tag": "b2c4",
+  "ops": [
+    { "op": "replace_block", "at": "#handleAuth", "content": "export function handleAuth(req, res, next) {\n  // …\n}" }
+  ]
+}
+```
+
+`replace_block`, `insert_after_block` (`{at, content}`), and `delete_block`
+(`{at}`) take `at` as a line number or a `"#symbol"` string — use them when
+the edit boundary is a whole function or class.
 
 ## Multiple edits in one file
 
 ```json
 {
   "path": "src/auth.ts",
-  "edits": [
-    { "start": "12:a1b", "content": "import { newHelper } from './helpers';" },
-    { "start": "44:b2c", "end": "89:e1d", "content": "// replaced function\n..." }
+  "tag": "b2c4",
+  "ops": [
+    { "op": "replace", "start": 12, "end": 12, "content": "import { newHelper } from './helpers';" },
+    { "op": "replace", "start": 44, "end": 89, "content": "// replaced function\n..." }
   ]
 }
 ```
 
-Keep related edits together when the backend supports it. If any anchor fails,
-re-read the file and recover before moving on.
+All ops in a section reference the line numbers from the same read — do not
+adjust later ops for earlier insertions or deletions. If the section is
+rejected, re-read the file and recover before moving on.
+
+## Create, move, delete files
+
+```json
+{ "path": "src/new-module.ts", "ops": [ { "op": "append", "content": "export const x = 1;\n" } ] }
+```
+
+Omitting `tag` seeds a brand-new file. `{ "op": "move_file", "dest": "src/renamed.ts" }`
+moves the section's file; `{ "op": "delete_file" }` removes it.
 
 ## Show diff in response
 
 ```text
-tilth_write(files: [{ "path": "src/auth.ts", "edits": [{ "start": "44:b2c", "end": "89:e1d", "content": "..." }] }], diff: true)
+tilth_write(edits: [{ "path": "src/auth.ts", "tag": "b2c4", "ops": [{ "op": "replace", "start": 44, "end": 89, "content": "..." }] }], diff: true)
 ```
 
-`diff` is a call option; if the backend exposes it only at batch scope, pass it there.
-
-## Insert "after" a line
-
-`tilth_write` replaces the anchored line(s); there is no native insert. To
-insert after line 13, anchor on line 13 and prepend the original line content
-to your new content:
-
-```json
-{
-  "path": "src/auth.ts",
-  "edits": [
-    {
-      "start": "13:abc",
-      "content": "import { existingThing } from './existing';\nimport { newHelper } from './helpers';"
-    }
-  ]
-}
-```
-
-The first line of `content` reproduces line 13 (`import { existingThing }
-…`); the second is the actual insertion. Read line 13 carefully before doing
-this — the original content goes back verbatim.
+`diff: true` is a call-level option: the response includes a compact
+before/after diff per section.
 
 ## Edits across multiple files
 
-Use the backend's batch form when it has one; otherwise edit one file at a time
-and verify each response before moving to the next file.
+Pass one `{path, tag, ops}` section per file in a single `edits` array (max
+20). Sections are independent and best-effort — a rejected section does not
+roll back the others — so check the per-`## <path>` results and re-read any
+rejected file before retrying.
 
 ## Caller-update notices
 

--- a/skills/cheez-write/references/edit-patterns.md
+++ b/skills/cheez-write/references/edit-patterns.md
@@ -112,7 +112,7 @@ rejected, re-read the file and recover before moving on.
 { "path": "src/new-module.ts", "ops": [ { "op": "append", "content": "export const x = 1;\n" } ] }
 ```
 
-Omitting `tag` seeds a brand-new file. `{ "op": "move_file", "dest": "src/renamed.ts" }`
+Omitting `tag` seeds a brand-new file; `move_file` / `delete_file` on an *existing* file keep the file's `tag` (omit it only to seed a new file). `{ "op": "move_file", "dest": "src/renamed.ts" }`
 moves the section's file; `{ "op": "delete_file" }` removes it.
 
 ## Show diff in response

--- a/skills/cheez-write/references/routing.md
+++ b/skills/cheez-write/references/routing.md
@@ -1,6 +1,6 @@
 # Pre-entry routing: semantic and symbol-bounded edits
 
-The **calling workflow skill** selects the stale-safe backend before entering `/cheez-write`, matching it to the edit shape: tilth hash anchors, LSP workspace edits, Serena symbol edits, harness-native snapshot edits, or a dry-run-first AST codemod.
+The **calling workflow skill** selects the stale-safe backend before entering `/cheez-write`, matching it to the edit shape: tilth tag-anchored edits, LSP workspace edits, Serena symbol edits, harness-native snapshot edits, or a dry-run-first AST codemod.
 
 ## When LSP rename beats line/range edits
 
@@ -27,4 +27,4 @@ Serena ([oraios/serena](https://github.com/oraios/serena)) is an LSP-driven MCP 
 
 `/cheez-write` is not tilth-only. Its invariant is stale safety: the chosen backend must anchor the current file state, be typechecker-owned, or be a bounded AST codemod run after a dry run.
 
-**Caveat — no race-safe hash anchors.** Serena's edits rely on LSP and file mtime, not the content-hash check that makes tilth hash anchors race-safe. The workflow skill should route to Serena only when the file is quiescent (no parallel writers, no in-flight `/cook` or `/cure` on the same path). Use a hash/snapshot anchored edit whenever concurrency safety dominates, the symbol isn't LSP-resolvable (broken or generated code), or the edit is sub-symbol (one line inside a function).
+**Caveat — no race-safe edit tags.** Serena's edits rely on LSP and file mtime, not the content-bound file tag that lets tilth detect drift and 3-way-merge or reject a racing write. The workflow skill should route to Serena only when the file is quiescent (no parallel writers, no in-flight `/cook` or `/cure` on the same path). Use a tag/snapshot anchored edit whenever concurrency safety dominates, the symbol isn't LSP-resolvable (broken or generated code), or the edit is sub-symbol (one line inside a function).

--- a/skills/cure/references/selection.md
+++ b/skills/cure/references/selection.md
@@ -75,7 +75,7 @@ When an age report lacks the `fix-cost-now` sub-field on its findings (older rep
 For each selected finding:
 
 1. Re-read the cited file/lines via `cheez-read` to confirm the finding is still accurate (the diff may have moved).
-2. Apply the fix via `cheez-write` using hash anchors.
+2. Apply the fix via `cheez-write` using the read's edit tag.
 3. Run the narrowest test that proves the fix.
 4. Move to the next selected item.
 

--- a/skills/melt/SKILL.md
+++ b/skills/melt/SKILL.md
@@ -14,7 +14,7 @@ For per-file inspection or manual edits, delegate to the `cheez-*` skills:
 
 - **`/cheez-search`** — locate conflict markers or related symbols across the tree.
 - **`/cheez-read`** — inspect conflicted files, view conflict hunks, list directory contents.
-- **`/cheez-write`** — apply hash-anchored resolutions when bash flows are not enough.
+- **`/cheez-write`** — apply tag-anchored resolutions when bash flows are not enough.
 
 ## Cascade
 

--- a/skills/mold/references/shape-check.md
+++ b/skills/mold/references/shape-check.md
@@ -17,8 +17,8 @@ Run all three. Cheap when the answers are small; the cost of skipping is silent 
 
 | Question | Tool | Call |
 | --- | --- | --- |
-| Current signature? Sibling signatures? Downstream callees (`── calls ──` footer)? | `cheez-search` | `tilth_search(query: "<symbol>", kind: "symbol", expand: 2, scope: "<module>")` |
-| Who calls this? (upstream) | `cheez-search` | `tilth_search(query: "<symbol>", kind: "callers", scope: ".")` |
+| Current signature? Sibling signatures? Downstream callees (`── calls ──` footer)? | `cheez-search` | `tilth_search(queries: [{query: "<symbol>", kind: "symbol"}], expand: 2, scope: "<module>")` |
+| Who calls this? (upstream) | `cheez-search` | `tilth_search(queries: [{query: "<symbol>", kind: "callers"}])` |
 | What's the import / blast radius? | `cheez-search` | `tilth_deps(path: "<file>")` |
 
 The first call does double duty — its `── calls ──` footer is the cheap callee read; do not issue a separate query for it.

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -273,10 +273,10 @@ STUB
 }
 
 @test "ec_install_tools routes tilth through ec_install_tilth, not brew" {
-    make_stub cargo
-    EC_CARGO="$STUB_BIN/cargo" EC_DRY_RUN=1 run ec_install_tools "tilth"
+    make_stub npm
+    EC_NPM="$STUB_BIN/npm" EC_DRY_RUN=1 run ec_install_tools "tilth"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"cargo install tilth"* ]]
+    [[ "$output" == *"npm install -g @paulnsorensen/tilth-nightly@latest"* ]]
     [[ "$output" != *"brew install tilth"* ]]
 }
 
@@ -289,46 +289,27 @@ STUB
     [[ "$output" == *"already installed"* ]]
 }
 
-@test "ec_install_tilth dry-run prefers cargo when both cargo and npm exist" {
-    make_stub cargo
-    make_stub npm
-    EC_CARGO="$STUB_BIN/cargo" EC_NPM="$STUB_BIN/npm" EC_DRY_RUN=1 \
-        run ec_install_tilth
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"would run"* ]]
-    [[ "$output" == *"cargo install tilth"* ]]
-    [[ "$output" != *"npm install -g tilth"* ]]
-}
-
-@test "ec_install_tilth invokes cargo when not dry-run" {
-    make_stub cargo
-    export EC_CARGO="$STUB_BIN/cargo"
-    run ec_install_tilth
-    [ "$status" -eq 0 ]
-    grep -q "^cargo install tilth$" "$STUB_LOG"
-}
-
-@test "ec_install_tilth falls back to npm install -g when cargo missing" {
+@test "ec_install_tilth dry-run installs via the npm nightly package" {
     make_stub npm
     EC_NPM="$STUB_BIN/npm" EC_DRY_RUN=1 run ec_install_tilth
     [ "$status" -eq 0 ]
-    [[ "$output" == *"npm install -g tilth"* ]]
-    [[ "$output" == *"cargo not found"* ]]
+    [[ "$output" == *"would run"* ]]
+    [[ "$output" == *"npm install -g @paulnsorensen/tilth-nightly@latest"* ]]
 }
 
-@test "ec_install_tilth invokes npm install -g when cargo missing" {
+@test "ec_install_tilth invokes npm install -g when not dry-run" {
     make_stub npm
     export EC_NPM="$STUB_BIN/npm"
     run ec_install_tilth
     [ "$status" -eq 0 ]
-    grep -q "^npm install -g tilth$" "$STUB_LOG"
+    grep -q "^npm install -g @paulnsorensen/tilth-nightly@latest$" "$STUB_LOG"
 }
 
-@test "ec_install_tilth fails clearly when neither cargo nor npm present" {
+@test "ec_install_tilth fails clearly when npm is not present" {
     run ec_install_tilth
     [ "$status" -eq 1 ]
-    [[ "$output" == *"needs cargo (Rust) or npm"* ]]
-    [[ "$output" == *"rustup.rs"* ]]
+    [[ "$output" == *"needs npm (Node 18+)"* ]]
+    [[ "$output" == *"nodejs.org"* ]]
 }
 
 # -- default + opt-in MCP wiring ----------------------------------------------
@@ -894,7 +875,6 @@ echo Darwin
 STUB
     chmod +x "$STUB_BIN/uname"
     make_stub brew
-    make_stub cargo
     make_stub gh
     make_stub claude
     make_stub tilth
@@ -902,7 +882,6 @@ STUB
     ln -sf /bin/bash "$STUB_BIN/bash"
     PATH="$STUB_BIN" \
     EC_BREW=brew \
-    EC_CARGO=cargo \
     EC_GH=gh \
     EC_CLAUDE=claude \
     EC_TILTH=tilth \


### PR DESCRIPTION
Fixes the U2 finding from the 2026-07-07 repo audit: cheez-write error rate regressed 2.8% → 17.1% week-over-week, correlated with tilth MCP "missing required parameter" errors.

## Root cause

The tilth binary was upgraded to 0.8.4 (~2026-07-06), which replaced the write interface, and the skill guidance still documented the old one. Agents following the docs sent guaranteed-failing shapes.

| Interface | Documented (stale) | Live 0.8.4 schema |
|---|---|---|
| `tilth_write` param | `files: [{path, edits: [{start: "44:b2c", end: "89:e1d", content}]}]` | `edits: [{path, tag, ops: [{op, start, end, content, …}]}]` |
| Edit anchor | per-line `<line>:<hash>\|content` hashes | whole-file 4-hex `[path#TAG]` header + plain `N:content` line numbers |
| Insert | "no native insert — prepend the original line" | native `insert_before` / `insert_after` / `prepend` / `append` / `*_block` ops |
| Checkout dir | `root:` parameter | `cwd` (hook-injected in Claude Code); no `root` parameter exists |
| Search call | `tilth_search(query: …)` (mold/shape-check) | `queries: [{query, kind?, glob?}]` |

## Forensics (~/.claude/analytics/sessions.duckdb, last 2 weeks)

- `tilth_write` weekly error rate: 2.6% (wk 06-22) → 5.5% (06-29) → **13.3%** (wk 07-06, partial); read/list/search carry parallel `missing required parameter: paths/patterns/queries` failures (53/22/2).
- Error-class timeline flips at the upgrade: through 07-05 the server demanded `files (array of {path, mode, ...})`; from 07-06 it demands `edits (JSON array of {path, tag?, ops})`, and 07-07's dominant class is `bad-op-shape` (14×: `unknown field 'lines'`, `missing field 'op'`) — agents improvising against stale guidance.
- Both old- and new-schema errors appear on 07-07: long-lived MCP server processes started before the upgrade still serve the old schema, so residual mixed errors are expected until sessions restart.

## Fix (guidance, not the tool)

- **cheez-write** SKILL.md + edit-patterns.md: full call-shape rewrite to `edits: [{path, tag, ops}]` with the 0.8.4 op grammar; "Hash Mismatch Handling" → "Stale Tag Handling" (3-way merge / section-reject semantics).
- **cheez-read** SKILL.md + routing.md: `[path#TAG]` + `N:content` output format; tag handoff to cheez-write; stripped reads can't round-trip.
- **cheez-search** SKILL.md + tilth-search-reference.md + tilth-deps.md: removed the nonexistent `root` parameter everywhere; documented hook-injected `cwd`; fixed singular `query:` in tilth-deps.md.
- **mold/references/shape-check.md**: two live call-shape bugs (`tilth_search(query: …)` → `queries: [{…}]`).
- **cure, melt, age, README**: hash-anchor → edit-tag terminology.

## Reported upstream (not papered over)

tilth 0.8.4's own MCP `instructions` block contradicts its schema (claims `edits` is "a single op-grammar string, NOT an array" — the runtime rejects exactly that), and its error text says `set "root"` while the schema declares `cwd`. Filed as jahala/tilth#179.

## Verification

- `just test`: 591+303+224+31+35 pytest + all bats pass (includes `test_docs_emphasis_guard`, which pins the live tool identifiers and bans renamed-away ones).
- markdownlint: 0 errors; docs site builds (76 pages). (`lint-yaml` flags gitignored local `.serena/project.yml` — not in the CI checkout.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)