### PR TITLE
feat(wheypoint): add provenance header fields and join/split verbs

### DIFF
--- a/.hallouminate/wiki/adr/index.md
+++ b/.hallouminate/wiki/adr/index.md
@@ -9,4 +9,5 @@
 - [skill-docs-single-page-001](./skill-docs-single-page-001.md) — ADR-001: Fold skill references into one docs page instead of separate sub-pages  [status: accepted]
 - [skill-docs-single-page-002](./skill-docs-single-page-002.md) — ADR-002: Left-nav heading TOC is h2-only, via a custom Starlight Sidebar override  [status: accepted]
 - [starlight-docs-cutover-001](./starlight-docs-cutover-001.md) — ADR: Starlight docs cutover
+- [wheypoint-provenance-schema-001](./wheypoint-provenance-schema-001.md) — ADR: wheypoint provenance as additive header fields with join/split verbs
 <!-- HALLOUMINATE:INDEX-END -->

--- a/.hallouminate/wiki/adr/wheypoint-provenance-schema-001.md
+++ b/.hallouminate/wiki/adr/wheypoint-provenance-schema-001.md
@@ -1,0 +1,38 @@
+# ADR: wheypoint provenance as additive header fields with join/split verbs
+
+Status: accepted (2026-07-09)
+Spec: session-convergence-wheypoint (dotfiles session; `/home/paul/Dev/dotfiles`)
+Ships in: `skills/wheypoint/SKILL.md`
+
+## Context
+
+Interrupted or parallel agent-session threads could not be converged into resumable artifacts. `/wheypoint` handoff notes carried no machine-readable lineage — no session id, git anchor, creation time, or parentage — so joining two threads or forking one was untracked hand-work. The header schema stopped at `status / next / mode / artifact` + the orientation line.
+
+## Decision
+
+Extend the wheypoint header schema **additively** with four fields, placed after `artifact:` and before the orientation line, all **optional**:
+
+- `session: <harness>:<session-id>` — auto-filled from the per-harness source map (claude: newest `*.jsonl` in the encoded-cwd projects dir; codex: `payload.cwd` in the rollout meta line; opencode: the `session` table). No user-supplied ids.
+- `git: <branch>@<short-sha>` — the working anchor.
+- `created: <UTC ISO-8601>` — capture time.
+- `parents: [<slug>, ...]` — lineage; empty/absent for a fresh single thread.
+
+Two verbs make lineage explicit:
+
+- `/wheypoint --join <slugA> <slugB>` — writes ONE merged note with `parents: [A, B]`, consolidating both sources by reference (not re-paste).
+- `/wheypoint --split` — writes TWO child notes, each `parents: [<current>]`, distinct slugs.
+
+**Backward compatibility is the linchpin.** All four fields are optional, so pre-provenance notes stay valid, and `/cheese --continue` parses provenance-bearing and pre-provenance notes identically: the parser is **key-based** (`skills/cheese/SKILL.md` scans for `status:`/`next:`/`mode:`/`artifact:` by key), and the orientation line stays the **first non-key line** after the header block. No consumer couples orientation to "the line immediately after `artifact:`". A contract test locks the field placement (mutation-verified: moving a provenance line below the orientation line fails it).
+
+## Gotcha — source the git short-sha from a granted command
+
+wheypoint's `allowed-tools` grants only `Bash(git status:*)`, `Bash(git log:*)`, `Bash(git diff:*)`. Fill `git:` via `git log -1 --format=%h` for the short-sha (branch from `git status`). **Do NOT use `git rev-parse`** — it matches no grant and stalls under `--auto`. Adding a `rev-parse` grant was a deliberate non-goal; the sha is reachable under the existing grant.
+
+## Why not the alternatives
+
+- A frozen positional 4-line header (the shape `shared/scripts/handoff.py::parse_handoff_slug` still assumes): rejected — it can't carry lineage and already breaks on the long-standing `mode:` line. The key-based `/cheese --continue` path is the real consumer; the positional parser is a latent, uninvoked capability (`--phase notes` has no caller).
+- Provenance in a sidecar file: rejected — splits the resumption contract across two artifacts; the note is meant to be read cold in one pass.
+
+## Scope note
+
+The historical short-sha of a *recovered* session is not in the session logs, so `/work-recovery --wheypoint` (the dotfiles-side sweep that writes provenance-bearing notes) fills `git:` branch-only — a schema-valid degradation, since every provenance field is optional.

