### PR TITLE
feat(age): add per-language de-slop catalogs and enrich the deslop dimension

### DIFF
--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -337,5 +337,5 @@ Inline-degrade is forced when the marker is present (no opt-out); it takes prece
 
 - `references/dimensions.md` — per-dimension rubrics and recommendation shapes.
 - `references/voice.md` — shared output discipline, reasoning posture, and confidence vocabulary.
-- `references/deslop-rust.md` / `deslop-typescript.md` / `deslop-python.md` / `deslop-shell.md` / `deslop-go.md` — per-language `deslop` pattern catalogs with lint-rule mappings and citations.
+- `references/deslop-rust.md` / `references/deslop-typescript.md` / `references/deslop-python.md` / `references/deslop-shell.md` / `references/deslop-go.md` — per-language `deslop` pattern catalogs with lint-rule mappings and citations.
 - `references/sub-agent-gate.md` — shared sub-agent kernel: digest contract, harness-agnostic selection, what the parent never delegates.

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -337,4 +337,5 @@ Inline-degrade is forced when the marker is present (no opt-out); it takes prece
 
 - `references/dimensions.md` — per-dimension rubrics and recommendation shapes.
 - `references/voice.md` — shared output discipline, reasoning posture, and confidence vocabulary.
+- `references/deslop-rust.md` / `deslop-typescript.md` / `deslop-python.md` / `deslop-shell.md` / `deslop-go.md` — per-language `deslop` pattern catalogs with lint-rule mappings and citations.
 - `references/sub-agent-gate.md` — shared sub-agent kernel: digest contract, harness-agnostic selection, what the parent never delegates.

--- a/skills/age/references/deslop-go.md
+++ b/skills/age/references/deslop-go.md
@@ -1,6 +1,6 @@
 # Go De-slop Catalog
 
-Per-language evidence for the `age` `deslop` dimension. Each pattern is a Go-specific AI tell to look for during review. Use alongside `dimensions.md`'s `deslop` rubric — this is the "Look for" detail, not a separate severity scale.
+Per-language evidence for the `age` `deslop` dimension. Each pattern is a Go-specific AI tell to look for during review; most map to a staticcheck or golangci-lint rule, giving a citable rule name to attach to a finding. Use alongside `dimensions.md`'s `deslop` rubric — this is the "Look for" detail, not a separate severity scale.
 
 ## 1. Error string conventions
 
@@ -18,6 +18,8 @@ return errors.New("user not found")
 
 The `%w` verb wraps the error so callers can use `errors.Is`/`errors.As`.
 Use `%v` only when you intentionally want to break the error chain.
+
+Lint: staticcheck `ST1005` (error-string capitalization/punctuation); `errorlint` for `%w`/`%v` wrapping.
 
 ## 2. Named returns with bare `return`
 
