### PR TITLE
docs(skills): fix fence nesting, Auto mode heading drift, and stale tilth claims

### DIFF
--- a/.hallouminate/config.toml
+++ b/.hallouminate/config.toml
@@ -12,3 +12,5 @@
 [[repository]]
 name = "easy-cheese"
 path = "."
+corpus_paths = ["skills"]
+corpus_globs = ["**/*.md"]

--- a/skills/affinage/SKILL.md
+++ b/skills/affinage/SKILL.md
@@ -212,7 +212,7 @@ The "present all four severity options on every run, empty-set-resolves-to-`none
 - **Skip posting** — leave the report for later; post nothing.
 - **Per-finding** — free-text pick of which drafts to post.
 
-On the selection (or the default post-all), post via Flow step 9 and exit with `status: ok / next: done` — see `### Auto mode` § "no findings meet the floor" for the auto path.
+On the selection (or the default post-all), post via Flow step 9 and exit with `status: ok / next: done` — see `## Auto mode` § "no findings meet the floor" for the auto path.
 
 **Slug `next:` values.** Write `next: cure` when at least one finding meets the `medium+` floor (medium-or-above, or a cheap contained-fix low). Write `next: done` when no severity-section finding exists or all meeting items are empty-selection after floor resolution.
 
@@ -228,7 +228,7 @@ handoff_context:
 
 `/cure` re-confirms cited ids and goes straight to apply. Propagate `--safe`, `--open-pr`, and `--hard` to `/cure` when in scope. `/affinage` resumes when `/cure` returns to post replies.
 
-### Auto mode
+## Auto mode
 
 When invoked with `--auto --stake <floor>`:
 