--- a/skills/wheypoint/SKILL.md
+++ b/skills/wheypoint/SKILL.md
@@ -15,6 +15,14 @@ allowed-tools: Read, Glob, mcp__tilth__tilth_read, mcp__tilth__tilth_list, Write
 
 - The conversation so far (the primary input).
 - Optional argument: a description of what the next session will focus on. When present, treat it as the lens and tailor the document to it. Drop state that does not serve that focus to a one-line pointer.
+- Optional verb `--join <slugA> <slugB>`: merge two existing handoff notes into one. Reads both notes from `.cheese/notes/` and writes a single merged note whose `parents:` lists both slugs.
+- Optional verb `--split`: fork the current thread into two resumable tracks. Writes two child notes, each with `parents: [<current-slug>]` and a distinct slug.
+
+```text
+/wheypoint                     -> one note with session/git/created auto-filled
+/wheypoint --join A B          -> one merged note, parents: [A, B]
+/wheypoint --split             -> two child notes, each parents: [<current>]
+```
 
 ## Flow
 
@@ -23,6 +31,25 @@ allowed-tools: Read, Glob, mcp__tilth__tilth_read, mcp__tilth__tilth_list, Write
 3. **Write the handoff document** to `.cheese/notes/<slug>.md` with the slug header (`## Handoff slug`) and body (`## Document`) below. When a focus argument was given, apply it as the lens throughout: emphasise state and decisions that serve the focus, and compress everything else to a one-line pointer.
 4. **Redact** secrets on the way out (`## Redaction`).
 5. **Point at resumption.** End by telling the user how to resume with `/cheese --continue <slug>` from the original repo, and include an absolute clickable path to the handoff note so the user can find it from any working directory.
+
+### `--join <slugA> <slugB>`
+
+Merge two interrupted threads into one resumable note.
+
+1. Read both source notes from `.cheese/notes/<slugA>.md` and `.cheese/notes/<slugB>.md`.
+2. Derive a merged slug that names the joined effort.
+3. Write ONE note to `.cheese/notes/<merged-slug>.md` with `parents: [<slugA>, <slugB>]` and the usual auto-filled provenance (`session:` / `git:` / `created:` from the live session).
+4. In `## Document`, consolidate both sources' Goal / State / Key decisions by **reference**, not re-paste (per `## Do not duplicate`): point at each source note by path and capture only the merged picture and any conflicts to reconcile.
+5. Point at resumption as in the default flow.
+
+### `--split`
+
+Fork the current thread into two parallel tracks.
+
+1. Take the current thread's slug as the parent (derive it as in step 1 of the default flow).
+2. Choose two distinct child slugs, one per track.
+3. Write TWO notes, `.cheese/notes/<child-a>.md` and `.cheese/notes/<child-b>.md`, each with `parents: [<current-slug>]`, its own auto-filled provenance, and a `## Document` scoped to that track's slice of the work.
+4. Point at resumption for each child so both tracks can be resumed independently.
 
 ## Handoff slug
 
