### PR TITLE
feat(docs): fold skill references into single pages with h2 left-nav TOC

### DIFF
--- a/.hallouminate/wiki/adr/index.md
+++ b/.hallouminate/wiki/adr/index.md
@@ -6,5 +6,7 @@
 - [codex-omp-portability-001](./codex-omp-portability-001.md) — ADR: Shared harness portability reference
 - [culture-wheypoint-collaboration-001](./culture-wheypoint-collaboration-001.md) — ADR: /culture delegates its end-of-session artifact to /wheypoint
 - [hard-cheese-retained-001](./hard-cheese-retained-001.md) — ADR: hard-cheese retained despite local zero-use signal
+- [skill-docs-single-page-001](./skill-docs-single-page-001.md) — ADR-001: Fold skill references into one docs page instead of separate sub-pages  [status: accepted]
+- [skill-docs-single-page-002](./skill-docs-single-page-002.md) — ADR-002: Left-nav heading TOC is h2-only, via a custom Starlight Sidebar override  [status: accepted]
 - [starlight-docs-cutover-001](./starlight-docs-cutover-001.md) — ADR: Starlight docs cutover
 <!-- HALLOUMINATE:INDEX-END -->

--- a/.hallouminate/wiki/adr/skill-docs-single-page-001.md
+++ b/.hallouminate/wiki/adr/skill-docs-single-page-001.md
@@ -1,0 +1,8 @@
+# ADR-001: Fold skill references into one docs page instead of separate sub-pages  [status: accepted]
+
+- **Context:** Starlight docs (`scripts/gen_docs.py`) rendered each `skills/<name>/references/*.md` as a standalone sidebar sub-page under a per-skill collapsible group (`Overview` + one page per reference). Readers saw pages like "Context isolation" with no cue they belonged to `briesearch`, and each skill's material was fragmented. Skill *source* keeps references as separate files on purpose (agents load them on-demand), so the fix must live in docs generation only.
+- **Decision:** Fold every `references/*.md` into its skill's single generated page as appended sections (`# H1 → ##`, internal headings bumped one level), rewrite reference links to intra-page anchors, and collapse the per-skill sidebar group to one flat link.
+- **Alternatives considered:**
+  - *Drop references from the site* — simplest, but loses genuinely useful docs (routing decision trees, evals, safety rules) and leaves a thin TOC.
+  - *Keep sub-pages, only restyle the sidebar* — doesn't satisfy "one page each"; the disorientation persists.
+- **Consequences:** Larger pages (mold 11 refs, age 9, cheese 7). Navigation shifts to a left-nav heading TOC (ADR-002). Skill source tree untouched — `test_reference_resolution.py` stays green; `test_gen_docs.py`'s sub-page-contract classes are rewritten.

--- a/.hallouminate/wiki/adr/skill-docs-single-page-002.md
+++ b/.hallouminate/wiki/adr/skill-docs-single-page-002.md
@@ -1,0 +1,9 @@
+# ADR-002: Left-nav heading TOC is h2-only, via a custom Starlight Sidebar override  [status: accepted]
+
+- **Context:** The user wants a skill page's section headings to appear as a table of contents under its link in the LEFT sidebar, only when that skill is the active page. Research settled the Starlight (`@astrojs/starlight` ^0.41.3) mechanics: anchor-link sidebar groups never auto-expand (`isCurrent` does an exact pathname compare including the fragment, and the server-side pathname has no hash), and a sidebar entry is strictly a link XOR a group. There is no built-in option to render the page TOC in the left nav.
+- **Decision:** (1) Render the TOC at **h2 only**. (2) Implement it with a custom `src/components/Sidebar.astro` override wired via `astro.config.mjs` `components.Sidebar`, reading `Astro.locals.starlightRoute.{sidebar, toc}`, matching the active page's link and replacing it with an expanded group of `toc` h2 anchors. Primary path mutates the sidebar tree then renders `<Default />`; fallback renders the tree directly if mutation doesn't propagate.
+- **Alternatives considered:**
+  - *h2 + h3 TOC* — richer but long (mold ≈ 60+ entries) and exposes duplicate-h3-slug collisions across folded refs.
+  - *Declarative anchor-item groups* — ruled out by research (no auto-expand, link XOR group).
+  - *Rely on the right-hand "On this page" TOC* — doesn't meet "under the link on the left."
+- **Consequences:** TOC entries come from `route.toc` (Starlight's real post-dedupe slugs), so duplicate folded headings never yield a wrong anchor. A first `docs:build` settles whether the `<Default />` mutation path or the direct-render fallback is needed.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -24,6 +24,9 @@ export default defineConfig({
         alt: 'easy-cheese',
       },
       sidebar,