@@ -45,6 +47,8 @@ func getUser(id int) (*User, error) {
 ```
 
 Named returns are acceptable only in `defer` recovery patterns.
+
+Lint: `nakedret`; revive `bare-return`.
 
 ## 3. `context.TODO()` permanently
 
@@ -107,6 +111,8 @@ go func(ctx context.Context) {
 }(ctx)
 ```
 
+Lint: `go.uber.org/goleak` catches leaked goroutines at test time.
+
 ## 6. `fmt.Sprintf` for string concatenation in loops
 
 O(n²) string building.
@@ -126,6 +132,8 @@ for _, s := range items {
 result := b.String()
 ```
 
+Lint: `perfsprint`.
+
 ## 7. Stuttering package names
 
 ```go
@@ -139,6 +147,8 @@ package user
 type Service struct{}
 type Model struct{}
 ```
+
+Lint: revive `exported` ("type name will be used as `user.UserService` by other packages").
 
 ## 8. `init()` for non-trivial setup
 
@@ -160,3 +170,13 @@ func NewDB(dsn string) (*sql.DB, error) {
     return sql.Open("postgres", dsn)
 }
 ```
+
+Lint: `gochecknoinits` flags any `init()` function.
+
+## Sources
+
+- staticcheck docs (staticcheck.dev/docs/checks) — the `ST1005` error-string check
+- Go wiki, Code Review Comments (go.dev/wiki/CodeReviewComments) — error strings, naked returns, package-name stutter, contexts
+- Uber Go Style Guide (github.com/uber-go/guide) — goroutine lifetimes, `init()` avoidance
+- golangci-lint linters index (golangci-lint.run/usage/linters) — `nakedret`, `perfsprint`, `gochecknoinits`, revive rules
+- go.uber.org/goleak — test-time goroutine-leak detection

--- a/skills/age/references/deslop-go.md
+++ b/skills/age/references/deslop-go.md
@@ -1,0 +1,162 @@
+# Go De-slop Catalog
+
+Per-language evidence for the `age` `deslop` dimension. Each pattern is a Go-specific AI tell to look for during review. Use alongside `dimensions.md`'s `deslop` rubric — this is the "Look for" detail, not a separate severity scale.
+
+## 1. Error string conventions
+
+Go errors are lowercase, no trailing punctuation, and wrap with `%w`.
+
+```go
+// SLOP
+return fmt.Errorf("Failed to open file: %s", err)
+return errors.New("User not found.")
+
+// CLEAN
+return fmt.Errorf("open file: %w", err)
+return errors.New("user not found")
+```
+
+The `%w` verb wraps the error so callers can use `errors.Is`/`errors.As`.
+Use `%v` only when you intentionally want to break the error chain.
+
+## 2. Named returns with bare `return`
+
+AI loves named returns. They obscure which values are being returned.
+
+```go
+// SLOP
+func getUser(id int) (user *User, err error) {
+    user = db.Find(id)
+    if user == nil {
+        err = errors.New("not found")
+        return  // Which values? Have to read the whole function
+    }
+    return
+}
+
+// CLEAN
+func getUser(id int) (*User, error) {
+    user := db.Find(id)
+    if user == nil {
+        return nil, errors.New("user not found")
+    }
+    return user, nil
+}
+```
+
+Named returns are acceptable only in `defer` recovery patterns.
+
+## 3. `context.TODO()` permanently
+
+AI scaffolds with `context.TODO()` and never replaces it.
+
+```go
+// SLOP
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+    ctx := context.TODO()
+    result, err := db.Query(ctx, query)
+}
+
+// CLEAN — use the context you already have
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+    result, err := db.Query(r.Context(), query)
+}
+```
+
+`context.TODO()` means "I haven't decided which context to use yet."
+In production code, you should always have decided.
+
+## 4. Pointer to interface
+
+Almost never correct. Interfaces are already reference types.
+
+```go
+// SLOP
+func NewService(repo *Repository) *Service { ... }
+// where Repository is an interface
+
+// CLEAN
+func NewService(repo Repository) *Service { ... }
+```
+
+## 5. Goroutine leaks
+
+AI spawns goroutines without cancellation paths.
+
+```go
+// SLOP — runs forever, no way to stop it
+go func() {
+    for {
+        doWork()
+        time.Sleep(time.Second)
+    }
+}()
+
+// CLEAN — respects context cancellation
+go func(ctx context.Context) {
+    ticker := time.NewTicker(time.Second)
+    defer ticker.Stop()
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case <-ticker.C:
+            doWork()
+        }
+    }
+}(ctx)
+```
+
+## 6. `fmt.Sprintf` for string concatenation in loops
+
+O(n²) string building.
+
+```go
+// SLOP
+var result string
+for _, s := range items {
+    result = fmt.Sprintf("%s%s", result, s)
+}
+
+// CLEAN
+var b strings.Builder
+for _, s := range items {
+    b.WriteString(s)
+}
+result := b.String()
+```
+
+## 7. Stuttering package names
+
+```go
+// SLOP — user.UserService, user.UserModel
+package user
+type UserService struct{}
+type UserModel struct{}
+
+// CLEAN — user.Service, user.Model
+package user
+type Service struct{}
+type Model struct{}
+```
+
+## 8. `init()` for non-trivial setup
+
+AI puts complex initialization in `init()` which can't return errors
+and runs at import time with no control.
+
+```go
+// SLOP
+func init() {
+    db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))
+    if err != nil {
+        log.Fatal(err)  // Kills the process at import time
+    }
+    globalDB = db
+}
+
+// CLEAN — explicit initialization the caller controls
+func NewDB(dsn string) (*sql.DB, error) {
+    return sql.Open("postgres", dsn)
+}
+```

--- a/skills/age/references/deslop-python.md
+++ b/skills/age/references/deslop-python.md
@@ -1,0 +1,240 @@
+# Python De-slop Catalog
+
+Per-language evidence for the `age` `deslop` dimension. Each pattern is a Python-specific AI tell to look for during review; most map to a Ruff rule code, giving a citable rule name to attach to a finding. Use alongside `dimensions.md`'s `deslop` rubric — this is the "Look for" detail, not a separate severity scale.
+
+## 1. `range(len())` instead of `enumerate`
+
+AI defaults to C-style index loops.
+
+```python
+# SLOP
+for i in range(len(items)):
+    print(i, items[i])
+
+# CLEAN
+for i, item in enumerate(items):
+    print(i, item)
+```
+
+When you don't need the index at all, just iterate directly:
+
+```python
+for item in items:
+    process(item)
+```
+
+## 2. Manual `None` checks instead of truthiness
+
+```python
+# SLOP
+if user is not None and user.name is not None and len(user.name) > 0:
+    greet(user.name)
+
+# CLEAN
+if user and user.name:
+    greet(user.name)
+```
+
+## 3. Old-style string formatting
+
+AI mixes `%`, `.format()`, and f-strings inconsistently.
+
+```python
+# SLOP
+message = "Hello, %s! You have %d messages." % (name, count)
+message = "Hello, {}!".format(name)
+
+# CLEAN — f-strings everywhere (Python 3.6+)
+message = f"Hello, {name}! You have {count} messages."
+```
+
+## 4. Silent `except: pass`
+
+Swallowing exceptions without handling is the #1 debugging time-sink.
+
+```python
+# SLOP
+try:
+    risky_operation()
+except Exception:
+    pass  # Silent failure — good luck debugging
+
+# CLEAN — either handle it meaningfully or don't catch it
+# If you truly need to ignore: except SpecificError as e: logger.debug(...)
+```
+
+## 5. Raw dicts for structured data
+
+AI returns `{"id": 1, "name": "Alice"}` where a dataclass gives you
+type safety, IDE support, and self-documenting code.
+
+```python
+# SLOP
+def get_user():
+    return {"id": 1, "name": "Alice", "email": "alice@example.com"}
+
+# CLEAN
+@dataclass
+class User:
+    id: int
+    name: str
+    email: str
+```
+
+## 6. `open()` without context manager
+
+```python
+# SLOP
+f = open("file.txt")
+data = f.read()
+f.close()  # Never reached if f.read() throws
+
+# CLEAN
+with open("file.txt") as f:
+    data = f.read()
+```
+
+## 7. Overzealous type hints on obvious locals
+
+```python
+# SLOP
+name: str = "Alice"
+count: int = 0
+items: list[str] = []
+active: bool = True
+
+# CLEAN — type hints on function signatures, not obvious assignments
+name = "Alice"
+count = 0
+items: list[str] = []  # Empty collection annotation is fine (inference can't know the element type)
+active = True
+```
+
+## 8. List comprehension where a generator suffices
+
+```python
+# SLOP — builds entire list in memory just to iterate
+total = sum([x * x for x in range(1_000_000)])
+
+# CLEAN — generator expression, lazy evaluation
+total = sum(x * x for x in range(1_000_000))
+```
+
+## 9. Mutable default arguments
+
+`def f(x=[])` shares one list across every call.
+
+```python
+# SLOP
+def append_item(item, items=[]):
+    items.append(item)
+    return items
+
+# CLEAN
+def append_item(item, items=None):
+    if items is None:
+        items = []
+    items.append(item)
+    return items
+```
+
+Ruff: `B006`.
+
+## 10. HTTP calls without a timeout
+
+`requests`/`httpx` calls with no `timeout=` hang forever when the server does.
+
+```python
+# SLOP
+response = requests.get(url)
+
+# CLEAN
+response = requests.get(url, timeout=10)
+```
+
+Ruff: `S113`.
+
+## 11. try/except shape slop
+
+Oversized `try` blocks with logging noise — the tryceratops family.
+
+```python
+# SLOP — log-and-raise duplicates the traceback up the stack
+try:
+    process(item)
+except ValueError as e:
+    logger.error(f"failed: {e}")   # TRY400: use logger.exception
+    raise
+
+# SLOP — raise inside try, caught by its own except (TRY301);
+# success path buried inside try (TRY300)
+try:
+    value = compute()
+    if value < 0:
+        raise ValueError("negative")
+    return transform(value)
+except ValueError:
+    ...
+
+# CLEAN — narrow try, raise outside it, else for the success path
+value = compute()
+if value < 0:
+    raise ValueError("negative")
+try:
+    data = load(value)
+except OSError:
+    logger.exception("load failed")
+    raise
+else:
+    return transform(data)
+```
+
+Ruff: `TRY300`, `TRY301`, `TRY400`, `TRY401`.
+
+## 12. Deprecated typing forms
+
+Models trained on pre-3.9 code emit `typing.List`/`Optional`/`Union`.
+
+```python
+# SLOP
+from typing import Dict, List, Optional, Union
+def find(ids: List[int]) -> Optional[Dict[str, Union[int, str]]]: ...
+
+# CLEAN — builtin generics (3.9+) and | unions (3.10+)
+def find(ids: list[int]) -> dict[str, int | str] | None: ...
+```
+
+Ruff: `UP006`, `UP007`, `UP045`.
+
+## 13. os.path / pathlib mixing
+
+`os.path.join`, `os.path.exists`, and `Path` interleaved in the same module.
+
+```python
+# SLOP
+path = os.path.join(base, "config.yaml")
+if os.path.exists(path): ...
+
+# CLEAN
+path = Path(base) / "config.yaml"
+if path.exists(): ...
+```
+
+Ruff: `PTH` family. Caveat: `open(path)` on a `Path` is fine — `PTH123`
+(force `Path.open()`) is contested among core devs; don't "fix" it.
+
+## 14. print() debugging in library code
+
+```python
+# SLOP
+print(f"processing {item}")
+
+# CLEAN — logging, or delete if the code is self-evident
+logger.debug("processing %s", item)
+```
+
+## Sources
+
+- Ruff rule docs (docs.astral.sh/ruff/rules) — every rule code above is verifiable there
+- charlax/professional-programming, error-handling anti-patterns — before/after exception examples
+- Greg-style caveat: PTH123 dispute thread (discuss.python.org/t/106904) — calibration for the pathlib rule

--- a/skills/age/references/deslop-rust.md
+++ b/skills/age/references/deslop-rust.md
@@ -1,0 +1,616 @@
+# Rust De-slop Catalog
+
+Per-language evidence for the `age` `deslop` dimension. Each pattern is a Rust-specific AI tell to look for during review; most map to a clippy lint, giving a citable rule name to attach to a finding. Use alongside `dimensions.md`'s `deslop` rubric — this is the "Look for" detail, not a separate severity scale.
+
+## 1. Excessive `.clone()` to silence the borrow checker
+
+LLMs reach for `.clone()` as a universal fix for ownership errors.
+
+**Fix:**
+
+- Use borrowing (`&` and `&mut`) instead
+- Take `&str` instead of `String` in function parameters
+- Use `.as_ref()` on `Option`/`Result` instead of cloning to unwrap
+- Rule: `.clone()` is banned unless you can explain why you need owned data
+
+```rust
+// SLOP
+fn greet(name: String) { println!("Hello, {name}"); }
+let msg = my_string.clone();
+greet(msg);
+
+// CLEAN
+fn greet(name: &str) { println!("Hello, {name}"); }
+greet(&my_string);
+```
+
+## 2. `.unwrap()` everywhere
+
+Creates runtime panics scattered throughout the codebase.
+
+**Fix:**
+
+- Use `?` operator for error propagation
+- Use `anyhow` or `thiserror` for structured errors
+- Use `if let Some(x)` or `match` for `Option` types
+- `.unwrap()` only for compile-time guarantees (hardcoded regex, constants)
+
+```rust
+// SLOP
+let file = File::open("config.toml").unwrap();
+let config: Config = toml::from_str(&contents).unwrap();
+
+// CLEAN
+let file = File::open("config.toml")?;
+let config: Config = toml::from_str(&contents)?;
+```
+
+## 3. Treating everything as `String`
+
+Losing type safety and adding unnecessary allocations.
+
+**Fix:**
+
+- Accept `&str` or `impl AsRef<str>` in function parameters
+- Use `Cow<'_, str>` when sometimes owned, sometimes borrowed
+- Create newtypes for domain concepts: `struct UserId(String)`
+
+```rust
+// SLOP
+fn find_user(id: String, name: String) -> String { ... }
+
+// CLEAN
+fn find_user(id: &UserId, name: &str) -> Result<User> { ... }
+```
+
+## 4. Index-based loops instead of iterators
+
+C-style `for i in 0..vec.len()` misses safety and optimization.
+
+**Fix:**
+
+- Use `.iter()`, `.map()`, `.filter()`, `.enumerate()`, `.collect()`
+- Use slice patterns: `match vec.as_slice() { [first, ..] => ... }`
+
+```rust
+// SLOP
+for i in 0..items.len() {
+    process(i, &items[i]);
+}
+
+// CLEAN
+for (i, item) in items.iter().enumerate() {
+    process(i, item);
+}
+```
+
+## 5. Fighting lifetimes with `Rc<RefCell<T>>`
+
+When ownership gets complex, AI reaches for interior mutability or `unsafe`.
+
+**Fix:**
+
+- Reduce borrow lifetimes so they don't overlap
+- Design structs to own their data
+- Pass short-lived borrows as method parameters
+- Restructure to avoid holding long-lived references
+
+## 6. Weak assertions — the #1 AI test smell
+
+`assert!(result.is_ok())` and `assert!(result.is_err())` swallow the actual
+error/value on failure, printing only `false`.
+
+**Fix:**
+
+- Propagate with `.expect("context")` or `?` to see the real error
+- Check actual values, not just existence
+- For errors, verify the specific variant with `matches!` or check the message
+- Every `assert_eq!`/`assert!` with non-obvious operands needs a failure message
+
+```rust
+// SLOP
+assert!(result.is_ok());
+assert!(result.is_err());
+assert_eq!(count, 3);  // no context on failure
+```
+
+```rust
+// CLEAN — propagate the real error
+let value = result.expect("scan_worktree should succeed");
+assert_eq!(value.label, "Ready");
+```
+
+```rust
+// CLEAN — check specific error variant
+assert!(matches!(result, Err(MyError::NotFound { .. })));
+// or check the message
+let err = result.unwrap_err();
+assert!(err.to_string().contains("not found"), "expected NotFound, got: {err}");
+```
+
+```rust
+// CLEAN — failure message for non-obvious operands
+assert_eq!(count, 3, "expected 3 active workers after spawn");
+```
+
+## 7. `is_none()` / `is_some()` without value context
+
+`assert!(x.is_none())` prints `assertion failed: false`. `assert_eq!` shows what was actually there.
+
+**Fix:**
+
+- Use `assert_eq!(x, None)` for better failure messages
+- For `is_some()`, extract and check the inner value
+
+```rust
+// SLOP
+assert!(x.is_none());
+assert!(ping["result"]["host_type"].as_str().is_some());
+
+// CLEAN
+assert_eq!(x, None);
+assert_eq!(ping["result"]["host_type"].as_str(), Some("daemon"));
+```
+
+## 8. Async timing slop
+
+Raw `tokio::time::sleep` before assertions is fragile — passes on fast machines, flakes in CI.
+
+**Fix:**
+
+- Use a `wait_until_async` polling pattern with timeout
+- Sleep-then-assert is only acceptable for testing actual timing behavior
+
+```rust
+// SLOP
+tokio::time::sleep(Duration::from_millis(500)).await;
+assert_eq!(state.status(), "ready");
+
+// CLEAN — poll with timeout
+wait_until_async(Duration::from_secs(2), || async {
+    state.status() == "ready"
+}).await.expect("status should reach ready");
+```
+
+## 9. `#[should_panic]` without `expected`
+
+A bare `#[should_panic]` passes on *any* panic — including unrelated ones from
+refactoring. Always pin the expected message.
+
+**Fix:**
+
+- Add `expected = "substring"` to match the intended panic message
+
+```rust
+// SLOP
+#[test]
+#[should_panic]
+fn rejects_empty_input() {
+    parse("");
+}
+
+// CLEAN
+#[test]
+#[should_panic(expected = "input must not be empty")]
+fn rejects_empty_input() {
+    parse("");
+}
+```
+
+## 10. No-crash-is-success tests
+
+Tests with zero assertions only prove the code doesn't panic — not that it works.
+
+**Fix:**
+
+- Add assertions on return values or side effects
+- If intentionally testing "no panic", add an explicit comment documenting why
+
+```rust
+// SLOP
+#[test]
+fn stamp_activity_nonexistent_is_noop() {
+    tracker.stamp_activity("ghost-id");
+}
+
+// CLEAN — document the intent
+#[test]
+fn stamp_activity_nonexistent_is_noop() {
+    // No assertion needed: verifying no panic on missing ID
+    tracker.stamp_activity("ghost-id");
+}
+```
+
+## 11. Lint suppression as band-aid (`#[allow(...)]`)
+
+AI sprinkles `#[allow(...)]` to silence warnings instead of fixing root causes.
+The compiler is telling you something — listen, don't muzzle it.
+
+### Crate-level nuclear options (instant fail)
+
+These suppress warnings globally and are never legitimate in production code:
+
+```rust
+// SLOP — the nuclear option
+#![allow(warnings)]
+#![allow(clippy::all)]
+
+// SLOP — the scaffold dump (3+ together = AI signature)
+#![allow(dead_code)]
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+```
+
+**Fix:** Delete the allows and fix each warning individually. If there are too
+many warnings, the code has bigger problems than lint noise.
+
+### The AI scaffold cluster
+
+These five attributes appearing together are the highest-confidence AI signal:
+
+| Attribute | AI excuse | Real fix |
+|-----------|-----------|----------|
+| `allow(dead_code)` | "I'll wire it up later" | Delete unconnected code |
+| `allow(unused_imports)` | Copied from examples | Remove unused `use` statements |
+| `allow(unused_variables)` | Bound "just in case" | Prefix with `_` or remove |
+| `allow(unused_mut)` | Added `mut` preemptively | Remove unnecessary `mut` |
+| `allow(unused_assignments)` | Assign then overwrite | Remove dead assignment |
+
+**Fix:** Each has a specific fix — the allow hides which one is needed.
+Remove the allow, read the warning, apply the real fix.
+
+### Clippy suppression smells
+
+**Red Flag (almost always slop — these suppress restrictions for a reason):**
+
+```rust
+// SLOP — hiding panic risks
+#[allow(clippy::unwrap_used)]
+#[allow(clippy::expect_used)]
+#[allow(clippy::indexing_slicing)]
+#[allow(clippy::panic)]
+
+// CLEAN — handle the error
+fn get_item(items: &[Item], idx: usize) -> Option<&Item> {
+    items.get(idx)
+}
+```
+
+```rust
+// SLOP — incomplete code in CI
+#[allow(clippy::todo)]
+#[allow(clippy::unimplemented)]
+#[allow(clippy::dbg_macro)]       // debug macros left in source
+
+// CLEAN — ship nothing with these lints suppressed
+```
+
+```rust
+// SLOP — logging-aware code ignored
+#[allow(clippy::print_stdout)]
+#[allow(clippy::print_stderr)]
+
+// CLEAN — use a logging framework (tracing, log, slog)
+tracing::info!("event happened");
+```
+
+```rust
+// SLOP — weak error handling
+#[allow(clippy::result_unit_err)]  // Result<T, ()> is useless for error context
+
+// CLEAN — use a real error type
+fn parse_config(s: &str) -> Result<Config, ConfigError> { ... }
+```
+
+**Yellow Flag (often slop, but context-dependent — check before removing):**
+
+```rust
+// SLOP (often) — hiding complexity debt
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_lines)]
+
+// CLEAN — decompose the function
+```
+
+```rust
+// SLOP (often) — legitimate in some contexts (async move blocks, trait impls)
+#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::cognitive_complexity)]
+
+// Check: does the suppression hide a real refactoring opportunity?
+```
+
+**Blue Flag (style preference, not necessarily slop):**
+
+```rust
+// Acceptable — pedantic lints are opt-in for a reason
+#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_sign_loss)]
+#[allow(clippy::module_name_repetitions)]
+#[allow(clippy::wildcard_imports)]
+
+// These are in "pedantic" (not "restriction"), so suppressing them
+// is more defensible. Still check the reason.
+```
+
+### Naming convention suppressions
+
+Three together = author came from Python/Java, not Rust:
+
+```rust
+// SLOP
+#![allow(non_snake_case)]
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+
+// CLEAN — use Rust conventions
+// snake_case for functions, CamelCase for types, SCREAMING for constants
+```
+
+**Exception:** FFI modules wrapping C libraries may legitimately need
+`non_snake_case` or `non_camel_case_types` to match the C API.
+
+### The "debug and print" tells
+
+Three patterns that almost certainly indicate hastily generated code:
+
+```rust
+// SLOP — debug macro left in source
+fn process(data: &[u8]) {
+    #[allow(clippy::dbg_macro)]
+    dbg!(data);  // this went to production
+    // ...
+}
+
+// CLEAN — remove the debug macro entirely
+fn process(data: &[u8]) {
+    tracing::debug!(?data);  // use structured logging
+    // ...
+}
+```
+
+```rust
+// SLOP — println instead of logging
+#[allow(clippy::print_stdout)]
+println!("Processing file: {}", path);
+
+// CLEAN — use a logging framework
+tracing::info!(file = %path, "Processing file");
+```
+
+```rust
+// SLOP — placeholder error type
+#[allow(clippy::result_unit_err)]
+fn load_config(path: &str) -> Result<Config, ()> {
+    // caller has no idea what went wrong
+}
+
+// CLEAN — define a real error type
+#[derive(Debug)]
+pub enum ConfigError {
+    NotFound(String),
+    InvalidFormat { line: usize, reason: String },
+}
+
+fn load_config(path: &str) -> Result<Config, ConfigError> {
+    // caller can now handle specific errors
+}
+```
+
+### Redundant allows
+
+An allow that duplicates what the language already provides:
+
+```rust
+// SLOP — `_name` already suppresses unused_variables
+#[allow(unused_variables)]
+fn process(_name: &str, _config: &Config) { ... }
+
+// SLOP — pub items can't be dead code (compiler perspective)
+#[allow(dead_code)]
+pub fn my_function() { ... }
+
+// CLEAN — just use the underscore prefix
+fn process(_name: &str, _config: &Config) { ... }
+```
+
+### Scope matters
+
+The further an allow reaches, the worse it smells:
+
+| Scope | Severity | Example |
+|-------|----------|---------|
+| Crate-level `#![allow(...)]` | High | Suppresses across entire crate |
+| Module-level `#[allow(...)]` on `mod` | Medium | Blanket suppression for module |
+| Function-level | Low | Targeted, possibly legitimate |
+| Statement-level | Lowest | Precise suppression with clear reason |
+
+**Rule:** If you must allow, scope it to the narrowest possible target and
+add a comment explaining why.
+
+```rust
+// Acceptable — narrow scope, clear reason
+#[allow(clippy::too_many_arguments)] // mirrors the C FFI signature exactly
+fn ffi_create_window(x: i32, y: i32, w: i32, h: i32, flags: u32) -> *mut Window { ... }
+```
+
+### Tier system for evaluation
+
+Clippy groups lints into categories. Use these groupings as a heuristic when judging whether suppression is legitimate:
+
+| Category | Philosophy | Example | Suppression OK? |
+|----------|-----------|---------|-----------------|
+| **restriction** | "Don't do this" | `unwrap_used`, `panic`, `todo`, `print_stdout` | 🔴 Almost never |
+| **correctness** | "This is likely wrong" | Most logic bugs | 🔴 Almost never |
+| **complexity** | "This is confusing" | `too_many_arguments`, `cognitive_complexity` | 🟡 With justification |
+| **perf** | "This is slow" | `clone_on_copy`, `inefficient_to_string` | 🟡 Document why |
+| **style** | "Use X instead" | `let_and_return`, `wildcard_imports` | 🟡 Preference |
+| **pedantic** | "Extra strict" | `cast_possible_truncation`, `missing_docs` | 🟢 Usually OK |
+
+**Rule:** Never suppress `restriction` lints casually. `Pedantic` lints are opt-in,
+so suppressing them is more defensible. `Complexity` lints need justification.
+
+### Legitimate uses (don't flag these)
+
+**Test code:**
+
+- `#[allow(dead_code)]` on test utility functions
+- `#[allow(unused)]` in `mod tests` blocks
+- `#[allow(clippy::unwrap_used)]` in test assertions (idiomatic)
+
+**Framework integration:**
+
+- `#[allow(unused)]` on trait impls required by framework (async frameworks often have dead-looking methods)
+- `#[allow(clippy::must_use_candidate)]` when the framework signature doesn't support `#[must_use]`
+
+**Intentional design:**
+
+- `#[allow(clippy::pedantic)]` at crate level (pedantic lints are opt-in)
+- `#[allow(clippy::cognitive_complexity)]` on state machines or DSLs (legitimately complex, not a bug)
+
+**FFI/interop:**
+
+- `#[allow(non_snake_case)]` / `non_camel_case_types` matching C signatures
+- `#[allow(unsafe_code)]` when wrapping C libraries
+
+**Generated code:**
+
+- `build.rs` output
+- Protobuf/gRPC generated files
+- Macro-generated code inside the macro itself
+- `#[cfg_attr(feature = "generated", allow(...))]` for optional generated modules
+
+**Red flag check:** If the allow targets a **restriction** lint (unwrap, panic, todo, print)
+in these contexts, it's still slop. Only pedantic/style/perf lints are genuinely legitimate here.
+
+## 12. Hallucinated APIs and deprecated syntax
+
+AI generates functions that don't exist or uses outdated API patterns
+(e.g., `clap` `App::new` instead of derive macros).
+
+**Fix:**
+
+- Run `cargo check` immediately after generating code
+- Pin specific crate versions
+- Use Clippy: `cargo clippy -- -W clippy::all`
+- When in doubt, check docs against the current crate version
+
+## 13. Deref polymorphism (fake inheritance)
+
+Implementing `Deref` on a wrapper so it "inherits" the inner type's methods —
+simulating the OO inheritance Rust deliberately doesn't have.
+
+```rust
+// SLOP
+struct AppConfig { base: Config }
+impl Deref for AppConfig {
+    type Target = Config;
+    fn deref(&self) -> &Config { &self.base }
+}
+
+// CLEAN — delegate explicitly, or implement the shared trait
+impl AppConfig {
+    fn timeout(&self) -> Duration { self.base.timeout() }
+}
+```
+
+`Deref` is for smart pointers. No clippy lint catches this — review by hand.
+(rust-unofficial/patterns, anti-patterns chapter.)
+
+## 14. Boxing reflex
+
+`Box`/`Arc` where plain ownership or a borrow works — indirection reached for
+to make the borrow checker go away.
+
+```rust
+// SLOP
+fn process(data: &Box<MyStruct>) { ... }        // borrowed_box
+struct Registry { items: Vec<Box<String>> }      // vec_box
+let cfg: Box<Config> = Box::new(Default::default()); // box_default
+
+// CLEAN
+fn process(data: &MyStruct) { ... }
+struct Registry { items: Vec<String> }
+let cfg = Config::default();
+```
+
+clippy: `borrowed_box`, `vec_box`, `box_collection`, `box_default`.
+Inverse case: a very large enum variant SHOULD be boxed
+(`large_enum_variant`) — boxing isn't wrong, unmotivated boxing is.
+
+## 15. `async fn` with no `.await`
+
+Functions marked async by habit. An async fn that never awaits forces every
+caller into the async machinery for nothing.
+
+```rust
+// SLOP
+async fn config_path() -> PathBuf {
+    dirs::config_dir().expect("config dir").join("app")
+}
+
+// CLEAN
+fn config_path() -> PathBuf { ... }
+```
+
+clippy: `unused_async` (has false-negative gaps — also check by hand).
+
+## 16. `#![deny(warnings)]`
+
+Turns every future compiler warning into a build break — the crate stops
+compiling on a new toolchain that added a lint.
+
+```rust
+// SLOP
+#![deny(warnings)]
+
+// CLEAN — enforce in CI instead:
+// RUSTFLAGS="-D warnings" cargo build
+```
+
+(rust-unofficial/patterns, anti-patterns chapter.)
+
+## 17. `anyhow::Error` in a library's public API
+
+`anyhow` is for applications. A library returning `anyhow::Error` gives
+callers nothing to match on.
+
+```rust
+// SLOP (in a lib crate)
+pub fn parse(s: &str) -> anyhow::Result<Config> { ... }
+
+// CLEAN — concrete error type; thiserror for the boilerplate
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("invalid syntax at line {0}")]
+    Syntax(usize),
+}
+pub fn parse(s: &str) -> Result<Config, ParseError> { ... }
+```
+
+Convention, not a lint — check whether the crate is a lib or a bin before
+flagging. `anyhow` in binaries and tests is fine.
+
+## 18. `unsafe` to make it compile
+
+Agent-speed pressure produces `unsafe` as a borrow-checker escape hatch.
+Bun's audit of its AI-assisted Zig→Rust port found 13,365 unsafe call sites
+needing review. For every `unsafe` block ask: is there a safe alternative, is
+the invariant documented, is it tested?
+
+```rust
+// SLOP — no SAFETY comment, no bounds reasoning
+let val = unsafe { *ptr.add(i) };
+
+// CLEAN — safe alternative existed all along
+let val = slice.get(i).copied().ok_or(Error::OutOfBounds)?;
+
+// If unsafe is genuinely required:
+// SAFETY: i < self.len is checked by the caller contract above.
+```
+
+## Sources
+
+- rust-unofficial/patterns (Rust Design Patterns book) — the official anti-pattern chapter
+- clippy lint list (rust-lang.github.io/rust-clippy/master) — ground truth for every lint named above
+- Bun unsafe audit (bun.com/bun-unsafe-audit) — quantified case study of AI-agent Rust output

--- a/skills/age/references/deslop-rust.md
+++ b/skills/age/references/deslop-rust.md
@@ -442,10 +442,10 @@ Clippy groups lints into categories. Use these groupings as a heuristic when jud
 |----------|-----------|---------|-----------------|
 | **restriction** | "Don't do this" | `unwrap_used`, `panic`, `todo`, `print_stdout` | 🔴 Almost never |
 | **correctness** | "This is likely wrong" | Most logic bugs | 🔴 Almost never |
-| **complexity** | "This is confusing" | `too_many_arguments`, `cognitive_complexity` | 🟡 With justification |
+| **complexity** | "This is confusing" | `too_many_arguments`, `type_complexity` | 🟡 With justification |
 | **perf** | "This is slow" | `clone_on_copy`, `inefficient_to_string` | 🟡 Document why |
 | **style** | "Use X instead" | `let_and_return`, `wildcard_imports` | 🟡 Preference |
-| **pedantic** | "Extra strict" | `cast_possible_truncation`, `missing_docs` | 🟢 Usually OK |
+| **pedantic** | "Extra strict" | `cast_possible_truncation`, `module_name_repetitions` | 🟢 Usually OK |
 
 **Rule:** Never suppress `restriction` lints casually. `Pedantic` lints are opt-in,
 so suppressing them is more defensible. `Complexity` lints need justification.

--- a/skills/age/references/deslop-shell.md
+++ b/skills/age/references/deslop-shell.md
@@ -1,0 +1,305 @@
+# Shell / Bash De-slop Catalog
+
+Per-language evidence for the `age` `deslop` dimension. Each pattern is a shell-specific AI tell to look for during review; most map to a ShellCheck code, giving a citable rule name to attach to a finding. Use alongside `dimensions.md`'s `deslop` rubric — this is the "Look for" detail, not a separate severity scale.
+
+## 1. Unquoted variables
+
+The #1 shell bug. Breaks on spaces, globs, and empty values.
+
+```bash
+# SLOP
+for file in $files; do
+    rm $file
+done
+
+# CLEAN
+for file in "${files[@]}"; do
+    rm -- "$file"
+done
+```
+
+Quote every variable expansion: `"$var"`, `"${array[@]}"`, `"$(command)"`.
+The `--` stops option parsing (protects against filenames starting with `-`).
+
+## 2. Missing or incomplete `set -euo pipefail`
+
+AI scripts either omit strict mode entirely or use partial `set -e` without
+`-u` and `-o pipefail`. Both are dangerous.
+
+```bash
+# SLOP — no strict mode
+#!/bin/bash
+cd /some/directory    # Might fail silently
+rm -rf build/         # Now you're deleting in the wrong place
+
+# SLOP — partial strict mode (common AI output)
+#!/bin/bash
+set -e
+yq '.items[]' file.yaml | while read -r item; do  # yq failure silently ignored
+    process "$item"
+done
+
+# CLEAN
+#!/bin/bash
+set -euo pipefail
+cd /some/directory
+rm -rf build/
+```
+
+- `-e`: Exit on error
+- `-u`: Error on undefined variables (catches typos like `$UESR` instead of `$USER`)
+- `-o pipefail`: Pipeline fails if any command fails (not just the last)
+
+All three flags together. `set -e` alone is a half-measure — especially
+dangerous in scripts that pipe through `jq`/`yq`/`grep` where a failure
+on the left side is silently swallowed.
+
+### Strict mode is not a cure-all
+
+`set -e` has sharp edges (BashFAQ/105) — don't assume it catches everything:
+
+```bash
+# MASKED — `local`'s own success hides the command's failure
+local output=$(failing_cmd)      # -e does NOT fire
+
+# CLEAN — declare and assign in two steps
+local output
+output=$(failing_cmd)            # -e fires here
+
+# MASKED — -e is disabled inside a function used as a conditional
+if my_func; then ...             # failures inside my_func won't exit
+```
+
+## 3. Parsing `ls` output
+
+`ls` output is not machine-readable. Filenames with spaces, newlines,
+or special characters break everything.
+
+```bash
+# SLOP
+for file in $(ls *.txt); do
+    process "$file"
+done
+
+# CLEAN — glob directly
+for file in *.txt; do
+    [[ -f "$file" ]] && process "$file"
+done
+
+# CLEAN — fd for complex searches
+fd -e txt -x process {}
+```
+
+## 4. Useless use of `cat`
+
+```bash
+# SLOP
+cat file.txt | grep "pattern"
+cat file.txt | wc -l
+
+# CLEAN
+grep "pattern" file.txt
+wc -l < file.txt
+```
+
+## 5. Backticks instead of `$()`
+
+Backticks don't nest and are harder to read.
+
+```bash
+# SLOP
+result=`command`
+nested=`echo \`date\``
+
+# CLEAN
+result=$(command)
+nested=$(echo "$(date)")
+```
+
+## 6. `[ ]` instead of `[[ ]]`
+
+`[[ ]]` is safer: no word splitting, supports regex, no quoting surprises.
+
+```bash
+# SLOP
+if [ $var = "value" ]; then
+if [ -z $maybe_empty ]; then
+
+# CLEAN
+if [[ "$var" == "value" ]]; then
+if [[ -z "${maybe_empty:-}" ]]; then
+```
+
+## 7. Hardcoded paths
+
+AI writes absolute paths or assumes CWD.
+
+```bash
+# SLOP
+source /home/user/project/lib/utils.sh
+config_file=./config.yaml
+
+# CLEAN
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/utils.sh"
+config_file="${SCRIPT_DIR}/config.yaml"
+```
+
+## 8. Not using `readonly` for constants
+
+```bash
+# SLOP
+MAX_RETRIES=3
+BASE_URL="https://api.example.com"
+
+# CLEAN
+readonly MAX_RETRIES=3
+readonly BASE_URL="https://api.example.com"
+```
+
+## 9. Using `echo` for error messages
+
+Errors go to stderr, not stdout.
+
+```bash
+# SLOP
+echo "Error: file not found"
+exit 1
+
+# CLEAN
+echo >&2 "Error: file not found"
+exit 1
+
+# Or with a helper
+die() { echo >&2 "$@"; exit 1; }
+die "file not found"
+```
+
+## 10. Checking `$?` instead of the command
+
+```bash
+# SLOP
+some_command
+if [ $? -eq 0 ]; then
+    echo "ok"
+fi
+
+# CLEAN
+if some_command; then
+    echo "ok"
+fi
+
+# CLEAN — error path
+if ! some_command; then
+    die "some_command failed"
+fi
+```
+
+ShellCheck: SC2181.
+
+## 11. `cd` without a fallback
+
+The highest-consequence tell: a failed `cd` (typo, permissions) lets every
+following command — including `rm -rf` — run in the wrong directory.
+
+```bash
+# SLOP
+cd "$build_dir"
+rm -rf ./*
+
+# CLEAN
+cd "$build_dir" || exit 1
+rm -rf ./*
+```
+
+ShellCheck: SC2164.
+
+## 12. Iterating command output with `for`
+
+`for x in $(cmd)` splits on whitespace, not lines — breaks on spaces and globs.
+
+```bash
+# SLOP
+for f in $(find . -name '*.log'); do
+    process "$f"
+done
+
+# CLEAN — NUL-delimited for filenames
+find . -name '*.log' -print0 | while IFS= read -r -d '' f; do
+    process "$f"
+done
+
+# CLEAN — line-oriented command output
+readarray -t lines < <(cmd)
+```
+
+ShellCheck: SC2044 (find loops), SC2046 (unquoted `$(...)` generally).
+
+## 13. Piping into `while read` and losing variables
+
+Each side of a pipe runs in a subshell — assignments inside the loop vanish.
+
+```bash
+# SLOP — prints 0
+count=0
+cat file | while read -r line; do
+    count=$((count + 1))
+done
+echo "$count"
+
+# CLEAN — redirect (or process-substitute); no subshell
+count=0
+while read -r line; do
+    count=$((count + 1))
+done < file
+```
+
+## 14. `echo -e` / `echo -n`
+
+`echo`'s flag behavior differs between the bash builtin and `/bin/echo` and
+isn't POSIX-portable.
+
+```bash
+# SLOP
+echo -e "line1\nline2"
+echo -n "no newline"
+
+# CLEAN
+printf '%s\n' "line1" "line2"
+printf '%s' "no newline"
+```
+
+## 15. `expr`, `let`, `$[ ]` arithmetic
+
+External processes and deprecated syntax for what the shell does natively.
+
+```bash
+# SLOP
+i=$(expr $i + 1)
+let i=i+1
+result=$[ a + b ]
+
+# CLEAN
+(( i += 1 ))
+result=$(( a + b ))
+```
+
+Google Shell Style Guide: always `(( ))` / `$(( ))`.
+
+## 16. Bare `$@` / `$*` for argument forwarding
+
+Unquoted, both split on internal spaces and drop empty arguments.
+
+```bash
+# SLOP
+my_func $@
+
+# CLEAN
+my_func "$@"
+```
+
+## Sources
+
+- ShellCheck wiki (shellcheck.net/wiki/SCxxxx) — canonical slop→fix rationale per code
+- Greg's Wiki: BashPitfalls + BashFAQ/105 — the `set -e` calibration source
+- Google Shell Style Guide — arithmetic, quoting, loop idioms, when not to use bash at all

--- a/skills/age/references/deslop-typescript.md
+++ b/skills/age/references/deslop-typescript.md
@@ -207,7 +207,7 @@ await Promise.all(items.map(i => process(i)));
 void saveUser(user);
 ```
 
-Lint: `@typescript-eslint/no-floating-promises`, `no-misused-promises`.
+Lint: `@typescript-eslint/no-floating-promises`, `@typescript-eslint/no-misused-promises`.
 
 ## 13. `enum` where a union suffices
 
@@ -250,7 +250,7 @@ try {
 ```
 
 Lint: `@typescript-eslint/only-throw-error`,
-`use-unknown-in-catch-callback-variable`.
+`@typescript-eslint/use-unknown-in-catch-callback-variable`.
 
 ## 15. `useEffect` for derived state (React)
 

--- a/skills/age/references/deslop-typescript.md
+++ b/skills/age/references/deslop-typescript.md
@@ -1,0 +1,275 @@
+# TypeScript / JavaScript De-slop Catalog
+
+Per-language evidence for the `age` `deslop` dimension. Each pattern is a TS/JS-specific AI tell to look for during review; most map to a typescript-eslint rule, giving a citable rule name to attach to a finding. Use alongside `dimensions.md`'s `deslop` rubric — this is the "Look for" detail, not a separate severity scale.
+
+## 1. `any` as escape hatch
+
+When types get complex, AI gives up and uses `any`, throwing away
+everything TypeScript provides.
+
+```typescript
+// SLOP
+function processData(data: any): any {
+  return data.value;
+}
+
+// CLEAN
+function processData<T extends { value: unknown }>(data: T): T['value'] {
+  return data.value;
+}
+
+// Or if you genuinely don't know the shape:
+function processData(data: unknown): unknown {
+  if (hasValue(data)) return data.value;
+  throw new Error("missing value field");
+}
+```
+
+## 2. `.then()` chains instead of `async/await`
+
+AI mixes paradigms or uses promise chains where async/await is cleaner.
+
+```typescript
+// SLOP
+function fetchUser(id: string) {
+  return fetch(`/api/users/${id}`)
+    .then(res => res.json())
+    .then(data => data.user)
+    .catch(err => console.error(err));
+}
+
+// CLEAN
+async function fetchUser(id: string): Promise<User> {
+  const res = await fetch(`/api/users/${id}`);
+  return (await res.json()).user;
+  // Let errors propagate — the caller should decide what to do
+}
+```
+
+## 3. `console.log` debugging left in
+
+AI adds debug logging that never gets removed.
+
+```typescript
+// SLOP
+console.log("Fetching user...");
+const user = await fetchUser(id);
+console.log("User fetched:", user);
+console.log("Processing...");
+```
+
+**Fix:** Delete all `console.log` debug statements. Use a proper logger
+if observability is needed, or remove entirely if the code is
+self-evident.
+
+## 4. `Array.forEach` with async callbacks
+
+`forEach` doesn't await — async callbacks fire and are silently dropped.
+
+```typescript
+// SLOP — these await calls do nothing useful
+items.forEach(async (item) => {
+  await processItem(item);  // Runs concurrently, forEach doesn't wait
+});
+
+// CLEAN — sequential
+for (const item of items) {
+  await processItem(item);
+}
+
+// CLEAN — concurrent with control
+await Promise.all(items.map(item => processItem(item)));
+```
+
+## 5. Redundant null checks TypeScript already handles
+
+With `strictNullChecks`, the compiler enforces null safety.
+
+```typescript
+// SLOP — name can't be undefined here, the type says string | null
+function greet(name: string | null): string {
+  if (name === null || name === undefined) {
+    return "Hello, stranger";
+  }
+  return `Hello, ${name}`;
+}
+
+// CLEAN
+function greet(name: string | null): string {
+  return name ? `Hello, ${name}` : "Hello, stranger";
+}
+```
+
+Lint: `@typescript-eslint/no-unnecessary-condition` — catches provably
+true/false conditions in general, not just null checks.
+
+## 6. `JSON.parse(JSON.stringify())` for deep cloning
+
+```typescript
+// SLOP
+const cloned = JSON.parse(JSON.stringify(user));
+
+// CLEAN — structuredClone (available in all modern runtimes)
+const cloned = structuredClone(user);
+```
+
+## 7. Redundant type annotations on initialized variables
+
+```typescript
+// SLOP
+const count: number = 0;
+const name: string = user.name;
+const isActive: boolean = true;
+const users: User[] = getUsers();
+
+// CLEAN — inference handles these
+const count = 0;
+const name = user.name;
+const isActive = true;
+const users = getUsers();  // Return type already typed
+
+// Keep annotations on empty collections or ambiguous initializers
+const users: User[] = [];
+```
+
+## 8. Over-importing from barrel files
+
+```typescript
+// SLOP — grabs everything, bloats bundle
+import { UserService, UserModel, UserDTO, UserMapper, UserValidator } from "./users";
+
+// CLEAN — import only what you use
+import { UserService } from "./users";
+```
+
+## 9. Non-null assertion as narrowing substitute
+
+`!` tells the compiler to shut up; a guard tells it something true. AI-authored
+PRs use `!` and `as` at a much higher rate than human PRs (arXiv 2602.17955).
+
+```typescript
+// SLOP
+const user = users.find(u => u.id === id)!;
+processUser(user);
+
+// CLEAN
+const user = users.find(u => u.id === id);
+if (!user) throw new Error(`unknown user: ${id}`);
+processUser(user);
+```
+
+Lint: `@typescript-eslint/no-non-null-assertion`.
+
+## 10. Double assertion to force a type
+
+`as unknown as T` makes any value claim any type — it erases the type system
+at exactly the spot most likely to be wrong.
+
+```typescript
+// SLOP
+const config = JSON.parse(raw) as unknown as Config;
+
+// CLEAN — validate at the boundary
+const config = configSchema.parse(JSON.parse(raw)); // zod or similar
+```
+
+## 11. `@ts-ignore` instead of `@ts-expect-error`
+
+`@ts-ignore` silences forever — when the underlying error is fixed, the stale
+directive stays. `@ts-expect-error` fails when it no longer suppresses anything.
+
+```typescript
+// SLOP
+// @ts-ignore
+legacyCall(data);
+
+// CLEAN
+// @ts-expect-error — legacy API typed wrong upstream (issue #123)
+legacyCall(data);
+```
+
+Lint: `@typescript-eslint/ban-ts-comment` (set `minimumDescriptionLength`).
+
+## 12. Floating promises
+
+Fire-and-forget async calls — rejections vanish, ordering is accidental.
+
+```typescript
+// SLOP
+saveUser(user);                          // not awaited — errors disappear
+items.map(async i => await process(i));  // array of dropped promises
+
+// CLEAN
+await saveUser(user);
+await Promise.all(items.map(i => process(i)));
+
+// Intentionally fire-and-forget? Say so:
+void saveUser(user);
+```
+
+Lint: `@typescript-eslint/no-floating-promises`, `no-misused-promises`.
+
+## 13. `enum` where a union suffices
+
+Enums imported from other languages' habits. Literal unions are erasable,
+serializable, and need no runtime object.
+
+```typescript
+// SLOP
+enum Status { Active = "active", Inactive = "inactive" }
+
+// CLEAN
+type Status = "active" | "inactive";
+
+// When you need the values at runtime:
+const STATUSES = ["active", "inactive"] as const;
+type Status = (typeof STATUSES)[number];
+```
+
+## 14. Catch-block slop
+
+`catch (e: any)` plus log-and-rethrow: the error is logged at every level and
+handled at none.
+
+```typescript
+// SLOP
+try {
+  await handler(req);
+} catch (e: any) {
+  console.error(e);
+  throw e;
+}
+
+// CLEAN — catch only where you add value; the error is unknown, not any
+try {
+  await handler(req);
+} catch (e) {
+  if (e instanceof ValidationError) return res.status(400).json(e.detail);
+  throw e; // the boundary logger handles the rest
+}
+```
+
+Lint: `@typescript-eslint/only-throw-error`,
+`use-unknown-in-catch-callback-variable`.
+
+## 15. `useEffect` for derived state (React)
+
+Effects reached for to compute values or chain fetches.
+
+```typescript
+// SLOP — derived state via effect
+const [fullName, setFullName] = useState("");
+useEffect(() => { setFullName(`${first} ${last}`); }, [first, last]);
+
+// CLEAN — derive during render
+const fullName = `${first} ${last}`;
+```
+
+No lint catches this (`react-hooks/exhaustive-deps` doesn't) — review by hand.
+See react.dev "You Might Not Need an Effect".
+
+## Sources
+
+- typescript-eslint `strict-type-checked` config + rule docs — ground truth for every rule named above
+- Effective TypeScript, 2nd ed. (Vanderkam, 2024) — ch. 5 on narrowing `any`'s scope
+- arXiv 2602.17955 — empirical AI-vs-human PR comparison (`!`/`as` overuse)

--- a/skills/age/references/dimensions.md
+++ b/skills/age/references/dimensions.md
@@ -228,7 +228,9 @@ Recommendation shape: "Extract `<sub-function>`" / "Inline `<one-call helper>`" 
 
 ### deslop
 
-Look for: dead code, AI tells (generic catches, useless docstrings, "// TODO: implement"), duplicated logic, copy-paste-with-variation, vague names.
+Look for: dead code, AI tells (generic catches, useless docstrings, "// TODO: implement", placeholder/apology comments like "// in a real implementation"), duplicated logic, copy-paste-over-reuse, vague or container-typed names (`user_data_dictionary`), convention blindness (reimplementing an existing repo utility from scratch), fake modularity (single-function utils file, God class spread thin), lint-suppression band-aids (`# noqa` / `@ts-ignore` / `#[allow(...)]` / `//nolint`) masking the real fix, phantom edge-case handling for inputs nobody can name, cargo-cult boilerplate, over-abstraction for one consumer, test bloat (shallow near-duplicate tests), partial shell strict mode (`set -e` without `-uo pipefail`).
+
+Per-language pattern catalogs with lint-rule mappings live in `deslop-rust.md` / `deslop-typescript.md` / `deslop-python.md` / `deslop-shell.md` / `deslop-go.md` (same directory).
 
 | Base | Trigger |
 | --- | --- |
@@ -242,7 +244,7 @@ Boundaries: correctness (AI-residue claim to deslop, silent-failure to correctne
 
 No default `blocker` row.
 
-Recommendation shape: "Delete dead branch at <line>" / "Reuse `<existing-helper>`" / "Extract shared `<helper>` from the two near-duplicate blocks" / "Rename `data` to `<noun>`".
+Recommendation shape: "Delete dead branch at <line>" / "Reuse `<existing-helper>`" / "Extract shared `<helper>` from the two near-duplicate blocks" / "Rename `data` to `<noun>`" / "Remove `<allow/noqa/ts-ignore>` and fix the underlying `<lint-rule>`" / "Delete the placeholder comment at <line> and implement the real branch".
 
 ### assertions
 


### PR DESCRIPTION
## What

Enriches the `/age` review skill's **deslop** dimension with sourced, per-language slop-pattern catalogs.

- **Five new reference catalogs** under `skills/age/references/`: `deslop-rust.md`, `deslop-typescript.md`, `deslop-python.md`, `deslop-shell.md`, `deslop-go.md`. Each pattern is mapped to the lint rule that catches it (clippy / typescript-eslint / ruff / ShellCheck) or cited to an empirical source; speculative, unsourced tells were excluded upstream.
- **`dimensions.md` `### deslop`** — the "Look for" list expands from one generic line to the full cross-language tell set (convention blindness, copy-paste-over-reuse, fake modularity, placeholder/apology comments, phantom edge-case handling, lint-suppression band-aids, test bloat, partial shell strict mode, …), plus a pointer to the per-language catalogs and two new recommendation shapes. Severity table and all other dimensions unchanged.
- **`SKILL.md`** — one grouped reference-list entry registering the catalogs.

## Why

The deslop dimension's rubric was a single generic sentence; reviewers had no language-specific evidence base. These catalogs give the dimension lint-rule-grounded teeth per language, ported from research-backed pattern work (five parallel research passes; only lint-backed or empirically sourced patterns kept).

## Verification

- `just check`: lint + full test suite green; `docs-build` (Starlight) exit 0, 81 pages.
- Fidelity check: catalog bodies verified byte-identical to their sources below the reframed intros; all patterns, lint mappings, and citations intact. One deliberate reword (`deslop-rust.md:493`) drops a harness-specific tooling reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)