### PR TITLE
fix(skills): preserve native cross-harness control

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -39,13 +39,14 @@ jobs:
           sudo install -m 755 "/tmp/gh_${ver}_linux_amd64/bin/gh" /usr/local/bin/gh
           gh --version
 
-      - name: Validate skills
+      - name: Stage shippable release tree
+        run: python3 scripts/stage_release.py --out "$RUNNER_TEMP/release"
+
+      - name: Validate staged skills
+        working-directory: ${{ runner.temp }}/release
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh skill publish --dry-run
-
-      - name: Stage shippable release tree
-        run: python3 scripts/stage_release.py --out "$RUNNER_TEMP/release"
 
       # `gh skill install` reads the git tree at the resolved tag, so the tag must
       # point at a commit that actually contains the built .pyz. main carries the

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ gh skill install paulnsorensen/easy-cheese cook
 Pin to a specific release tag or commit SHA for reproducibility:
 
 ```sh
-gh skill install paulnsorensen/easy-cheese cook@v1.2.0
+gh skill install paulnsorensen/easy-cheese cook@v0.10.1
 gh skill install paulnsorensen/easy-cheese cook@abc123def
 ```
 

--- a/skills/cheese/SKILL.md
+++ b/skills/cheese/SKILL.md
@@ -2,7 +2,6 @@
 name: cheese
 description: Route any dropped-in input — idea, spec path, file path, PR or issue, stack trace, bug report, or bare `/cheese` — to the right workflow skill. Use as the unified entry point — phrases include "/cheese", "what should I do with this", "help me get started", "route this", or any opening message that does not already name a downstream skill.
 license: MIT
-allowed-tools: Skill, Task, Agent, AskUserQuestion, Read, Glob, mcp__tilth__tilth_read, mcp__tilth__tilth_search, mcp__tilth__tilth_list, Bash(gh pr view:*), Bash(gh issue view:*)
 ---
 
 # /cheese
@@ -38,7 +37,7 @@ If `$ARGUMENTS` is missing entirely and there is no recent context to lean on, a
 6. **Self-check** — run the coherence questions in `references/coherence-check.md`. If any fails, downgrade to `clarify` (tier 3) or `research`.
 7. **Dispatch** — without `--safe`, run the chosen skill immediately with its exact dispatch command and context packet, in the same turn as the announce. With `--safe`, issue a handoff gate per [`references/handoff-gate.md`](references/handoff-gate.md) (recommended target pre-selected, at least one alternative, `Stop`) and wait for the user's selection before dispatching.
 
-`/cheese` is a router, not a worker — it never edits files, runs tests, or opens PRs; the frontmatter `allowed-tools` grant (read, search, dispatch — no write tools) backs this. The sole exception: it invokes `/mold`'s agent-invoked mini-spec mode in tier 1 when `/cook --auto` needs a spec first — that write happens inside `/mold`'s own skill scope, under `/mold`'s tool grants, not the router's.
+`/cheese` is a router, not a worker: it never edits files, runs tests, or opens PRs. Use only the host's read, search, and dispatch capabilities. The sole exception is invoking `/mold`'s agent-invoked mini-spec mode in tier 1 when `/cook --auto` needs a spec first; that write happens inside `/mold`'s own capability scope, not the router's.
 
 Portability reference: [`references/harness-portability.md`](references/harness-portability.md). It covers helper resolution, sub-agent dispatch, GitHub operations, and handoff transitions; prefer the bundled or repo-local helper first, and treat `${CLAUDE_SKILL_DIR}` as optional host-provided fallback.
 The handoff blocks below are the portable contract; slash commands are host renderings, not the control model.
@@ -155,4 +154,4 @@ Pre-select only the highest-confidence target. Without `--safe`, surface the tar
 
 - `references/classification.md` — intent shapes, signals, disambiguation rules.
 - `references/coherence-check.md` — pre-dispatch self-checks that downgrade misroutes.