+      components: {
+        Sidebar: './src/components/Sidebar.astro',
+      },
       customCss: ['./src/styles/cheese.css'],
       social: [
         {

--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ test:
     python3 -m pytest tests/fanout/python -q
     python3 -m pytest tests/hard-cheese/python -q
     python3 -m pytest tests/pasteurize/python -q
-    node --test tests/js/**/*.test.mjs
+    node --test 'tests/js/**/*.test.mjs'
     bats tests/bash/test_install.bats
     bats tests/fanout/bash/test_pr_plan_to_branches.bats
 

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ export PYTEST_DISABLE_PLUGIN_AUTOLOAD := "1"
 @default:
     just --list
 
-# Run all tests (skill validators + melt + shared + fan-out suites + bash install tests + fan-out bats)
+# Run all tests (skill validators + melt + shared + fan-out suites + bash install tests + fan-out bats + JS)
 test:
     python3 .github/scripts/test_validate_skills.py -v
     python3 .github/scripts/validate_skills.py
@@ -19,6 +19,7 @@ test:
     python3 -m pytest tests/fanout/python -q
     python3 -m pytest tests/hard-cheese/python -q
     python3 -m pytest tests/pasteurize/python -q
+    node --test tests/js/**/*.test.mjs
     bats tests/bash/test_install.bats
     bats tests/fanout/bash/test_pr_plan_to_branches.bats
 

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 import shutil
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Callable
@@ -41,7 +41,6 @@ class GeneratedPage:
     title: str
     slug: str
     source_rel: str | None
-    refs: list["GeneratedPage"] = field(default_factory=list)
 
 
 def parse_frontmatter(text: str) -> tuple[dict, str]:
@@ -92,11 +91,6 @@ def _read_text(path: Path) -> str:
 
 def _strip_md_suffix(path: str) -> str:
     return path[:-3] if path.endswith(".md") else path
-
-
-def _route_path_for_md(path: str) -> str:
-    route = _strip_md_suffix(path)
-    return f"{route}/" if route else ""
 
 
 def _doc_path_for_slug(slug: str) -> str:
@@ -173,21 +167,60 @@ def convert_mkdocs_admonitions(markdown: str) -> str:
     return ADMONITION_RE.sub(repl, markdown)
 
 
+# github-slugger (the slugger Starlight's markdown renderer uses to assign
+# heading ids) applied to this repo's heading titles: lowercase, drop every
+# char that is not a word char / hyphen / space, then turn each space into a
+# hyphen. It KEEPS underscores and does NOT collapse repeated separators, which
+# is what github-slugger does on these ASCII titles (e.g. "tilth_write JSON
+# cookbook" -> "tilth_write-json-cookbook"; "Cascade stages \u2014 branch-specific
+# steps" -> "cascade-stages--branch-specific-steps"). Verified byte-for-byte
+# against the installed github-slugger over every real heading title
+# (tests/python/test_gen_docs.py::TestHeadingSlug pins the golden cases).
+_HEADING_SLUG_STRIP_RE = re.compile(r"[^\w\- ]", re.UNICODE)
+
+
+def _heading_slug(text: str) -> str:
+    return _HEADING_SLUG_STRIP_RE.sub("", text.lower()).replace(" ", "-")
+
+
+def _ref_title(skill_name: str, ref_stem: str) -> str:
+    return _ref_title_cached(str(SKILLS_DIR), skill_name, ref_stem)
+
+
+@lru_cache(maxsize=None)
+def _ref_title_cached(skills_dir: str, skill_name: str, ref_stem: str) -> str:
+    ref_path = Path(skills_dir) / skill_name / "references" / f"{ref_stem}.md"
+    try:
+        text = ref_path.read_text(encoding="utf-8")
+    except OSError:
+        return _heading_slug(ref_stem.replace("-", " "))
+    meta, body = parse_frontmatter(text)
+    title = meta.get("title") or _first_h1(body) or ref_stem.replace("-", " ").capitalize()
+    return _heading_slug(title)
+
+
+_ref_title.cache_clear = _ref_title_cached.cache_clear
+
+
 def rewrite_skill_link(url: str, skill_name: str) -> str:
     if _is_external(url):
         return url
     path, anchor = _split_anchor(url)
 
-    if path.startswith("references/"):
-        return f"{_route_path_for_md(path)}{anchor}"
+    m = re.match(r"^references/(.+)\.md$", path)
+    if m:
+        return anchor if anchor else f"#{_ref_title(skill_name, m.group(1))}"
 
     m = re.match(r"^\.\./([^/]+)/SKILL\.md$", path)
     if m:
         return f"../{m.group(1)}/{anchor}"
 
-    m = re.match(r"^\.\./([^/]+)/references/(.+\.md)$", path)
+    m = re.match(r"^\.\./([^/]+)/references/(.+)\.md$", path)
     if m:
-        return f"../{m.group(1)}/references/{_route_path_for_md(m.group(2))}{anchor}"
+        other_skill, stem = m.group(1), m.group(2)
+        if anchor:
+            return f"../{other_skill}/{anchor}"
+        return f"../{other_skill}/#{_ref_title(other_skill, stem)}"
 
     m = re.match(r"^\.\./\.\./([A-Z_]+\.md)$", path)
     if m and m.group(1) in ROOT_DOC_MAP:
@@ -203,23 +236,26 @@ def rewrite_ref_link(url: str, skill_name: str) -> str:
         return url
     path, anchor = _split_anchor(url)
 
-
-    if re.match(r"^[^/]+\.md$", path):
-        return f"../{_route_path_for_md(path)}{anchor}"
+    m = re.match(r"^([^/]+)\.md$", path)
+    if m:
+        return anchor if anchor else f"#{_ref_title(skill_name, m.group(1))}"
     if path == "../SKILL.md":
-        return f"../../{anchor}"
+        return anchor if anchor else "#"
 
     m = re.match(r"^\.\./\.\./([^/]+)/SKILL\.md$", path)
     if m:
-        return f"../../../{m.group(1)}/{anchor}"
+        return f"../{m.group(1)}/{anchor}"
 
-    m = re.match(r"^\.\./\.\./([^/]+)/references/(.+\.md)$", path)
+    m = re.match(r"^\.\./\.\./([^/]+)/references/(.+)\.md$", path)
     if m:
-        return f"../../../{m.group(1)}/references/{_route_path_for_md(m.group(2))}{anchor}"
+        other_skill, stem = m.group(1), m.group(2)
+        if anchor:
+            return f"../{other_skill}/{anchor}"
+        return f"../{other_skill}/#{_ref_title(other_skill, stem)}"
 
     m = re.match(r"^\.\./\.\./\.\./([A-Z_]+\.md)$", path)
     if m and m.group(1) in ROOT_DOC_MAP:
-        return f"../../../../{ROOT_DOC_MAP[m.group(1)]}{anchor}"
+        return f"../../{ROOT_DOC_MAP[m.group(1)]}{anchor}"
     if path == "../../../LICENSE":
         return LICENSE_URL
 
@@ -241,9 +277,12 @@ def rewrite_root_passthrough_link(url: str) -> str:
     if m:
         return f"../skills/{m.group(1)}/{anchor}"
 
-    m = re.match(r"^skills/([^/]+)/references/(.+\.md)$", stripped)
+    m = re.match(r"^skills/([^/]+)/references/(.+)\.md$", stripped)
     if m:
-        return f"../skills/{m.group(1)}/references/{_route_path_for_md(m.group(2))}{anchor}"
+        other_skill, stem = m.group(1), m.group(2)
+        if anchor:
+            return f"../skills/{other_skill}/{anchor}"
+        return f"../skills/{other_skill}/#{_ref_title(other_skill, stem)}"
 
     return url
 
@@ -258,6 +297,35 @@ def apply_link_rewrite(text: str, rewriter: Callable[[str], str]) -> str:
         return f"[{label}]({rewriter(url)}{title})"
 
     return LINK_RE.sub(repl, NESTED_IMAGE_LINK_RE.sub(image_repl, text))
+
+
+HEADING_RE = re.compile(r"^(#{1,5})(\s)", re.MULTILINE)
+
+
+def _bump_headings(text: str) -> str:
+    return HEADING_RE.sub(lambda m: "#" + m.group(1) + m.group(2), text)
+
+
+def fold_references(skill_name: str, refs_dir: Path) -> tuple[str, dict[str, str]]:
+    titles: dict[str, str] = {}
+    sections: list[str] = []
+    if not refs_dir.is_dir():
+        return "", titles
+
+    for ref in sorted(p for p in refs_dir.iterdir() if p.is_file()):
+        if ref.suffix.lower() != ".md":
+            continue
+        stem = ref.stem
+        meta, body = parse_frontmatter(ref.read_text(encoding="utf-8"))
+        body = apply_link_rewrite(body, lambda url: rewrite_ref_link(url, skill_name))
+        body = convert_mkdocs_admonitions(body)
+        title = meta.get("title") or _first_h1(body) or stem.replace("-", " ").capitalize()
+        titles[stem] = title
+        body = re.sub(r"^#\s[^\n]*\n+", "", body.lstrip(), count=1)
+        body = _bump_headings(body)
+        sections.append(f"## {title}\n\n{body.rstrip()}\n")
+
+    return "\n\n".join(sections), titles
 
 
 def emit_skill_page(skill_dir: Path) -> GeneratedPage | None:
@@ -288,38 +356,17 @@ def emit_skill_page(skill_dir: Path) -> GeneratedPage | None:
     body = convert_mkdocs_admonitions(body)
 
     refs_dir = skill_dir / "references"
-    refs: list[GeneratedPage] = []
-    if refs_dir.is_dir():
-        for ref in sorted(p for p in refs_dir.iterdir() if p.is_file()):
-            ref_rel = ref.relative_to(REPO_ROOT).as_posix()
-            if ref.suffix.lower() != ".md":
-                # Non-Markdown references aren't rendered by Starlight; skip them.
-                # The parent page links to the skill's own SKILL.md source.
-                continue
-
-            out = f"skills/{name}/references/{ref.name}"
-            ref_text = ref.read_text(encoding="utf-8")
-            ref_meta, ref_body = parse_frontmatter(ref_text)
-            ref_body = apply_link_rewrite(ref_body, lambda url: rewrite_ref_link(url, name))
-            ref_body = convert_mkdocs_admonitions(ref_body)
-            title = ref_meta.get("title") or _first_h1(ref_body) or ref.stem.replace("-", " ").capitalize()
-            ref_page = write_doc(
-                out,
-                ref_body,
-                title=title,
-                description=ref_meta.get("description"),
-                source_rel=ref_rel,
-            )
-            refs.append(ref_page)
+    folded, _ = fold_references(name, refs_dir)
+    full_body = body.rstrip() + "\n\n" + folded if folded else body
 
     page = write_doc(
         page_path,
-        header + body,
+        header + full_body,
         title=f"/{name}",
         description=first_sentence(description),
         source_rel=src_rel,
     )
-    return GeneratedPage(page.title, page.slug, page.source_rel, refs)
+    return GeneratedPage(page.title, page.slug, page.source_rel)
 
 
 def emit_skills_index(skills: list[GeneratedPage]) -> GeneratedPage:
@@ -433,10 +480,10 @@ def _first_h1(text: str) -> str:
     return ""
 
 
-def _sidebar_link(page: GeneratedPage, label: str | None = None) -> dict[str, str]:
+def _sidebar_link(page: GeneratedPage) -> dict[str, str]:
     item = {"slug": page.slug}
-    if label or page.title:
-        item["label"] = label or page.title
+    if page.title:
+        item["label"] = page.title
     return item
 
 
@@ -447,19 +494,7 @@ def emit_sidebar(
 ) -> None:
     skill_items: list[dict] = [{"label": "Skills index", "slug": "skills"}]
     for skill in skills:
-        if skill.refs:
-            skill_items.append(
-                {
-                    "label": skill.title,
-                    "items": [
-                        _sidebar_link(skill, "Overview"),
-                        *[_sidebar_link(ref) for ref in skill.refs],
-                    ],
-                    "collapsed": True,
-                }
-            )
-        else:
-            skill_items.append(_sidebar_link(skill))
+        skill_items.append(_sidebar_link(skill))
 
     start_items = [{"label": "Home", "slug": ""}]
     if install:
@@ -492,7 +527,7 @@ def clean_generated_docs() -> None:
             child.unlink()
     if SIDEBAR_PATH.exists():
         SIDEBAR_PATH.unlink()
-
+    _ref_title.cache_clear()
 
 def main() -> None:
     clean_generated_docs()

--- a/scripts/gen_docs.py
+++ b/scripts/gen_docs.py
@@ -303,7 +303,16 @@ HEADING_RE = re.compile(r"^(#{1,5})(\s)", re.MULTILINE)
 
 
 def _bump_headings(text: str) -> str:
-    return HEADING_RE.sub(lambda m: "#" + m.group(1) + m.group(2), text)
+    """Demote markdown headings one level, leaving fenced code blocks untouched."""
+    lines = text.split("\n")
+    in_fence = False
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            lines[i] = HEADING_RE.sub(lambda m: "#" + m.group(1) + m.group(2), line)
+    return "\n".join(lines)
 
 
 def fold_references(skill_name: str, refs_dir: Path) -> tuple[str, dict[str, str]]:

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -1,0 +1,14 @@
+---
+import Default from '@astrojs/starlight/components/Sidebar.astro';
+import { injectToc } from './sidebar-toc.mjs';
+
+// Mutation path is active: Default reads Astro.locals.starlightRoute.sidebar
+// internally, so splicing the h2 group in before rendering <Default />
+// propagates through the stock SidebarPersister/SidebarSublist chain.
+const { starlightRoute } = Astro.locals;
+const { sidebar, toc } = starlightRoute;
+
+starlightRoute.sidebar = injectToc(sidebar, toc?.items, (entry) => entry.isCurrent);
+---
+
+<Default />

--- a/src/components/sidebar-toc.mjs
+++ b/src/components/sidebar-toc.mjs
@@ -1,0 +1,57 @@
+// Pure tree-transform for the h2 left-nav TOC override (ADR-002). No Astro /
+// Astro.locals access here -- Sidebar.astro supplies the sidebar tree, the
+// toc items, and the active-page predicate; this module only mutates the
+// tree, so it is testable with node's built-in test runner.
+
+// Starlight's generateToC always prepends a synthetic depth-2 title node
+// (`{depth: 2, slug: '_top', text: 'Overview'}`) to every page's toc.items,
+// even though it isn't a real content heading. Left in, it renders a
+// redundant "Overview -> #_top" entry duplicating the skill link above it.
+const TOC_TITLE_SLUG = '_top';
+
+// ADR-002 scopes the TOC to skill pages (route `/skills/<name>/`), not the
+// skills index (`/skills/`) or other pages with h2s (README, Install, ...).
+export function isSkillPageHref(href) {
+	return /\/skills\/[^/]+\/?$/.test(href ?? '');
+}
+
+export function injectToc(sidebar, tocItems, isActive) {
+	const h2Headings = (tocItems ?? []).filter(
+		(item) => item.depth === 2 && item.slug !== TOC_TITLE_SLUG,
+	);
+
+	function walk(entries) {
+		return entries.map((entry) => {
+			if (entry.type === 'group') {
+				return { ...entry, entries: walk(entry.entries) };
+			}
+			if (
+				entry.type === 'link' &&
+				isActive(entry) &&
+				isSkillPageHref(entry.href) &&
+				h2Headings.length > 0
+			) {
+				return {
+					type: 'group',
+					label: entry.label,
+					collapsed: false,
+					badge: undefined,
+					entries: [
+						entry,
+						...h2Headings.map((heading) => ({
+							type: 'link',
+							label: heading.text,
+							href: `${entry.href}#${heading.slug}`,
+							isCurrent: false,
+							badge: undefined,
+							attrs: {},
+						})),
+					],
+				};
+			}
+			return entry;
+		});
+	}
+
+	return walk(sidebar);
+}

--- a/tests/js/sidebar-toc.test.mjs
+++ b/tests/js/sidebar-toc.test.mjs
@@ -1,0 +1,110 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { injectToc, isSkillPageHref } from '../../src/components/sidebar-toc.mjs';
+
+const isActive = (entry) => entry.isCurrent;
+
+function skillLink(href, { isCurrent = false, label = 'label' } = {}) {
+	return { type: 'link', label, href, isCurrent, badge: undefined, attrs: {} };
+}
+
+test('active skill link with h2s expands into a group excluding the synthetic _top node', () => {
+	const sidebar = [
+		{
+			type: 'group',
+			label: 'Skills',
+			entries: [skillLink('/skills/age/', { isCurrent: true, label: '/age' })],
+		},
+	];
+	const tocItems = [
+		{ depth: 2, slug: '_top', text: 'Overview' },
+		{ depth: 2, slug: 'voice', text: 'Voice' },
+		{ depth: 2, slug: 'formatting', text: 'Formatting' },
+	];
+
+	const result = injectToc(sidebar, tocItems, isActive);
+
+	const group = result[0].entries[0];
+	assert.equal(group.type, 'group');
+	assert.equal(group.label, '/age');
+	assert.equal(group.entries.length, 3);
+	assert.deepEqual(group.entries[0], skillLink('/skills/age/', { isCurrent: true, label: '/age' }));
+	assert.deepEqual(group.entries[1], {
+		type: 'link',
+		label: 'Voice',
+		href: '/skills/age/#voice',
+		isCurrent: false,
+		badge: undefined,
+		attrs: {},
+	});
+	assert.deepEqual(group.entries[2], {
+		type: 'link',
+		label: 'Formatting',
+		href: '/skills/age/#formatting',
+		isCurrent: false,
+		badge: undefined,
+		attrs: {},
+	});
+	assert.ok(!group.entries.some((e) => e.href?.endsWith('#_top')));
+});
+
+test('page with no h2s leaves the tree unchanged', () => {
+	const sidebar = [
+		{
+			type: 'group',
+			label: 'Skills',
+			entries: [skillLink('/skills/age/', { isCurrent: true, label: '/age' })],
+		},
+	];
+
+	const result = injectToc(sidebar, [], isActive);
+
+	assert.deepEqual(result, sidebar);
+});
+
+test('undefined toc items does not throw and leaves the tree unchanged', () => {
+	const sidebar = [
+		{
+			type: 'group',
+			label: 'Skills',
+			entries: [skillLink('/skills/age/', { isCurrent: true, label: '/age' })],
+		},
+	];
+
+	const result = injectToc(sidebar, undefined, isActive);
+
+	assert.deepEqual(result, sidebar);
+});
+
+test('non-active links stay flat even when h2s exist', () => {
+	const sidebar = [
+		{
+			type: 'group',
+			label: 'Skills',
+			entries: [skillLink('/skills/age/', { isCurrent: false, label: '/age' })],
+		},
+	];
+	const tocItems = [{ depth: 2, slug: 'voice', text: 'Voice' }];
+
+	const result = injectToc(sidebar, tocItems, isActive);
+
+	assert.deepEqual(result, sidebar);
+});
+
+test('active README-style page with h2s is not expanded (skill pages only, ADR-002)', () => {
+	const sidebar = [
+		{
+			type: 'group',
+			label: 'Project',
+			entries: [skillLink('/readme/', { isCurrent: true, label: 'README' })],
+		},
+	];
+	const tocItems = [{ depth: 2, slug: 'install', text: 'Install' }];
+
+	const result = injectToc(sidebar, tocItems, isActive);
+
+	assert.deepEqual(result, sidebar);
+	assert.equal(isSkillPageHref('/readme/'), false);
+	assert.equal(isSkillPageHref('/skills/age/'), true);
+	assert.equal(isSkillPageHref('/skills/'), false);
+});

--- a/tests/python/test_gen_docs.py
+++ b/tests/python/test_gen_docs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import re
 import shutil
 from pathlib import Path
@@ -32,6 +33,7 @@ def isolated_docs(gen_docs, tmp_path, monkeypatch):
     monkeypatch.setattr(gen_docs, "SKILLS_DIR", tmp_path / "skills")
     monkeypatch.setattr(gen_docs, "CONTENT_ROOT", tmp_path / "src" / "content" / "docs")
     monkeypatch.setattr(gen_docs, "SIDEBAR_PATH", tmp_path / "src" / "sidebar.mjs")
+    gen_docs._ref_title.cache_clear()
     return tmp_path
 
 
@@ -45,11 +47,13 @@ class TestRewriteSkillLink:
         ):
             assert gen_docs.rewrite_skill_link(url, "cook") == url
 
-    def test_local_reference_resolves_from_skill_route(self, gen_docs):
-        assert gen_docs.rewrite_skill_link("references/foo.md", "cook") == "references/foo/"
+    def test_local_reference_resolves_to_anchor(self, gen_docs):
+        # No SKILLS_DIR fixture populated here — title resolution degrades to
+        # a stem-derived slug.
+        assert gen_docs.rewrite_skill_link("references/foo.md", "cook") == "#foo"
 
-    def test_local_reference_keeps_anchor(self, gen_docs):
-        assert gen_docs.rewrite_skill_link("references/foo.md#part", "cook") == "references/foo/#part"
+    def test_local_reference_with_explicit_anchor_overrides_title(self, gen_docs):
+        assert gen_docs.rewrite_skill_link("references/foo.md#part", "cook") == "#part"
 
     def test_cross_skill_skill_md_routes_to_sibling_skill(self, gen_docs):
         assert gen_docs.rewrite_skill_link("../press/SKILL.md", "cook") == "../press/"
@@ -57,8 +61,11 @@ class TestRewriteSkillLink:
     def test_cross_skill_skill_md_with_anchor(self, gen_docs):
         assert gen_docs.rewrite_skill_link("../press/SKILL.md#auto-mode", "cook") == "../press/#auto-mode"
 
-    def test_cross_skill_reference(self, gen_docs):
-        assert gen_docs.rewrite_skill_link("../press/references/quality-gates.md", "cook") == "../press/references/quality-gates/"
+    def test_cross_skill_reference_resolves_to_anchor(self, gen_docs):
+        assert gen_docs.rewrite_skill_link("../press/references/quality-gates.md", "cook") == "../press/#quality-gates"
+
+    def test_cross_skill_reference_with_explicit_anchor_overrides_title(self, gen_docs):
+        assert gen_docs.rewrite_skill_link("../press/references/quality-gates.md#x", "cook") == "../press/#x"
 
     def test_root_doc_resolves_to_root_route(self, gen_docs):
         assert gen_docs.rewrite_skill_link("../../CONTRIBUTING.md", "cook") == "../../contributing/"
@@ -71,28 +78,58 @@ class TestRewriteSkillLink:
     def test_unknown_path_is_untouched(self, gen_docs):
         assert gen_docs.rewrite_skill_link("../../some/other/file.md", "cook") == "../../some/other/file.md"
 
+    def test_cross_skill_reference_resolves_via_sibling_title_not_stem_fallback(self, gen_docs, isolated_docs):
+        # Positive path for _ref_title: a REAL sibling skill+ref exists, so the
+        # anchor must come from that ref's actual title, not the stem-derived
+        # fallback slug the degrade-path tests above exercise. The em-dash title
+        # coincidentally slugs to the same string as the stem fallback would for
+        # a plain "quality-gates" stem, so also assert against a stem-diverging
+        # title to prove real resolution, not a fallback that happens to match.
+        press_refs = isolated_docs / "skills" / "press" / "references"
+        press_refs.mkdir(parents=True)
+        (press_refs / "quality-gates.md").write_text(
+            "---\ntitle: Quality Gates — the bar\n---\n\n# Ignored\n\nBody.\n",
+            encoding="utf-8",
+        )
+        gen_docs._ref_title.cache_clear()
+
+        result = gen_docs.rewrite_skill_link("../press/references/quality-gates.md", "cook")
+
+        assert result == "../press/#quality-gates--the-bar"
+        stem_fallback = f"#{gen_docs._heading_slug('quality-gates'.replace('-', ' '))}"
+        assert result != f"../press/{stem_fallback}"
+
 
 class TestRewriteRefLink:
     def test_external_urls_pass_through(self, gen_docs):
         for url in ("https://example.com", "mailto:x@y.z", "#anchor"):
             assert gen_docs.rewrite_ref_link(url, "press") == url
 
-    def test_sibling_reference(self, gen_docs):
-        assert gen_docs.rewrite_ref_link("adr.md", "mold") == "../adr/"
+    def test_sibling_reference_resolves_to_anchor(self, gen_docs):
+        assert gen_docs.rewrite_ref_link("foo.md", "mold") == "#foo"
 
-    def test_sibling_skill_md(self, gen_docs):
-        assert gen_docs.rewrite_ref_link("../SKILL.md", "press") == "../../"
-        assert gen_docs.rewrite_ref_link("../SKILL.md#auto", "press") == "../../#auto"
+    def test_sibling_reference_with_explicit_anchor_overrides_title(self, gen_docs):
+        assert gen_docs.rewrite_ref_link("foo.md#part", "mold") == "#part"
+
+    def test_sibling_skill_md_points_to_top_of_same_page(self, gen_docs):
+        assert gen_docs.rewrite_ref_link("../SKILL.md", "press") == "#"
+        assert gen_docs.rewrite_ref_link("../SKILL.md#auto", "press") == "#auto"
 
     def test_cross_skill_skill_md(self, gen_docs):
-        assert gen_docs.rewrite_ref_link("../../cook/SKILL.md", "press") == "../../../cook/"
+        assert gen_docs.rewrite_ref_link("../../cook/SKILL.md", "press") == "../cook/"
 
-    def test_cross_skill_reference(self, gen_docs):
-        assert gen_docs.rewrite_ref_link("../../cook/references/foo.md", "press") == "../../../cook/references/foo/"
+    def test_cross_skill_skill_md_with_anchor(self, gen_docs):
+        assert gen_docs.rewrite_ref_link("../../cook/SKILL.md#auto", "press") == "../cook/#auto"
+
+    def test_cross_skill_reference_resolves_to_anchor(self, gen_docs):
+        assert gen_docs.rewrite_ref_link("../../cook/references/foo.md", "press") == "../cook/#foo"
+
+    def test_cross_skill_reference_with_explicit_anchor_overrides_title(self, gen_docs):
+        assert gen_docs.rewrite_ref_link("../../cook/references/foo.md#x", "press") == "../cook/#x"
 
     def test_root_doc(self, gen_docs):
-        assert gen_docs.rewrite_ref_link("../../../CONTRIBUTING.md", "press") == "../../../../contributing/"
-        assert gen_docs.rewrite_ref_link("../../../README.md", "press") == "../../../../readme/"
+        assert gen_docs.rewrite_ref_link("../../../CONTRIBUTING.md", "press") == "../../contributing/"
+        assert gen_docs.rewrite_ref_link("../../../README.md", "press") == "../../readme/"
 
     def test_license(self, gen_docs):
         assert gen_docs.rewrite_ref_link("../../../LICENSE", "press") == f"{gen_docs.REPO_URL}/blob/main/LICENSE"
@@ -115,7 +152,7 @@ class TestRewriteRootPassthroughLink:
         assert gen_docs.rewrite_root_passthrough_link("LICENSE") == f"{gen_docs.REPO_URL}/blob/main/LICENSE"
 
     def test_skill_reference(self, gen_docs):
-        assert gen_docs.rewrite_root_passthrough_link("skills/age/references/voice.md") == "../skills/age/references/voice/"
+        assert gen_docs.rewrite_root_passthrough_link("skills/age/references/voice.md") == "../skills/age/#voice"
 
     def test_shared_path_untouched(self, gen_docs):
         # shared/*.md docs moved to skills/cheese/references/; no rewrite branch remains.
@@ -296,8 +333,86 @@ class TestEmitInstallPage:
         assert "## gh skill" in body
 
 
+class TestHeadingSlug:
+    def test_lowercases_and_hyphenates(self, gen_docs):
+        assert gen_docs._heading_slug("Go De-slop Catalog") == "go-de-slop-catalog"
+
+    def test_strips_punctuation(self, gen_docs):
+        assert gen_docs._heading_slug("Auto Mode (v2)!") == "auto-mode-v2"
+
+    def test_does_not_collapse_separators(self, gen_docs):
+        # github-slugger turns each space into its own hyphen and never collapses
+        # repeats, so a run of spaces yields a run of hyphens.
+        assert gen_docs._heading_slug("Quality   Gates") == "quality---gates"
+
+    def test_keeps_underscores(self, gen_docs):
+        # Regression: a naive slugger strips underscores; github-slugger keeps them.
+        assert gen_docs._heading_slug("tilth_write JSON cookbook") == "tilth_write-json-cookbook"
+
+    def test_em_dash_leaves_double_hyphen(self, gen_docs):
+        # The space-em-dash-space idiom (`A — B`) drops the em-dash but keeps both
+        # surrounding spaces, so github-slugger emits a double hyphen.
+        assert gen_docs._heading_slug("Cascade stages — branch-specific steps") == "cascade-stages--branch-specific-steps"
+
+
+class TestFoldReferences:
+    def test_missing_refs_dir_returns_empty(self, gen_docs, isolated_docs):
+        folded, titles = gen_docs.fold_references("cook", isolated_docs / "skills" / "cook" / "references")
+        assert folded == ""
+        assert titles == {}
+
+    def test_promotes_h1_to_h2_and_bumps_inner_headings(self, gen_docs, isolated_docs):
+        refs_dir = isolated_docs / "skills" / "cook" / "references"
+        refs_dir.mkdir(parents=True)
+        (refs_dir / "gate.md").write_text(
+            "---\ntitle: Quality gates\n---\n"
+            "# Original H1\n\nIntro text.\n\n### Sub heading\n\nBody text.\n",
+            encoding="utf-8",
+        )
+
+        folded, titles = gen_docs.fold_references("cook", refs_dir)
+
+        assert "## Quality gates" in folded
+        assert "# Original H1" not in folded
+        assert "#### Sub heading" in folded
+        assert not re.search(r"(?m)^### Sub heading$", folded)
+        assert "Intro text." in folded
+        assert titles == {"gate": "Quality gates"}
+
+    def test_title_precedence_falls_back_to_first_h1_then_stem(self, gen_docs, isolated_docs):
+        refs_dir = isolated_docs / "skills" / "cook" / "references"
+        refs_dir.mkdir(parents=True)
+        (refs_dir / "first-h1.md").write_text("# From body\n\nBody.\n", encoding="utf-8")
+        (refs_dir / "no-heading.md").write_text("Just prose.\n", encoding="utf-8")
+
+        _, titles = gen_docs.fold_references("cook", refs_dir)
+
+        assert titles["first-h1"] == "From body"
+        assert titles["no-heading"] == "No heading"
+
+    def test_sections_are_sorted_by_filename(self, gen_docs, isolated_docs):
+        refs_dir = isolated_docs / "skills" / "cook" / "references"
+        refs_dir.mkdir(parents=True)
+        (refs_dir / "b.md").write_text("# B title\n\nB body.\n", encoding="utf-8")
+        (refs_dir / "a.md").write_text("# A title\n\nA body.\n", encoding="utf-8")
+
+        folded, _ = gen_docs.fold_references("cook", refs_dir)
+
+        assert folded.index("A title") < folded.index("B title")
+
+    def test_skips_non_markdown_files(self, gen_docs, isolated_docs):
+        refs_dir = isolated_docs / "skills" / "cook" / "references"
+        refs_dir.mkdir(parents=True)
+        (refs_dir / "diagram.png").write_bytes(b"not markdown")
+
+        folded, titles = gen_docs.fold_references("cook", refs_dir)
+
+        assert folded == ""
+        assert titles == {}
+
+
 class TestEmitSkillPage:
-    def test_writes_skill_and_nested_reference_pages(self, gen_docs, isolated_docs):
+    def test_writes_single_page_with_folded_reference_and_no_ref_files(self, gen_docs, isolated_docs):
         skill_dir = isolated_docs / "skills" / "cook"
         refs_dir = skill_dir / "references"
         refs_dir.mkdir(parents=True)
@@ -311,30 +426,21 @@ class TestEmitSkillPage:
         page = gen_docs.emit_skill_page(skill_dir)
 
         skill_out = isolated_docs / "src" / "content" / "docs" / "skills" / "cook.md"
-        ref_out = isolated_docs / "src" / "content" / "docs" / "skills" / "cook" / "references" / "gate.md"
-        assert page == gen_docs.GeneratedPage(
-            "/cook",
-            "skills/cook",
-            "skills/cook/SKILL.md",
-            [gen_docs.GeneratedPage("Gate", "skills/cook/references/gate", "skills/cook/references/gate.md")],
-        )
+        assert page == gen_docs.GeneratedPage("/cook", "skills/cook", "skills/cook/SKILL.md")
         skill_body = skill_out.read_text(encoding="utf-8")
         assert "title: /cook" in skill_body
         assert ":::note[Skill metadata]" in skill_body
         assert "- **Source:** [`skills/cook/SKILL.md`](https://github.com/paulnsorensen/easy-cheese/blob/main/skills/cook/SKILL.md)" in skill_body
-        assert "See [gate](references/gate/)." in skill_body
+        assert "See [gate](#gate)." in skill_body
+        assert "## Gate" in skill_body
+        assert "Back to [skill](#)." in skill_body
         assert "editUrl: https://github.com/paulnsorensen/easy-cheese/edit/main/skills/cook/SKILL.md" in skill_body
-        assert "Back to [skill](../../)." in ref_out.read_text(encoding="utf-8")
+        assert not (isolated_docs / "src" / "content" / "docs" / "skills" / "cook" / "references").exists()
 
 
 class TestEmitSidebar:
-    def test_writes_sidebar_module_with_nested_refs(self, gen_docs, isolated_docs):
-        skill = gen_docs.GeneratedPage(
-            "/age",
-            "skills/age",
-            "skills/age/SKILL.md",
-            [gen_docs.GeneratedPage("Voice", "skills/age/references/voice", "skills/age/references/voice.md")],
-        )
+    def test_writes_flat_sidebar_links(self, gen_docs, isolated_docs):
+        skill = gen_docs.GeneratedPage("/age", "skills/age", "skills/age/SKILL.md")
         project = gen_docs.GeneratedPage("README", "readme", "README.md")
         install = gen_docs.GeneratedPage("Install", "install", "README.md")
 
@@ -342,12 +448,29 @@ class TestEmitSidebar:
 
         out = (isolated_docs / "src" / "sidebar.mjs").read_text(encoding="utf-8")
         assert out.startswith("// Generated by scripts/gen_docs.py")
-        assert "export const sidebar" in out
-        assert '"label": "Skills"' in out
-        assert '"slug": "skills/age"' in out
-        assert '"slug": "skills/age/references/voice"' in out
-        assert '"label": "Install"' in out
-        assert "SUMMARY.md" not in out
+        sidebar = json.loads(out.split("export const sidebar = ", 1)[1].rstrip(";\n"))
+
+        skills_group = next(g for g in sidebar if g["label"] == "Skills")
+        assert skills_group["items"] == [
+            {"label": "Skills index", "slug": "skills"},
+            {"slug": "skills/age", "label": "/age"},
+        ]
+        start_group = next(g for g in sidebar if g["label"] == "Start")
+        assert {"label": "Install", "slug": "install"} in start_group["items"]
+
+    def test_skill_entries_have_no_items_overview_or_collapsed(self, gen_docs, isolated_docs):
+        skill = gen_docs.GeneratedPage("/age", "skills/age", "skills/age/SKILL.md")
+
+        gen_docs.emit_sidebar([skill], [], None)
+
+        out = (isolated_docs / "src" / "sidebar.mjs").read_text(encoding="utf-8")
+        sidebar = json.loads(out.split("export const sidebar = ", 1)[1].rstrip(";\n"))
+        skills_group = next(g for g in sidebar if g["label"] == "Skills")
+        skill_entry = next(item for item in skills_group["items"] if item.get("slug") == "skills/age")
+        assert "items" not in skill_entry
+        assert "collapsed" not in skill_entry
+        assert skill_entry == {"slug": "skills/age", "label": "/age"}
+
 
     def test_omits_install_link_when_no_install_page(self, gen_docs, isolated_docs):
         skill = gen_docs.GeneratedPage("/age", "skills/age", "skills/age/SKILL.md")
@@ -424,15 +547,24 @@ class TestMainGeneration:
         assert (root / "install.md").exists()
         assert (root / "skills" / "index.md").exists()
         assert (root / "skills" / "age.md").exists()
-        assert (root / "skills" / "age" / "references" / "voice.md").exists()
-        assert (root / "skills" / "age" / "references" / "formatting.md").exists()
+        assert not (root / "skills" / "age" / "references").exists()
         assert not (root / "shared").exists()
         assert (root / "readme.md").exists()
         assert (root / "contributing.md").exists()
         assert (isolated_docs / "src" / "sidebar.mjs").exists()
         assert not (root / "SUMMARY.md").exists()
+
+        age_body = (root / "skills" / "age.md").read_text(encoding="utf-8")
+        assert "## Voice" in age_body
+        assert "## Formatting" in age_body
+        assert "See [Voice](#voice)." in age_body
+
         generated_markdown = "\n".join(p.read_text(encoding="utf-8") for p in root.rglob("*.md"))
         assert not re.search(r"\]\((?!https?://|mailto:|#)[^)]+\.md(?:#[^)]*)?\)", generated_markdown)
+        # Non-.md dead routes: a reference sub-page URL leaking through would
+        # still 404 even though it has no .md suffix (the High-severity gap
+        # the `.md`-only guard above missed).
+        assert not re.search(r"\]\([^)]*references/[^)]*\)", generated_markdown)
         for page in root.rglob("*.md"):
             if page == root / "index.md":
                 continue  # authored homepage, not generated
@@ -443,11 +575,12 @@ class TestMainGeneration:
 class TestMainGenerationRealCheeseKernelDocs:
     """Integration-shaped check: the five real shared docs that moved to
     skills/cheese/references/ in the cheese-kernel-shared-refs change must
-    actually render under cheese's Starlight pages, and no src/content/docs/shared/
-    section may reappear. Copies the real repo files into the isolated tmp
-    tree rather than a synthetic fixture, so a doc that's dropped or renamed
-    in skills/cheese/references/ fails this test even if the synthetic
-    TestMainGeneration fixture above still passes."""
+    actually render as folded sections inside cheese's single Starlight page,
+    and no src/content/docs/shared/ section may reappear. Copies the real
+    repo files into the isolated tmp tree rather than a synthetic fixture, so
+    a doc that's dropped or renamed in skills/cheese/references/ fails this
+    test even if the synthetic TestMainGeneration fixture above still
+    passes."""
 
     MOVED_DOC_NAMES = (
         "formatting",
@@ -457,7 +590,7 @@ class TestMainGenerationRealCheeseKernelDocs:
         "skill-authoring",
     )
 
-    def test_moved_docs_render_under_cheese_pages_no_shared_dir(self, gen_docs, isolated_docs):
+    def test_moved_docs_fold_into_cheese_page_no_shared_dir(self, gen_docs, isolated_docs):
         real_cheese_dir = REPO_ROOT / "skills" / "cheese"
         real_refs_dir = real_cheese_dir / "references"
         for name in self.MOVED_DOC_NAMES:
@@ -477,7 +610,85 @@ class TestMainGenerationRealCheeseKernelDocs:
         gen_docs.main()
 
         root = isolated_docs / "src" / "content" / "docs"
-        for name in self.MOVED_DOC_NAMES:
-            out = root / "skills" / "cheese" / "references" / f"{name}.md"
-            assert out.is_file(), f"{name}.md did not render under skills/cheese/references/"
+        assert not (root / "skills" / "cheese" / "references").exists()
         assert not (root / "shared").exists()
+        cheese_body = (root / "skills" / "cheese.md").read_text(encoding="utf-8")
+        for name in self.MOVED_DOC_NAMES:
+            heading = re.compile(r"^## .+\n", re.MULTILINE)
+            assert heading.search(cheese_body), "expected at least one folded ## section"
+        assert cheese_body.count("## ") >= len(self.MOVED_DOC_NAMES)
+
+
+class TestAnchorResolution:
+    """End-to-end seam between the link rewriters and fold_references: an
+    emitted `](#anchor)` must resolve to a real folded heading, not just look
+    plausible in isolation. Regression this guards: a slugger divergence once
+    made references/tilth_write.md-style links resolve to nonexistent anchors
+    because the anchor-generating path and the heading-rendering path could
+    drift apart on underscore/em-dash handling. The generic
+    anchor-equals-heading-slug check alone would NOT catch a regression in
+    _heading_slug itself (both sides would recompute with the same regressed
+    function and still agree) -- the hardcoded literal anchor strings below are
+    what actually pin the underscore- and em-dash-idiom behavior; if
+    _heading_slug reverts to stripping underscores, EXPECTED_FOO_ANCHOR stops
+    appearing in the emitted links and those asserts fail.
+    """
+
+    EXPECTED_FOO_ANCHOR = "#tilth_write-json-cookbook"
+    EXPECTED_BAR_ANCHOR = "#cascade-stages--branch-specific-steps"
+
+    def test_emitted_anchors_resolve_to_real_folded_headings(self, gen_docs, isolated_docs):
+        skill_dir = isolated_docs / "skills" / "demo"
+        refs_dir = skill_dir / "references"
+        refs_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: demo\ndescription: Demo skill for anchor integration testing.\n---\n"
+            "# /demo\n\n"
+            "See the [tilth_write JSON cookbook](references/foo.md) for details, "
+            "or jump to [a specific section](references/bar.md#some-section) directly.\n",
+            encoding="utf-8",
+        )
+        (refs_dir / "foo.md").write_text(
+            "---\ntitle: tilth_write JSON cookbook\n---\n\n"
+            "# Ignored\n\nFoo body. See also [the bar](bar.md).\n",
+            encoding="utf-8",
+        )
+        (refs_dir / "bar.md").write_text(
+            "---\ntitle: Cascade stages — branch-specific steps\n---\n\n"
+            "# Ignored\n\nBar body.\n\n## Some section\n\n"
+            "More detail. Back to [demo](../SKILL.md).\n",
+            encoding="utf-8",
+        )
+
+        page = gen_docs.emit_skill_page(skill_dir)
+
+        assert page is not None
+        body = (isolated_docs / "src" / "content" / "docs" / "skills" / "demo.md").read_text(encoding="utf-8")
+
+        headings = re.findall(r"^#{2,6}\s+(.+?)\s*$", body, re.MULTILINE)
+        heading_slugs = {gen_docs._heading_slug(h) for h in headings}
+        assert heading_slugs, "expected at least one folded heading in the generated page"
+
+        anchors = re.findall(r"\]\(#([^)]*)\)", body)
+        assert anchors, "expected at least one intra-page anchor link in the generated page"
+
+        # "#" (bare, empty anchor) is the deliberate back-to-top-of-page link
+        # produced for a same-skill ../SKILL.md reference -- it has no heading
+        # to resolve against by design, so it's excluded from the resolution
+        # check below rather than silently satisfied by it.
+        section_anchors = [a for a in anchors if a]
+        assert section_anchors, "expected at least one non-top-of-page anchor"
+        for anchor in section_anchors:
+            assert anchor in heading_slugs, (
+                f"anchor #{anchor} does not resolve to any real folded heading; "
+                f"available headings slug to {sorted(heading_slugs)}"
+            )
+
+        # Literal pins on the exact regression: these must be present verbatim
+        # in the emitted links, independent of whatever _heading_slug computes
+        # at test time (see class docstring for why the generic check above
+        # can't catch a regression in _heading_slug on its own).
+        assert f"](#{self.EXPECTED_FOO_ANCHOR[1:]})" in body
+        assert f"](#{self.EXPECTED_BAR_ANCHOR[1:]})" in body
+        assert "_" in self.EXPECTED_FOO_ANCHOR  # underscore survives
+        assert "--" in self.EXPECTED_BAR_ANCHOR  # em-dash idiom keeps a double hyphen

--- a/tests/python/test_gen_docs.py
+++ b/tests/python/test_gen_docs.py
@@ -379,6 +379,28 @@ class TestFoldReferences:
         assert "Intro text." in folded
         assert titles == {"gate": "Quality gates"}
 
+    def test_bump_leaves_fenced_code_blocks_untouched(self, gen_docs, isolated_docs):
+        """Regression: _bump_headings once regexed the whole body, so fenced
+        code lines starting with `# ` (shell comments, markdown examples) were
+        demoted too, corrupting copied snippets in the rendered page."""
+        refs_dir = isolated_docs / "skills" / "cook" / "references"
+        refs_dir.mkdir(parents=True)
+        (refs_dir / "fenced.md").write_text(
+            "# Fenced doc\n\n## Real heading\n\n"
+            "```bash\n# a shell comment\n## not a heading either\n```\n\n"
+            "### After fence\n",
+            encoding="utf-8",
+        )
+
+        folded, _ = gen_docs.fold_references("cook", refs_dir)
+
+        assert "### Real heading" in folded
+        assert "#### After fence" in folded
+        assert "# a shell comment" in folded
+        assert "## a shell comment" not in folded
+        assert "## not a heading either" in folded
+        assert "### not a heading either" not in folded
+
     def test_title_precedence_falls_back_to_first_h1_then_stem(self, gen_docs, isolated_docs):
         refs_dir = isolated_docs / "skills" / "cook" / "references"
         refs_dir.mkdir(parents=True)
@@ -614,8 +636,18 @@ class TestMainGenerationRealCheeseKernelDocs:
         assert not (root / "shared").exists()
         cheese_body = (root / "skills" / "cheese.md").read_text(encoding="utf-8")
         for name in self.MOVED_DOC_NAMES:
-            heading = re.compile(r"^## .+\n", re.MULTILINE)
-            assert heading.search(cheese_body), "expected at least one folded ## section"
+            meta, ref_body = gen_docs.parse_frontmatter(
+                (real_refs_dir / f"{name}.md").read_text(encoding="utf-8")
+            )
+            title = (
+                meta.get("title")
+                or gen_docs._first_h1(ref_body)
+                or name.replace("-", " ").capitalize()
+            )
+            heading = re.compile(rf"^## {re.escape(title)}\s*$", re.MULTILINE)
+            assert heading.search(cheese_body), (
+                f"expected folded section '## {title}' for {name}.md in the cheese page"
+            )
         assert cheese_body.count("## ") >= len(self.MOVED_DOC_NAMES)
 
 


### PR DESCRIPTION
## What

Each skill's `references/*.md` now render as appended `##` sections on the skill's **single** Starlight page (H1→H2, inner headings +1), reference links rewritten to intra-page / skill-page anchors, and the per-skill sidebar group collapsed to one **flat** link. A custom `Sidebar.astro` override renders the active skill page's **h2** headings as a nested left-nav TOC.

Implements the accepted design in **ADR-001** (fold references into one page) and **ADR-002** (h2-only left-nav TOC via a custom Starlight `Sidebar` override).

## Why

Standalone reference sub-pages (e.g. "Context isolation") gave readers no cue which skill they belonged to, and fragmented each skill's material. Folding keeps the docs whole while leaving the skill **source** tree untouched (agents still load references on demand).

## How

- **`scripts/gen_docs.py`** — `fold_references`; `_heading_slug` faithful to `github-slugger@2.0.0` (keeps underscores, no separator collapse — verified byte-for-byte over all 686 real heading titles, 0 mismatches); `_ref_title` anchor resolution across all three link rewriters incl. the root-passthrough pages; flat `emit_sidebar`.
- **`src/components/Sidebar.astro`** + **`sidebar-toc.mjs`** — the tree-transform is a pure, unit-tested module (`node --test`, 5 cases). TOC uses Starlight's real post-dedupe `route.toc` slugs, excludes the synthetic `_top` title node, and is gated to skill pages only.

## Verification

- `pytest tests/python` — 600 passed, 1 skipped (incl. golden github-slugger cases + an anchor↔folded-heading integration test).
- `node --test tests/js` — 5 passed.
- `pnpm run docs:build` — 25 pages built.
- Site-wide anchor audit (real slugger, URL-route resolution): **0 dead reference anchors** across skill pages and root-passthrough pages.

## Notes

- Documented residual: no page-order anchor dedup for body links (`-1/-2` suffixes); 0 collisions in the current corpus, and the left-nav TOC is immune (uses `route.toc`).
- No JS render-harness exists for full Astro output; the pure transform logic is unit-covered and the build is the end-to-end gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)