@@ -33,10 +60,27 @@ status: ok | gated: <one-line decision> | halt: <one-line reason>
 next: mold | cook | press | age | cure | affinage | briesearch | culture | hold | tasks | done
 mode: single | parallel
 artifact: <path-to-richer-report, or PR ref (PR#<n> / URL) when next: affinage, else none>
+session: <harness>:<session-id>      # optional; auto-filled provenance
+git: <branch>@<short-sha>            # optional; auto-filled provenance
+created: <UTC ISO-8601>              # optional; auto-filled provenance
+parents: [<slug>, ...]               # optional; lineage (join => 2+, split-child => 1)
 <one-line orientation: where the session is and what is mid-flight>
 ```
 
 `mode:` is optional for backwards compatibility; omitted mode means `mode: single`. In `mode: single`, `next:` names the skill the cold reader should run, which is the machine-readable form of the suggested-skills section below. Use `done` only when the work is genuinely finished and the handoff is a record, not a baton. `/cheese --continue <slug>` scans `.cheese/notes/<slug>.md` and dispatches `next:` directly; `/cheese --continue <absolute-note-path>` reads that handoff file directly when the user is outside the original repo. When `next: affinage`, record the PR reference (`PR#<n>` or its URL) in `artifact:` so the resume dispatches `/affinage <pr>` explicitly rather than relying on branch auto-detection.
+
+### Provenance fields
+
+Four optional provenance fields sit between `artifact:` and the orientation line. Auto-fill each one from the live session; never take a user-supplied value. All four are optional and additive: a note carrying none of them is valid, and every consumer treats a pre-provenance note (none of these keys) as valid. Placement rule: the orientation line stays the first non-key line, so it must follow whichever of these fields are present.
+
+- **`session: <harness>:<session-id>`** — the current session's harness and id, read from the per-harness source map:
+  - **claude** — the newest `*.jsonl` in the encoded-cwd projects dir (`~/.claude/projects/<encoded-cwd>/`); its basename (minus `.jsonl`) is the session id.
+  - **codex** — the `payload.cwd` field in the rollout meta line of the active rollout log.
+  - **opencode** — the matching row in the `session` table.
+  - When the harness is unknown or no log is accessible, omit the field. `<speculative>` the newest-mtime claude heuristic can bind the wrong `*.jsonl` when several live sessions share one cwd; the field is optional so a wrong bind is hand-correctable.
+- **`git: <branch>@<short-sha>`** — the branch and short commit at capture time: the branch from `git status` and the short sha from `git log -1 --format=%h` (the `Bash(git status:*)` and `Bash(git log:*)` grants cover the reads). Omit outside a git repo.
+- **`created: <UTC ISO-8601>`** — the capture timestamp in UTC ISO-8601 (e.g. `2026-07-09T14:32:00Z`).
+- **`parents: [<slug>, ...]`** — lineage. Empty or absent for a fresh single-thread note. `--join` sets two or more source slugs; each `--split` child sets exactly the current slug.
 
 ### `status:` values
 

--- a/tests/python/test_ultracook_skills.py
+++ b/tests/python/test_ultracook_skills.py
@@ -334,6 +334,108 @@ class TestWheypointParallelHandoff:
 
 
 # ---------------------------------------------------------------------------
+# session-convergence-wheypoint — provenance header fields + join/split verbs.
+#
+# The four optional provenance fields (session/git/created/parents) are
+# additive and backward-compatible: a pre-provenance note stays valid, and the
+# orientation line stays the FIRST non-key line so /cheese --continue's
+# key-based parse is unaffected (spec acceptance #4/#5). These lock the
+# placement + optionality invariant and the join/split lineage cardinality
+# (acceptance #2/#3) against a silent reorder or a dropped contract clause.
+# ---------------------------------------------------------------------------
+
+
+def _handoff_schema_fence() -> list[str]:
+    """Return the canonical ordered field list — the header-schema block under
+    `## Handoff slug`, from its `status: ok | gated:` line through the
+    orientation placeholder — as its individual lines. Sliced by anchor rather
+    than by fence so it is insensitive to the surrounding code-fence syntax."""
+    lines = _skill("wheypoint").splitlines()
+    start = next(
+        (i for i, ln in enumerate(lines) if ln.startswith("status: ok | gated:")),
+        None,
+    )
+    if start is None:
+        raise AssertionError("wheypoint must carry the `status: ok | gated:` header schema")
+    end = next(
+        (
+            i
+            for i, ln in enumerate(lines[start:], start)
+            if ln.lstrip().startswith("<one-line orientation")
+        ),
+        None,
+    )
+    if end is None:
+        raise AssertionError("wheypoint header schema must end with the orientation line")
+    return lines[start : end + 1]
+
+
+class TestWheypointProvenance:
+    PROVENANCE_KEYS = ("session:", "git:", "created:", "parents:")
+
+    def test_schema_lists_all_provenance_fields(self) -> None:
+        fence = "\n".join(_handoff_schema_fence())
+        for key in self.PROVENANCE_KEYS:
+            assert key in fence, (
+                f"wheypoint header schema must document the provenance field `{key}`"
+            )
+
+    def test_provenance_fields_sit_between_artifact_and_orientation(self) -> None:
+        # The backward-compat linchpin: orientation stays the first non-key
+        # line, so every provenance field must appear after `artifact:` and
+        # before the orientation placeholder. A reorder pushing a provenance
+        # key below orientation would break /cheese --continue's key-based
+        # parse and silently consume a wrong orientation.
+        lines = _skill("wheypoint").splitlines()
+        orient_i = next(
+            i for i, ln in enumerate(lines)
+            if ln.lstrip().startswith("<one-line orientation")
+        )
+        artifact_i = max(
+            i for i, ln in enumerate(lines[:orient_i]) if ln.startswith("artifact:")
+        )
+        for key in self.PROVENANCE_KEYS:
+            positions = [i for i, ln in enumerate(lines) if ln.startswith(key)]
+            assert any(artifact_i < i < orient_i for i in positions), (
+                f"provenance field `{key}` must sit between artifact: and the "
+                f"orientation line (orientation stays the first non-key line)"
+            )
+
+    def test_provenance_documented_optional_and_backward_compatible(self) -> None:
+        body = _skill("wheypoint").lower()
+        # Scope the optionality check to the `### Provenance fields` block so
+        # it cannot be satisfied by an unrelated "optional" elsewhere in the
+        # file (the word appears many times outside the provenance section).
+        start = body.find("### provenance fields")
+        assert start != -1, "wheypoint must carry a `### Provenance fields` section"
+        end = body.find("\n### ", start + 1)
+        section = body[start:end] if end != -1 else body[start:]
+        assert "optional" in section, (
+            "provenance fields must be documented as optional in the "
+            "`### Provenance fields` section"
+        )
+        assert "pre-provenance" in body, (
+            "wheypoint must state pre-provenance notes (none of the new keys) stay valid"
+        )
+
+
+class TestWheypointJoinSplitVerbs:
+    def test_join_documented_with_both_parent_slugs(self) -> None:
+        body = _skill("wheypoint")
+        assert "--join" in body, "wheypoint must document the --join verb"
+        assert "parents: [<slugA>, <slugB>]" in body or "parents: [A, B]" in body, (
+            "--join must write one note whose parents lists both source slugs"
+        )
+
+    def test_split_documented_with_current_slug_as_parent(self) -> None:
+        body = _skill("wheypoint")
+        assert "--split" in body, "wheypoint must document the --split verb"
+        assert (
+            "parents: [<current-slug>]" in body or "parents: [<current>]" in body
+        ), "--split children must each be parented on the current slug"
+
+
+# ---------------------------------------------------------------------------
 # Wiring: install fallback list and README skill table
 # ---------------------------------------------------------------------------
 

--- a/tests/python/test_ultracook_skills.py
+++ b/tests/python/test_ultracook_skills.py
@@ -388,12 +388,23 @@ class TestWheypointProvenance:
         # parse and silently consume a wrong orientation.
         lines = _skill("wheypoint").splitlines()
         orient_i = next(
-            i for i, ln in enumerate(lines)
-            if ln.lstrip().startswith("<one-line orientation")
+            (
+                i
+                for i, ln in enumerate(lines)
+                if ln.lstrip().startswith("<one-line orientation")
+            ),
+            None,
         )
-        artifact_i = max(
+        assert orient_i is not None, (
+            "wheypoint schema must keep the `<one-line orientation` placeholder"
+        )
+        artifact_positions = [
             i for i, ln in enumerate(lines[:orient_i]) if ln.startswith("artifact:")
+        ]
+        assert artifact_positions, (
+            "wheypoint schema must document `artifact:` above the orientation line"
         )
+        artifact_i = max(artifact_positions)
         for key in self.PROVENANCE_KEYS:
             positions = [i for i, ln in enumerate(lines) if ln.startswith(key)]
             assert any(artifact_i < i < orient_i for i in positions), (


### PR DESCRIPTION
## What

Extends the `/wheypoint` handoff-note schema additively so interrupted or parallel session threads can be converged into resumable artifacts (Phase 1 of the session-convergence effort; the work-recovery `--wheypoint` write mode and duckdb indexing land in dotfiles).

- **Four optional provenance header fields** — `session:` / `git:` / `created:` / `parents:` — placed after `artifact:` and before the orientation line, auto-filled from the per-harness session source map, git, and capture time.
- **Two verbs** — `--join <A> <B>` writes one merged note (`parents: [A, B]`); `--split` writes two child notes (each `parents: [<current>]`).
- `git` short-sha sourced via the already-granted `git log -1 --format=%h` — **no new `allowed-tools` grant**.

## Backward compatibility

All four fields are optional; pre-provenance notes stay valid. `/cheese --continue` parses provenance-bearing and pre-provenance notes identically — the parser is key-based and the orientation line stays the first non-key line. A mutation-verified structural test locks that placement invariant.

## Tests

5 contract tests in `tests/python/test_ultracook_skills.py` (`TestWheypointProvenance` ×3, `TestWheypointJoinSplitVerbs` ×2), conforming to the file's existing string-shaped convention.

## Review provenance

Produced via the ultracook pipeline (cook → press → age → cure → age, clean early stop). One Medium (an ungranted `git rev-parse` in an earlier draft) and one Low (a vacuous assertion) were found and cured; the second age pass is clean at the medium+ floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)