-- [`references/handoff-gate.md`](references/handoff-gate.md) — Codex-safe post-selection dispatch contract (shared across workflow skills).
+- [`references/handoff-gate.md`](references/handoff-gate.md) — cross-harness post-selection dispatch contract (shared across workflow skills).

--- a/skills/cheese/references/handoff-gate.md
+++ b/skills/cheese/references/handoff-gate.md
@@ -54,13 +54,14 @@ Every option must include:
 ## Host routing guide
 
 The `handoff_gate:` block is the semantic source of truth. After building it,
-choose the richest question mechanism the current harness actually exposes;
-never name a host tool in the transcript unless it is callable in that session.
+choose the richest question mechanism the current harness actually exposes **and
+that can faithfully encode every option**; never name a host tool in the
+transcript unless it is callable in that session.
 
 | Harness | Prefer | Notes |
 | --- | --- | --- |
 | Claude Code | `AskUserQuestion` | Supports `questions[]` with `question`, short `header`, `options[]`, and optional `multiSelect`; hooks can fill `answers` via `updatedInput`. Source: [Claude Code hooks reference](https://docs.anthropic.com/en/docs/claude-code/hooks#askuserquestion). |
-| Codex / OpenAI app-server | `request_user_input` / `tool/requestUserInput` when exposed | OpenAI's app server documents `tool/requestUserInput` for 1-3 short questions and free-form `isOther` options. In Codex CLI, use `request_user_input` only when the active tool list and current collaboration mode both allow it; otherwise fall back to numbered text. Source: [Codex app-server reference](https://developers.openai.com/codex/app-server). |
+| Codex / OpenAI app-server | `request_user_input` / `tool/requestUserInput` when exposed and lossless | In Codex CLI, use `request_user_input` only when the active tool list and current collaboration mode both allow it **and the full gate fits its 2-3 explicit-choice limit**. A standard four-option forward-step menu does not fit: render every action with the numbered fallback (or a lossless hybrid where the fourth action remains an explicit numbered choice). Never merge or drop actions to make the tool call fit. Source: [Codex app-server reference](https://developers.openai.com/codex/app-server). |
 | Conductor | Underlying agent primitive | Conductor runs Claude Code or Codex sessions; route to that agent's question primitive. Conductor Plan Mode exists for both, but Conductor is not a separate question API. Source: [Conductor agent modes](https://conductor.build/docs/concepts/agent-modes). |
 | OpenCode | `question` tool | The built-in `question` tool asks during execution with header, question text, options, and custom answers; ensure `permission.question` is not denied. Source: [OpenCode tools](https://opencode.ai/docs/tools#question). |
 | GitHub Copilot CLI | `ask_user` tool | Copilot CLI lists `ask_user` as "Ask the user a question" and `--no-ask-user` disables it. Use it when available; otherwise numbered text. Source: [Copilot CLI command reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference). |
@@ -79,6 +80,8 @@ Recommended: <label> — <why>
 1. <label> — <effect/tradeoff>
 2. <label> — <effect/tradeoff>
 3. <label> — <effect/tradeoff>
+4. <label> — <effect/tradeoff, when present>
+... <continue until every handoff_gate option is explicit>
 Other: reply with `other: <short answer>`
 ```
 
@@ -89,6 +92,8 @@ as option 1 in this fallback.
 Keep gates small: one decision by default, at most three questions when the
 host primitive explicitly supports batching. Include a free-form `Other` path
 when the host supports it; otherwise spell out the `other:` fallback in text.
+
+The fallback must enumerate every option in `handoff_gate.options`; its list is not capped at three. Host option limits select the rendering mechanism—they never shrink the decision.
 
 ## After the answer arrives
 

--- a/skills/cheese/references/handoff-gate.md
+++ b/skills/cheese/references/handoff-gate.md
@@ -55,13 +55,15 @@ Every option must include:
 
 The `handoff_gate:` block is the semantic source of truth. After building it,
 choose the richest question mechanism the current harness actually exposes **and
-that can faithfully encode every option**; never name a host tool in the
-transcript unless it is callable in that session.
+that can faithfully encode every option**. Inspect the active primitive's
+advertised question and option capacities rather than assuming limits from a
+particular harness version; never name a host tool in the transcript unless it
+is callable in that session.
 
 | Harness | Prefer | Notes |
 | --- | --- | --- |
 | Claude Code | `AskUserQuestion` | Supports `questions[]` with `question`, short `header`, `options[]`, and optional `multiSelect`; hooks can fill `answers` via `updatedInput`. Source: [Claude Code hooks reference](https://docs.anthropic.com/en/docs/claude-code/hooks#askuserquestion). |
-| Codex / OpenAI app-server | `request_user_input` / `tool/requestUserInput` when exposed and lossless | In Codex CLI, use `request_user_input` only when the active tool list and current collaboration mode both allow it **and the full gate fits its 2-3 explicit-choice limit**. A standard four-option forward-step menu does not fit: render every action with the numbered fallback (or a lossless hybrid where the fourth action remains an explicit numbered choice). Never merge or drop actions to make the tool call fit. Source: [Codex app-server reference](https://developers.openai.com/codex/app-server). |
+| Codex / OpenAI app-server | `request_user_input` / `tool/requestUserInput` when exposed and lossless | In Codex CLI, use `request_user_input` only when the active tool list and current collaboration mode both allow it **and the full gate fits the capacities advertised by that callable primitive**. If an active schema advertises only 2-3 explicit choices, a standard four-option forward-step menu does not fit: render every action with the numbered fallback (or a lossless hybrid where the fourth action remains an explicit numbered choice). Never merge or drop actions to make the tool call fit. Source: [Codex app-server reference](https://developers.openai.com/codex/app-server). |
 | Conductor | Underlying agent primitive | Conductor runs Claude Code or Codex sessions; route to that agent's question primitive. Conductor Plan Mode exists for both, but Conductor is not a separate question API. Source: [Conductor agent modes](https://conductor.build/docs/concepts/agent-modes). |
 | OpenCode | `question` tool | The built-in `question` tool asks during execution with header, question text, options, and custom answers; ensure `permission.question` is not denied. Source: [OpenCode tools](https://opencode.ai/docs/tools#question). |
 | GitHub Copilot CLI | `ask_user` tool | Copilot CLI lists `ask_user` as "Ask the user a question" and `--no-ask-user` disables it. Use it when available; otherwise numbered text. Source: [Copilot CLI command reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference). |

--- a/skills/cheese/references/harness-portability.md
+++ b/skills/cheese/references/harness-portability.md
@@ -18,12 +18,12 @@ Use the host primitive that preserves bounded context. When the host offers mult
 
 ## User interaction
 
-Build the semantic question or handoff record first, following the shared [`handoff-gate.md`](handoff-gate.md) contract. Then use the richest callable structured question primitive that can faithfully encode the complete decision:
+Build the semantic question or handoff record first, following the shared [`handoff-gate.md`](handoff-gate.md) contract. Then use the richest callable structured question primitive that can faithfully encode the complete decision. Discover callability and the active primitive's advertised question and option capacities at runtime instead of assuming a harness-wide limit:
 
 - Claude Code: `AskUserQuestion`.
-- Codex: `request_user_input` when it is exposed, the active collaboration mode permits it, and the complete gate fits its 2-3 explicit-choice limit.
+- Codex: `request_user_input` when it is exposed, the active collaboration mode permits it, and the complete gate fits the capacities advertised by that callable primitive.
 - Other harnesses: an equivalent structured question primitive with enough option capacity for every action.
-- When no structured primitive is callable **or its limits cannot represent every action**: use the lossless numbered-text fallback from the handoff gate. A hybrid is valid only if every omitted button remains an explicit, equally actionable numbered choice alongside the structured prompt.
+- When no structured primitive is callable **or its limits cannot represent every action**: use the lossless numbered-text fallback from the handoff gate. If an active primitive advertises only 2-3 explicit choices, a four-option gate is one case that requires the fallback or a hybrid. A hybrid is valid only if every omitted button remains an explicit, equally actionable numbered choice alongside the structured prompt.
 
 This is a native-first priority order, not a lowest-common-denominator rule. Never merge, hide, or drop actions to fit a host primitive. Preserve the recommended choice, every option's effect or tradeoff, a free-form `Other` path, and immediate execution of the selected non-stop action across every rendering. Degrade only as far as the active harness requires.
 

--- a/skills/cheese/references/harness-portability.md
+++ b/skills/cheese/references/harness-portability.md
@@ -16,6 +16,17 @@ If a helper path is shown, the doc should say what behavior the helper provides,
 
 Use the host primitive that preserves bounded context. When the host offers multiple primitives, prefer the one that returns fresh line or snapshot context and call out the fallback only as a fallback.
 
+## User interaction
+
+Build the semantic question or handoff record first, following the shared [`handoff-gate.md`](handoff-gate.md) contract. Then use the richest callable structured question primitive that can faithfully encode the complete decision:
+
+- Claude Code: `AskUserQuestion`.
+- Codex: `request_user_input` when it is exposed, the active collaboration mode permits it, and the complete gate fits its 2-3 explicit-choice limit.
+- Other harnesses: an equivalent structured question primitive with enough option capacity for every action.
+- When no structured primitive is callable **or its limits cannot represent every action**: use the lossless numbered-text fallback from the handoff gate. A hybrid is valid only if every omitted button remains an explicit, equally actionable numbered choice alongside the structured prompt.
+
+This is a native-first priority order, not a lowest-common-denominator rule. Never merge, hide, or drop actions to fit a host primitive. Preserve the recommended choice, every option's effect or tradeoff, a free-form `Other` path, and immediate execution of the selected non-stop action across every rendering. Degrade only as far as the active harness requires.
+
 ## Sub-agent dispatch
 
 Name the semantic contract first:
@@ -29,8 +40,10 @@ Name the semantic contract first:
 Then show the host-specific syntax as an example:
 
 - Anthropic Claude Code: `Agent(...)`
-- Codex: `multi_agent_v1.spawn_agent` or the host's exposed sub-agent primitive
+- Codex: host-exposed sub-agent capability, such as `collaboration.spawn_agent`
 - OMP: `task(...)`
+
+Treat every syntax name as an example. Discover the active host capability and gate on fresh context, tool scope, and synchronous completion rather than a versioned identifier.
 
 ## GitHub operations
 
@@ -56,7 +69,9 @@ If a skill can render a slash command, it may do so, but the same transition sho
 When writing or editing a skill doc:
 
 1. Say the semantic contract first.
-2. Show the bundled or repo-local helper path before the host fallback.
-3. Treat `${CLAUDE_SKILL_DIR}` as optional host context, not the required contract.
-4. Keep `status`, `next`, and `artifact` as the durable handoff fields.
-5. Use the host GitHub primitive when present; use `gh` as the documented fallback.
+2. Use the richest callable structured question primitive that fits every action; otherwise use a lossless numbered or hybrid rendering.
+3. Preserve every explicit action, recommendations, option tradeoffs, free-form `Other`, and immediate selected action.
+4. Show the bundled or repo-local helper path before the host fallback.
+5. Treat `${CLAUDE_SKILL_DIR}` as optional host context, not the required contract.
+6. Keep `status`, `next`, and `artifact` as the durable handoff fields.
+7. Use the host GitHub primitive when present; use `gh` as the documented fallback.

--- a/skills/ultracook/references/spawn-primitive-reference.md
+++ b/skills/ultracook/references/spawn-primitive-reference.md
@@ -12,7 +12,7 @@ A spawn primitive is acceptable iff it satisfies all five:
 4. **Returns control.** The orchestrator regains control after each spawn so it can read the handoff slug. Fire-and-forget primitives do not satisfy this invariant.
 5. **Writes handoff slug.** Each spawn writes its result to `.cheese/<phase>/<slug>.md` per the schema. The orchestrator decides chain progression from the slug, never from stdout.
 
-If the host harness exposes no fan-out primitive at all, parallel mode is unavailable — fall back to `/ultracook`'s linear chain (or `/cook --auto`) in the parent's own context, which needs no fan-out primitive.
+If the host harness exposes no spawn primitive that satisfies all five invariants, halt `/ultracook` and recommend `/cook --auto`. Running in the parent's context explicitly drops `/ultracook`'s fresh-context guarantee.
 
 ## Anthropic Claude Code — `Agent()` / `/batch`
 
@@ -60,13 +60,14 @@ Rules:
 - Fleet agents inherit the same model and tool scope as the parent session, satisfying invariant 2.
 - Each agent must write the handoff slug to `.cheese/ultracook/<slug>/curds/<id>.md` per the per-curd prompt template.
 
-## OpenAI Codex — `multi_agent_v1.spawn_agent`
+## OpenAI Codex: host-exposed sub-agent capability
 
-In Codex API sessions, use the exposed multi-agent tool rather than OMP's `task(...)` shorthand:
+In Codex sessions, use the host's exposed spawn capability rather than assuming a versioned tool name. For example, a host may expose `collaboration.spawn_agent`:
 
 ```text
-multi_agent_v1.spawn_agent(
-  agent_type: "generalist",  # or a typed full-peer equivalent — gate on capability, not the label
+collaboration.spawn_agent(
+  task_name: "<phase>-<slug>",
+  fork_turns: "none",
   message: "Run /<phase> <slug> --auto for THIS PHASE ONLY. Write
            .cheese/<phase>/<slug>.md with the handoff schema and stop.
            Do not chain forward to the next phase even though your
@@ -77,7 +78,8 @@ multi_agent_v1.spawn_agent(
 Rules:
 
 - Omit model overrides unless the user explicitly requests one; the spawn should inherit the parent model where the host supports it.
-- Pick an `agent_type` that satisfies invariant 2. Reject scoped read-only workers that lack a phase's tools.
+- Request the host's no-context mode (`fork_turns: "none"` in this example); inheriting conversation turns violates invariant 1.
+- Choose a full-peer, write-capable worker that satisfies invariant 2. Reject scoped read-only workers that lack a phase's tools.
 - Wait for the returned agent before reading the handoff slug; fire-and-forget dispatch fails invariant 4.
 - The prompt must include the no-chain-forward directive and the foreground-only directive (run in the foreground; do not background yourself or defer work; write a partial slug with `status: halt: <reason>` if the context window is exhausted, do not silently timeout).
 
@@ -91,4 +93,4 @@ Any primitive that satisfies the five invariants is acceptable. When evaluating 
 4. Confirm control returns synchronously (invariant 4).
 5. Confirm the sub-agent can write files inside `.cheese/` (invariant 5).
 
-If any invariant fails, document the limitation in the host capabilities section of the manifest and route to `/ultracook` (sequential, same context) instead.
+If any invariant fails, halt `/ultracook` and recommend `/cook --auto`, explicitly noting that it runs in the parent's context and does not provide `/ultracook`'s fresh-context guarantee.

--- a/skills/wheypoint/SKILL.md
+++ b/skills/wheypoint/SKILL.md
@@ -2,7 +2,6 @@
 name: wheypoint
 description: Mark a checkpoint in the current conversation — compact it into a durable handoff document so a fresh agent can resume the work without context loss. Use when the user wants to preserve session state for a later or parallel session — phrases like "hand this off", "write a handoff", "drop a wheypoint", "checkpoint this", "compact the conversation", "I'm running low on context", "save where we are for the next session", "prep a handoff for another agent", "/wheypoint". Use even when the user just says "wrap up" or "I need to clear context" mid-task. Do NOT use for per-phase pipeline handoffs — those belong to `/cook`, `/press`, `/age`, and `/cure`.
 license: MIT
-allowed-tools: Read, Glob, mcp__tilth__tilth_read, mcp__tilth__tilth_list, Write(.cheese/notes/**), Bash(git status:*), Bash(git log:*), Bash(git diff:*)
 ---
 
 # /wheypoint
@@ -204,7 +203,7 @@ Strip anything sensitive before writing: API keys, tokens, passwords, connection
 
 ## Handoff
 
-The handoff document is the only thing `/wheypoint` writes. No commits, no PRs, no production-code edits — enforced by the frontmatter `allowed-tools` grant: read-only inspection plus `Write` scoped to `.cheese/notes/**`. End by surfacing the slug's orientation line, a normal Markdown link to the note, and repo-root-aware resumption commands. Keep the note link outside fenced code so it is clickable. The link line should match this shape: `Wheypoint dropped: [.cheese/notes/<slug>.md](<absolute-note-path>)`.
+The handoff document is the only thing `/wheypoint` writes. No commits, PRs, or production-code edits. Use the host's read-only inspection capabilities plus a write capability scoped to `.cheese/notes/**`. End by showing the slug's orientation line, a normal Markdown link to the note, and repo-root-aware resumption commands. Keep the note link outside fenced code so it is clickable. The link line should match this shape: `Wheypoint dropped: [.cheese/notes/<slug>.md](<absolute-note-path>)`.
 
 Resume from original repo:
 

--- a/skills/wheypoint/SKILL.md
+++ b/skills/wheypoint/SKILL.md
@@ -77,7 +77,7 @@ Four optional provenance fields sit between `artifact:` and the orientation line
   - **codex** — the `payload.cwd` field in the rollout meta line of the active rollout log.
   - **opencode** — the matching row in the `session` table.
   - When the harness is unknown or no log is accessible, omit the field. `<speculative>` the newest-mtime claude heuristic can bind the wrong `*.jsonl` when several live sessions share one cwd; the field is optional so a wrong bind is hand-correctable.
-- **`git: <branch>@<short-sha>`** — the branch and short commit at capture time: the branch from `git status` and the short sha from `git log -1 --format=%h` (the `Bash(git status:*)` and `Bash(git log:*)` grants cover the reads). Omit outside a git repo.
+- **`git: <branch>@<short-sha>`** — the branch and short commit at capture time. Use any callable, read-only git inspection capability the active harness exposes. CLI transports may run `git status --short --branch` for the branch and `git rev-parse --short HEAD` for the short SHA. Omit the field when git inspection is unavailable, outside a git repository, or either value cannot be determined.
 - **`created: <UTC ISO-8601>`** — the capture timestamp in UTC ISO-8601 (e.g. `2026-07-09T14:32:00Z`).
 - **`parents: [<slug>, ...]`** — lineage. Empty or absent for a fresh single-thread note. `--join` sets two or more source slugs; each `--split` child sets exactly the current slug.
 

--- a/tests/python/test_docs_emphasis_guard.py
+++ b/tests/python/test_docs_emphasis_guard.py
@@ -234,7 +234,9 @@ def test_harness_portability_reference_covers_the_portability_contract():
     assert "repo-local" in body and "bundled" in body and "environment variable" in body
     assert "sub-agent dispatch" in body
     assert "Anthropic Claude Code: `Agent(...)`" in body
-    assert "Codex: `multi_agent_v1.spawn_agent`" in body
+    assert "Codex: host-exposed sub-agent capability" in body
+    assert "`collaboration.spawn_agent`" in body
+    assert "multi_agent_v1.spawn_agent" not in body
     assert "OMP: `task(...)`" in body
     assert "OMP / Codex" not in body and "Codex-style" not in body
     assert "GitHub operations" in body
@@ -243,3 +245,61 @@ def test_harness_portability_reference_covers_the_portability_contract():
     assert "Handoff transitions" in body
     assert "Slash commands are presentation, not the control model." in body
     assert "status" in body and "next" in body and "artifact" in body and "explicit dispatch data" in body
+
+
+def test_question_routing_is_native_first_and_lossless():
+    portability = (REPO_ROOT / "skills/cheese/references/harness-portability.md").read_text(
+        encoding="utf-8"
+    )
+    gate = (REPO_ROOT / "skills/cheese/references/handoff-gate.md").read_text(encoding="utf-8")
+
+    assert "Claude Code: `AskUserQuestion`" in portability
+    assert "Codex: `request_user_input`" in portability
+    assert "active collaboration mode permits it" in portability
+    assert "richest callable structured question primitive" in portability
+    assert "faithfully encode the complete decision" in portability
+    assert "2-3 explicit-choice limit" in portability
+    assert "limits cannot represent every action" in portability
+    assert "lossless numbered-text fallback" in portability
+    assert "Never merge, hide, or drop actions" in portability
+    for required in ("recommended choice", "every option's effect or tradeoff", "free-form `Other`", "immediate execution"):
+        assert required in portability
+
+    assert "richest question mechanism" in gate
+    assert "faithfully encode every option" in gate
+    assert "active tool list and current collaboration mode both allow it" in gate
+    assert "2-3 explicit-choice limit" in gate
+    assert "standard four-option forward-step menu does not fit" in gate.lower()
+    assert "Never merge or drop actions" in gate
+    assert "fallback must enumerate every option" in gate
+    assert "free-form `Other` path" in gate
+    assert "execute that in-skill action immediately" in gate
+    assert "immediately enter that skill" in gate
+
+
+def test_core_cheese_questions_use_the_shared_handoff_gate():
+    cheese = (REPO_ROOT / "skills/cheese/SKILL.md").read_text(encoding="utf-8")
+
+    assert "ask one clarifying question through the host routing guide" in cheese
+    assert "references/handoff-gate.md" in cheese
+    assert "Tier 3 blocks on a single targeted host-routed question" in cheese
+    assert "With `--safe`, issue a handoff gate" in cheese
+    assert "cross-harness post-selection dispatch contract" in cheese
+    assert "Codex-safe" not in cheese
+
+
+def test_router_and_wheypoint_do_not_assume_claude_native_tools():
+    for relative in ("skills/cheese/SKILL.md", "skills/wheypoint/SKILL.md"):
+        frontmatter = (REPO_ROOT / relative).read_text(encoding="utf-8").split("---", 2)[1]
+        for claude_tool in ("AskUserQuestion", "Read", "Glob", "Task", "Agent"):
+            assert claude_tool not in frontmatter, f"{relative} assumes {claude_tool}"
+
+
+def test_ultracook_spawn_reference_requires_fresh_context_or_halts():
+    body = (REPO_ROOT / "skills/ultracook/references/spawn-primitive-reference.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'fork_turns: "none"' in body
+    assert "halt `/ultracook` and recommend `/cook --auto`" in body
+    assert "same context) instead" not in body

--- a/tests/python/test_docs_emphasis_guard.py
+++ b/tests/python/test_docs_emphasis_guard.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 FENCE_RE = re.compile(r"```.*?```", re.S)
@@ -253,28 +255,65 @@ def test_question_routing_is_native_first_and_lossless():
     )
     gate = (REPO_ROOT / "skills/cheese/references/handoff-gate.md").read_text(encoding="utf-8")
 
+    # Native structured controls stay first-class on both primary harnesses.
     assert "Claude Code: `AskUserQuestion`" in portability
     assert "Codex: `request_user_input`" in portability
     assert "active collaboration mode permits it" in portability
     assert "richest callable structured question primitive" in portability
+
+    # Routing discovers the callable primitive and its live advertised capacities.
+    for body in (portability, gate):
+        assert "callable" in body
+        assert "advertised question and option capacities" in body
+    assert "active tool list and current collaboration mode both allow it" in gate
+    assert "capacities advertised by that callable primitive" in gate
+
+    # A four-option gate is conditional on the active schema, never a Codex-wide limit.
+    for body in (portability, gate):
+        assert "If an active" in body
+        assert "2-3 explicit choices" in body
+        assert "four-option" in body
+        assert "2-3 explicit-choice limit" not in body
+
+    # Every rendering preserves the semantic decision without dropping fidelity.
     assert "faithfully encode the complete decision" in portability
-    assert "2-3 explicit-choice limit" in portability
     assert "limits cannot represent every action" in portability
     assert "lossless numbered-text fallback" in portability
     assert "Never merge, hide, or drop actions" in portability
-    for required in ("recommended choice", "every option's effect or tradeoff", "free-form `Other`", "immediate execution"):
+    for required in (
+        "recommended choice",
+        "every option's effect or tradeoff",
+        "free-form `Other`",
+        "immediate execution",
+    ):
         assert required in portability
-
-    assert "richest question mechanism" in gate
     assert "faithfully encode every option" in gate
-    assert "active tool list and current collaboration mode both allow it" in gate
-    assert "2-3 explicit-choice limit" in gate
-    assert "standard four-option forward-step menu does not fit" in gate.lower()
     assert "Never merge or drop actions" in gate
     assert "fallback must enumerate every option" in gate
     assert "free-form `Other` path" in gate
     assert "execute that in-skill action immediately" in gate
     assert "immediately enter that skill" in gate
+
+
+@pytest.mark.parametrize(
+    "skill",
+    (
+        "affinage",
+        "age",
+        "cheese",
+        "cook",
+        "culture",
+        "cure",
+        "melt",
+        "mold",
+        "pasteurize",
+        "press",
+    ),
+)
+def test_core_workflow_question_sites_reference_shared_handoff_gate(skill: str):
+    body = (REPO_ROOT / f"skills/{skill}/SKILL.md").read_text(encoding="utf-8")
+
+    assert "handoff-gate.md" in body
 
 
 def test_core_cheese_questions_use_the_shared_handoff_gate():
@@ -286,6 +325,18 @@ def test_core_cheese_questions_use_the_shared_handoff_gate():
     assert "With `--safe`, issue a handoff gate" in cheese
     assert "cross-harness post-selection dispatch contract" in cheese
     assert "Codex-safe" not in cheese
+
+
+def test_wheypoint_git_provenance_is_capability_based_and_optional():
+    body = (REPO_ROOT / "skills/wheypoint/SKILL.md").read_text(encoding="utf-8")
+
+    assert "callable, read-only git inspection capability" in body
+    assert "git status --short --branch" in body
+    assert "git rev-parse --short HEAD" in body
+    assert "branch and short commit" in body
+    assert "Omit the field when git inspection is unavailable" in body
+    assert "Bash(git" not in body
+    assert "grant" not in body.lower()
 
 
 def test_router_and_wheypoint_do_not_assume_claude_native_tools():

--- a/tests/python/test_stage_release.py
+++ b/tests/python/test_stage_release.py
@@ -107,3 +107,19 @@ def test_moved_cheese_kernel_docs_ship_with_zero_vendoring(staged: Path) -> None
     for name in _MOVED_DOC_NAMES:
         assert (refs_dir / f"{name}.md").is_file(), f"{name}.md missing from staged skills/cheese/references/"
     assert not (staged / "shared").exists()
+
+
+def test_release_workflow_validates_staged_tree_after_transformations() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+    stage = workflow.index("python3 scripts/stage_release.py")
+    validate = workflow.index("gh skill publish --dry-run")
+    publish = workflow.index("git init -q")
+
+    assert stage < validate < publish
+    assert "working-directory: ${{ runner.temp }}/release" in workflow[stage:validate]
+
+
+def test_release_workflow_pins_checkout_to_v6_0_2() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+    assert "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2" in workflow


### PR DESCRIPTION
## Summary

- preserve native structured questions for Claude and Codex when they can encode the complete handoff gate
- degrade losslessly to equivalent structured input or numbered choices without hiding actions
- make Codex fresh-context spawning explicit and remove the invalid same-context ultracook fallback
- validate the staged release tree and pin release dependencies/examples to verified versions

## Verification

- `PIP_BREAK_SYSTEM_PACKAGES=1 just check`
- fresh-context portability/release review: pass

## Notes

Hallouminate prose grounding was attempted but blocked by the LanceDB missing-file defect tracked in paulnsorensen/hallouminate#204.