@@ -246,7 +246,7 @@ The whole cure chain (cure → `/age --scope --auto` → up to the two-cure-pass
 
 If no findings meet the floor, skip the `/cure` dispatch, post replies for `Reviewer-rejected` + `Needs-investigation` items only, and exit with `status: ok / next: done`.
 
-### --hard mode
+## --hard mode
 
 `/affinage` does not fire the `/hard-cheese` gate. It propagates `--hard` forward to `/cure` so the gate can fire at the share-for-review boundary inside `/cure --hard`. See `skills/cure/SKILL.md` `--hard mode`.
 

--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -25,7 +25,7 @@ Accept:
 
 When called with a `<slug>`, resolve `.cheese/press/<slug>.md` (if present) for press context and review the current working diff. When called with a `<ref-or-range>`, review that range. Default to the current working diff when neither is supplied. If the base branch is unclear, ask or use the repository's documented default.
 
-`--auto` is the propagated autonomous-mode flag from `/cook --auto`. It changes the handoff (see `## Handoff` and `### Auto mode` for the cap rule and full chain). See `### When invoked from /ultracook` for the no-shared-memory variant.
+`--auto` is the propagated autonomous-mode flag from `/cook --auto`. It changes the handoff (see `## Handoff` and `## Auto mode` for the cap rule and full chain). See `### When invoked from /ultracook` for the no-shared-memory variant.
 
 `--hard` is the propagated metacognitive-gate flag from `/cook --hard` (or `/cheese --hard`). Age does not fire the gate; it only passes `--hard` forward to `/cure` at the handoff so the gate can fire at the share-for-review boundary. See `skills/hard-cheese/SKILL.md`.
 
@@ -285,9 +285,9 @@ handoff_context:
 
 On `none` / `Stop` (only reachable via the gate), exit cleanly with the report path.
 
-`--auto` substitutes a severity-floor selection and its own chain — see `### Auto mode` below.
+`--auto` substitutes a severity-floor selection and its own chain — see `## Auto mode` below.
 
-### Auto mode
+## Auto mode
 
 When invoked with `--auto`:
 

--- a/skills/cheez-read/references/routing.md
+++ b/skills/cheez-read/references/routing.md
@@ -31,7 +31,7 @@ If no LSP is installed for the language, or the file is in a broken / incomplete
 
 ## When Serena beats broad read backends for symbol-table reads (if your harness has it)
 
-Serena ([oraios/serena](https://github.com/oraios/serena)) is an LSP-driven MCP exposing LSP queries as named tools. When Serena is configured (`.serena/project.yml` present) and the read is symbol-shaped, the **calling workflow skill** should route directly to Serena rather than entering `/cheez-read`:
+Serena ([oraios/serena](https://github.com/oraios/serena)) is an LSP-driven MCP exposing LSP queries as named tools. When Serena is configured (`.serena/project.yml` present) and the read is symbol-shaped, the **calling workflow skill** should route directly to Serena rather than entering `/cheez-read` (*should*, not *may*: a symbol-shaped read via LSP is strictly cheaper and risk-free, unlike the edit case in cheez-write's routing):
 
 | Goal | Serena tool | Why |
 |------|-------------|-----|

--- a/skills/cheez-search/references/tilth-search-reference.md
+++ b/skills/cheez-search/references/tilth-search-reference.md
@@ -3,10 +3,10 @@
 Detailed invocation shapes, output format, and per-kind parameter reference.
 For which kind to pick, see the **Choose your search kind** table in `SKILL.md`.
 
-All examples omit `root`: every tilth tool anchors relative paths and `scope`
-against it (your absolute checkout directory) and refuses a relative path
-without it — the examples' relative `scope` values assume it is set. Omit
-`scope` to search the whole checkout; pass it only to narrow to a subdirectory.
+All examples omit `cwd`: every tilth tool requires it (your absolute checkout
+directory), but the Claude Code hook injects it automatically — set it only on
+harnesses without the hook. There is no `root` parameter. Omit `scope` to
+search the whole checkout; pass it only to narrow to a subdirectory.
 
 ---
 

--- a/skills/cheez-search/references/tilth-search-reference.md
+++ b/skills/cheez-search/references/tilth-search-reference.md
@@ -3,10 +3,10 @@
 Detailed invocation shapes, output format, and per-kind parameter reference.
 For which kind to pick, see the **Choose your search kind** table in `SKILL.md`.
 
-All examples omit `cwd`: every tilth tool requires it (your absolute checkout
-directory), but the Claude Code hook injects it automatically — set it only on
-harnesses without the hook. There is no `root` parameter. Omit `scope` to
-search the whole checkout; pass it only to narrow to a subdirectory.
+All examples omit `root`: every tilth tool anchors relative paths and `scope`
+against it (your absolute checkout directory) and refuses a relative path
+without it — the examples' relative `scope` values assume it is set. Omit
+`scope` to search the whole checkout; pass it only to narrow to a subdirectory.
 
 ---
 
@@ -19,11 +19,11 @@ tilth_search(queries: [{query: "handleAuth"}], scope: "src/")
 
 **Output:**
 ```
-# Search: "handleAuth" in src/ - 6 matches (2 definitions, 4 usages)
+# Search: "handleAuth" in src/ — 6 matches (2 definitions, 4 usages)
 
 ## src/auth.ts:44-89 [definition]
   [24-42]  fn validateToken(token: string)
--> [44-89]  export fn handleAuth(req, res, next)
+→ [44-89]  export fn handleAuth(req, res, next)
   [91-120] fn refreshSession(req, res)
 
   44 | export function handleAuth(req, res, next) {
@@ -37,7 +37,7 @@ tilth_search(queries: [{query: "handleAuth"}], scope: "src/")
   refreshSession  src/auth.ts:91-120  fn refreshSession(req, res)
 
 ## src/routes/api.ts:34 [usage]
--> [34]   router.use('/api/protected/*', handleAuth);
+→ [34]   router.use('/api/protected/*', handleAuth);
 ```
 
 **Key features:**

--- a/skills/cheez-write/references/routing.md
+++ b/skills/cheez-write/references/routing.md
@@ -16,7 +16,7 @@ If no LSP is installed, or the rename touches a symbol the typechecker can't res
 
 ## When Serena beats line/range edits for symbol-bounded edits
 
-Serena ([oraios/serena](https://github.com/oraios/serena)) is an LSP-driven MCP that exposes symbol-bounded edits as named tools; when it is configured (`.serena/project.yml` present) and the edit is symbol-shaped, the **calling workflow skill** may route directly to Serena rather than using a line/range edit:
+Serena ([oraios/serena](https://github.com/oraios/serena)) is an LSP-driven MCP that exposes symbol-bounded edits as named tools; when it is configured (`.serena/project.yml` present) and the edit is symbol-shaped, the **calling workflow skill** may route directly to Serena rather than using a line/range edit (*may*, not *should*: edits are riskier than reads, so the anchored line/range path remains a first-class default):
 
 | Edit | Serena tool | When to prefer over line/range edits |
 |------|-------------|----------------------------------|

--- a/skills/cook/SKILL.md
+++ b/skills/cook/SKILL.md
@@ -132,7 +132,7 @@ In every early-stop case, surface the report from the failing skill and tell the
 
 ### Failure handling inside cure
 
-See `skills/cure/SKILL.md` `### Auto mode` for cure's per-finding revert/defer behaviour. Cook does not duplicate the contract — cure owns it.
+See `skills/cure/SKILL.md` `## Auto mode` for cure's per-finding revert/defer behaviour. Cook does not duplicate the contract — cure owns it.
 
 ### Final report
 

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -141,11 +141,11 @@ Pre-select **Re-review the touched code** when any applied fix touched logic out
 
 - **Interactive `/cure --hard`:** the gate fires at the share-for-review boundary — the PR push. In the default (no `--safe`) path, fire `/hard-cheese <slug>` *before* the autonomous push and proceed only on exit `0`. Under `--safe`, fire it when the user selects the share-for-review option (the **Ship it — open or update the PR** label, which dispatches `/gh`). Either way, proceed only on exit `0`. If the gate exits non-zero (`FAILED` status — cap exhausted), surface the artifact path and abort the push; the user must improve their understanding before sharing for review.
 - **Not sharing for review** (no open PR and no `--open-pr`, or under `--safe` picking **Re-review the touched code** / **Checkpoint & stop** / **Stop**) does *not* fire the gate. Re-review and pausing do not put code in front of readers.
-- **Auto-mode puncture** — see the clause in `### Auto mode` below. The auto-mode puncture is the single sanctioned point at which `--hard` overrides `--auto`'s skip-handoff semantics.
+- **Auto-mode puncture** — see the clause in `## Auto mode` below. The auto-mode puncture is the single sanctioned point at which `--hard` overrides `--auto`'s skip-handoff semantics.
 
 The gate's mechanism (SOLO-graded fresh-context judge, Socratic retry, fail-open on judge error) lives in `skills/hard-cheese/SKILL.md`. The full composition matrix lives in `../hard-cheese/references/composition.md`.
 
-### Auto mode
+## Auto mode
 
 When invoked with `--auto --stake <floor>`:
 

--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -21,7 +21,7 @@ Press may add or strengthen tests and make tiny corrective fixes only when a tes
 5. **Corrective fixes** — only for defects the hardening tests expose. No new behaviour.
 6. **Run checks** — narrowest useful tests, then relevant wider gates already in the project.
 7. **Report** — write `.cheese/press/<slug>.md` (slug carried from `/cook`, or derived from branch/task) and print the path. Mark readiness: `ready for /age`, `follow-up recommended`, or `blocked`.
-8. **Hand off** — in manual mode, prompt the next step via the shared handoff gate (see `## Handoff` below); in `--auto` mode, chain forward per `### Auto mode`.
+8. **Hand off** — in manual mode, prompt the next step via the shared handoff gate (see `## Handoff` below); in `--auto` mode, chain forward per `## Auto mode`.
 
 ## Preferred tools and fallbacks
 
@@ -100,7 +100,7 @@ After the press report is on disk, ask via the shared handoff gate in [`../chees
 
 Pre-select **Review the diff** when readiness is `ready for /age` or `follow-up recommended`. If the report is `blocked`, do not pre-select anything (and do not pre-select **Ship it**); the user decides whether to fix or escalate. After a non-stop selection, run the selected command immediately.
 
-### Auto mode
+## Auto mode
 
 When invoked with `--auto` (propagated from `/cook --auto`):
 

--- a/skills/ultracook/references/decomposer-prompt.md
+++ b/skills/ultracook/references/decomposer-prompt.md
@@ -2,7 +2,7 @@
 
 Loaded by `/ultracook` at Phase 0. Substitute `{spec_text}`, `{slug}`, and `{quality_gate}` before dispatch.
 
-```text
+````text
 You are the decomposer sub-agent for /ultracook spec: {slug}
 
 ## Your job
@@ -111,4 +111,4 @@ Do NOT write any production code in this phase — your only artifact is the man
 Write the manifest, then return a brief one-paragraph summary naming the curd count and
 any tricky decomposition decisions you made (e.g. files you considered shared but moved
 to seed). The orchestrator presents this in the user-approval gate.
-```
+````

--- a/skills/ultracook/references/pr-planner-prompt.md
+++ b/skills/ultracook/references/pr-planner-prompt.md
@@ -2,7 +2,7 @@
 
 Loaded by `/ultracook` at Phase 7. Substitute `{slug}`, `{manifest_path}`, `{merged_diff_path}`, and `{spec_summary}` before dispatch.
 
-```text
+````text
 You are the PR planner sub-agent for /ultracook spec: {slug}
 
 ## Your job
@@ -84,4 +84,4 @@ defined by `references/pr-plan-schema.json`.
 Write `pr-plan.yaml` and return a one-paragraph rationale naming the chosen shape and
 why. The orchestrator reads the rationale to confirm the layout looks sensible before
 delegating publish.
-```
+````

--- a/skills/ultracook/references/wiring-prompt.md
+++ b/skills/ultracook/references/wiring-prompt.md
@@ -2,7 +2,7 @@
 
 Loaded by `/ultracook` at Phase 4. Substitute `{id}`, `{slug}`, `{type}`, `{file}`, `{description}`, and `{spec_summary}` before dispatch.
 
-```text
+````text
 You are performing integration wiring task: {id} for spec {slug}
 
 ## Task
@@ -50,4 +50,4 @@ artifact: <path-to-richer-report-if-any>
 - Push or create PRs (the orchestrator handles that).
 - Chain forward (the orchestrator owns the chain).
 - Retry on failure — write the halt and return; the orchestrator decides retry policy.
-```
+````

--- a/tests/python/test_hard_cheese.py
+++ b/tests/python/test_hard_cheese.py
@@ -290,15 +290,15 @@ def test_attribution_uniform_across_artifacts() -> None:
 
 def test_cure_auto_puncture_clause_lives_in_auto_section() -> None:
     """Placement matters: the auto-puncture clause must live inside cure's
-    `### Auto mode` section, not as a free-floating paragraph elsewhere.
+    `## Auto mode` section, not as a free-floating paragraph elsewhere.
     A future reader looking at auto mode must see it without searching.
     """
     cure = (SKILLS / "cure" / "SKILL.md").read_text(encoding="utf-8")
-    auto_idx = cure.find("### Auto mode")
-    assert auto_idx >= 0, "cure must have an `### Auto mode` section"
+    auto_idx = cure.find("\n## Auto mode\n")
+    assert auto_idx >= 0, "cure must have an `## Auto mode` section"
     rules_idx = cure.find("## Rules", auto_idx)
     auto_section = cure[auto_idx:rules_idx if rules_idx >= 0 else len(cure)]
-    assert "--hard" in auto_section, "--hard puncture clause must live inside `### Auto mode`"
+    assert "--hard" in auto_section, "--hard puncture clause must live inside `## Auto mode`"
     assert "puncture" in auto_section.lower()
 
 


### PR DESCRIPTION
Consistency pass over the skills prose, found by mining the hallouminate embeddings (`repo:easy-cheese:corpus`, 634 chunks) for cross-file cosine-similar pairs and verifying candidates against source. Also declares that corpus in `.hallouminate/config.toml`.

## Fixes

**Broken template fences (functional).** `ultracook/references/pr-planner-prompt.md` and `wiring-prompt.md` wrapped templates containing inner fenced blocks in 3-backtick outer fences, so the outer block closed at the first inner close — everything after (field docs, `## Return`, the wiring `## Do NOT` constraints) rendered outside the template. Both now use 4-backtick outers, matching `curd-prompt.md`; `decomposer-prompt.md` aligned for uniformity.

**"Auto mode" heading drift (structural).** cook and pasteurize used `## Auto mode`; affinage, age, cure, press used `###`. The docs site left-nav lists h2s only (#245), so the section was navigable for two skills and invisible for four — and cure's `###` sat wrongly nested under `## --hard mode` despite carrying the general `--auto` contract. All six are h2 now; cross-references updated (`cure:23` and `ultracook:89` already said `##` and are now correct). affinage's `### --hard mode` promoted alongside so it doesn't nest under the promoted section. The placement test (`test_cure_auto_puncture_clause_lives_in_auto_section`) updated to the new level, anchored to the heading line.

**Serena routing strength (doc drift).** cheez-read said workflow skills "should" route symbol-shaped reads to Serena; cheez-write said they "may" route symbol-bounded edits. The difference is deliberate (reads are cheap and risk-free; edits are riskier) but undocumented — both files now state the rationale inline.

**Stale tilth reference doc.** `cheez-search/references/tilth-search-reference.md` diverged from live 0.8.4 behaviour, verified against a live `tilth_search` call and the served MCP schema:

- claimed "There is no `root` parameter" and a hook-injected `cwd` — the live schema has `root` and no `cwd`; paragraph rewritten
- example output used ASCII `->`/`-` where real output emits `→`/`—`; realigned with `SKILL.md`'s (correct) examples

## Verification

- `just lint-md` — 78 files, 0 errors
- `.github/scripts/validate_skills.py` — 17 SKILL.md files OK
- `pytest tests/python` — 606 passed, 0 failed, 1 skipped (pre-existing environmental skip: `test_gate_graph.py:405` skips when `dot` is installed)
- fence balance and heading levels re-checked by grep after the edits

## Also included

`chore(hallouminate)`: the two-line `.hallouminate/config.toml` change declaring `corpus_paths = ["skills"]` / `corpus_globs = ["**/*.md"]`, which derives `repo:easy-cheese:corpus` (73 files / 634 chunks verified indexed) — the corpus this PR's findings came from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQAY281wugW59qGin9TS1U
