### PR TITLE
feat(skills): import /pr-stack

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "easy-cheese",
   "skills": [
-    "./skills/age",
     "./skills/affinage",
+    "./skills/age",
     "./skills/briesearch",
     "./skills/cheese",
     "./skills/cheez-read",
@@ -15,6 +15,7 @@
     "./skills/melt",
     "./skills/mold",
     "./skills/pasteurize",
+    "./skills/pr-stack",
     "./skills/press",
     "./skills/ultracook",
     "./skills/wheypoint"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Content shared _across_ skills lives in the always-installed `cheese` skill's `r
 | `skills/hard-cheese/SKILL.md` | `/hard-cheese` (or `--hard` flag) | Metacognitive vibecheck gate before review — asks the author to explain the diff's causal logic, grades the explanation against the SOLO Taxonomy. Standalone or via `--hard` propagation through the pipeline. |
 | `skills/ultracook/SKILL.md` | `/ultracook` | Autonomous fresh-context pipeline for high-blast-radius specs. The decomposer picks the mode: a decomposable 2+-curd spec fans out into parallel curds (each running per-curd `cook → press → age → cure` in its own worktree, harvested back, then one post-merge review pass, ending in 1–N reviewable PRs); an indivisible spec runs the linear chain (`cook → press → age → cure → age → cure → age`, all `--auto`). Each phase runs inside its own full-peer sub-agent so review stays adversarial and parent context never bloats. |
 | `skills/melt/SKILL.md` | `/melt` | Resolve merge / rebase / cherry-pick conflicts via the structural cascade (mergiraf → rerere → kdiff3) with batch, pick-side, and lockfile helpers. |
+| `skills/pr-stack/SKILL.md` | `/pr-stack` | Manage stacked PRs with whichever stacking tool is installed — Graphite (`gt`), git-town, or `gh stack` — detected per repo and driven via its per-tool reference. |
 | `skills/wheypoint/SKILL.md` | `/wheypoint` | Mark a checkpoint: compact a mid-task conversation into a durable handoff document at `.cheese/notes/<slug>.md` (resumable slug + state-mapped suggested-skills + redacted secrets) so a fresh agent can resume via `/cheese --continue <slug>`. |
 
 ### Tool skills
@@ -212,7 +213,7 @@ gh skill install paulnsorensen/easy-cheese
 Install every current skill in one shot:
 
 ```sh
-for s in age affinage briesearch cheese cheez-read cheez-search cheez-write cook culture cure hard-cheese melt mold pasteurize press ultracook wheypoint; do
+for s in age affinage briesearch cheese cheez-read cheez-search cheez-write cook culture cure hard-cheese melt mold pasteurize pr-stack press ultracook wheypoint; do
   gh skill install paulnsorensen/easy-cheese "$s"
 done
 ```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,7 +29,7 @@ EC_SKILL_REPO="paulnsorensen/easy-cheese"
 # new skills land — this list is only used when the API call is
 # unavailable (offline, rate-limited, repo temporarily private). Kept
 # loosely in sync with skills/ but not load-bearing for happy-path runs.
-EC_FALLBACK_SKILLS="age affinage briesearch cheese cheez-read cheez-search cheez-write cook culture cure hard-cheese melt mold pasteurize press ultracook wheypoint"
+EC_FALLBACK_SKILLS="age affinage briesearch cheese cheez-read cheez-search cheez-write cook culture cure hard-cheese melt mold pasteurize pr-stack press ultracook wheypoint"
 
 # Default selections.
 EC_DEFAULT_TOOLS="$EC_KNOWN_TOOLS"

--- a/skills/pr-stack/SKILL.md
+++ b/skills/pr-stack/SKILL.md
@@ -14,8 +14,9 @@ description: >
   "the bottom PR merged, what now", "clean up after a stack merge", or
   invokes /pr-stack. If none is available, stop and tell the
   user — never fall back to ad-hoc `git push` chains. Do NOT use for
-  staging or committing — hand off to /commit. Do NOT use for PR review
-  traffic, comments, or CI checks — hand off to /gh.
+  staging or committing — hand off to a discovered /commit skill (plain
+  `git commit` otherwise). Do NOT use for PR review traffic, comments, or
+  CI checks — hand off to a discovered /gh skill (plain `gh` otherwise).
 ---
 
 # pr-stack
@@ -197,8 +198,11 @@ to memory — all three CLIs drift between versions.
 - **Don't `git push` a single branch in a stack.** Use the tool's submit /
   push command — bare push skips the parent-target wiring and leaves the
   rest of the stack stale.
-- **Stage explicitly.** All three tools follow the staged set the way
-  `git commit` does. Stage by name; avoid `git add -A`.
+- **Stage deliberately.** All three tools follow the staged set the way
+  `git commit` does. Stage by name by default; the per-tool stage-all
+  flags shown in the references (`gt … -a`/`-am`, `gh stack add -Am`) are
+  fine when you mean to stage every tracked change. Avoid blind
+  `git add -A` outside that deliberate case.
 - **One concern per branch.** That's the whole point of stacking — keep each
   PR reviewable in isolation.
 - **After a rebase conflict, use the tool's `continue` / `abort`**, never

--- a/skills/pr-stack/SKILL.md
+++ b/skills/pr-stack/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: pr-stack
+model: haiku
+allowed-tools: Bash(gt:*), Bash(gh:*), Bash(git:*)
+license: MIT
+description: >
+  Manage stacked PRs using whichever stacking tool is installed: Graphite
+  (`gt`), git-town (`git town`), or GitHub's native `gh stack` extension.
+  Detects which is available in the current repo, then drives the matching
+  one via its per-tool reference (`references/gt.md`,
+  `references/git-town.md`, or `references/gh-stack.md`). Use when the
+  user asks to "create a stack", "stack a branch", "restack", "submit a
+  stacked PR", "rebase the stack", "sync the stack", "track this branch",
+  "the bottom PR merged, what now", "clean up after a stack merge", or
+  invokes /pr-stack. If none is available, stop and tell the
+  user — never fall back to ad-hoc `git push` chains. Do NOT use for
+  staging or committing — hand off to /commit. Do NOT use for PR review
+  traffic, comments, or CI checks — hand off to /gh.
+---
+
+# pr-stack
+
+Stacked branches: a chain of small branches each opening one PR, kept in
+order across rebases and pushed as a group.
+
+Three tools implement this workflow today. They share the same mental model
+but live in different ecosystems:
+
+- **Graphite (`gt`)** — third-party CLI, mature, requires a Graphite account
+  (`gt auth`). Stack metadata lives in `.git/.graphite_repo_config`.
+- **git-town (`git town`)** — third-party CLI, mature, no account and
+  forge-agnostic (GitHub / GitLab / Gitea / Bitbucket / Forgejo / Azure
+  DevOps). Branch lineage lives in local git config
+  (`git-town-branch.<name>.parent`), so there's nothing to sign up for.
+- **GitHub `gh stack`** — first-party `gh` extension (`github/gh-stack`),
+  private preview as of 2026-05; repos must be allow-listed via
+  [gh.io/stacksbeta](https://gh.io/stacksbeta). Stack metadata lives in
+  `.git/gh-stack`. Uses standard `gh auth login` — no third-party account.
+
+This skill picks whichever one the user has and drives it. It does not
+emulate stacking with plain `git`.
+
+## Detection — run before anything else
+
+```bash
+# gt available?
+command -v gt >/dev/null 2>&1 && gt --version >/dev/null 2>&1
+
+# gt initialized in this repo?
+test -f "$(git rev-parse --git-dir)/.graphite_repo_config"
+
+# gh stack extension installed?
+# (gh extension list output is TAB-separated: <short-name>\t<owner/repo>\t<version>)
+# Guard with `command -v gh` so the probe stays quiet when gh itself is missing
+# — `2>/dev/null` on the pipeline doesn't catch the shell's own "command not
+# found" message.
+command -v gh >/dev/null 2>&1 \
+  && gh extension list 2>/dev/null | awk -F '\t' '$2 == "github/gh-stack"' | grep -q .
+
+# git-town available?
+command -v git-town >/dev/null 2>&1 && git town --version >/dev/null 2>&1
+
+# git-town configured for this repo? (non-empty trunk = set up)
+git config --local --get git-town.main-branch >/dev/null 2>&1
+```
+
+**Pick the tool the repo is already set up for.** A tool counts as *usable
+here* when it's installed **and** configured for this repo:
+
+| Tool | Installed probe | Configured-for-repo probe |
+| --- | --- | --- |
+| `gt` | `command -v gt` | `.git/.graphite_repo_config` exists |
+| `git town` | `command -v git-town` | `git config --local --get git-town.main-branch` non-empty |
+| `gh stack` | `gh extension list` has `github/gh-stack` | no preflight — detected lazily when a remote op exits `4` |
+
+Then:
+
+- **Exactly one usable** → use it; read that tool's reference.
+- **More than one usable** → prefer **`gt`** (GA, mature, and the repo may
+  already track a stack), then **`git town`** (GA, no account,
+  forge-agnostic), then **`gh stack`** (first-party but private preview).
+  Tell the user which others are present and offer to switch.
+- **Installed but not configured** → offer the one-time setup (`gt init`,
+  or `git config --local git-town.main-branch <trunk>` — your trunk name,
+  e.g. `main` / `master`; `gh stack` needs no repo init) and proceed.
+- **None usable** → **stop.** Don't reach for `git push` chains. See
+  "None installed" below.
+
+Run the probes every invocation — the user's environment can change between
+sessions.
+
+## None installed
+
+If detection finds none of `gt`, `git town`, or the `gh stack` extension,
+surface this verbatim and stop:
+
+> Stacked-PR tooling isn't available on this machine / for this repo. Install
+> one of:
+>
+> - **Graphite CLI** — `brew install withgraphite/tap/graphite` (or
+>   `npm install -g @withgraphite/graphite-cli@stable`), then
+>   `gt auth --token <token from https://app.graphite.com/activate>` and
+>   `gt init` inside this repo.
+> - **git-town** — `brew install git-town` (or `choco` / `scoop` on
+>   Windows), then `git config --local git-town.main-branch <trunk>` (your
+>   trunk name, e.g. `main` / `master`; or the `git town config setup`
+>   wizard) inside this repo, plus either `git config --local
+>   git-town.github-connector gh` (reuse your `gh` auth) or a
+>   `git-town.github-token` PAT. Works on GitHub, GitLab, Gitea, and more.
+> - **GitHub native `gh stack`** — `gh extension install github/gh-stack`,
+>   then make sure the repo is allow-listed at
+>   [gh.io/stacksbeta](https://gh.io/stacksbeta) (private preview as of
+>   2026-05).
+>
+> Once one of those is installed, re-invoke `/pr-stack` and I'll drive it.
+
+Do not improvise with plain `git push` chains, parent-target wiring, or
+manual PR linking — the value of this skill is the stack-aware machinery,
+and faking it produces a worse outcome than telling the user the tool is
+missing.
+
+**Third failure mode — `gh stack` installed but the repo isn't allow-listed.**
+The CLI installs anywhere, but remote ops (`submit`, `sync`, `link`) fail
+with exit code `4` when the repo isn't on the private-preview allow-list.
+If you see exit `4`, surface this and point the user at
+[gh.io/stacksbeta](https://gh.io/stacksbeta). If `gt` is also installed
+locally, offer to fall back to it for this repo.
+
+## Mental model (shared)
+
+- **Trunk** is `main` (or whatever the repo calls it).
+- **Stack** is a chain of branches, each parented on the previous one. The
+  bottom of every stack is trunk.
+- **One PR per branch**, each PR targeting its parent branch. The chain
+  reviews bottom-up.
+- **Submit pushes the whole chain** and opens / updates one PR per branch.
+- **Sync** pulls trunk, restacks every surviving branch onto the new trunk
+  tip, and prunes branches whose PRs have merged.
+
+All three tools implement this model. Command names diverge — see the per-tool
+reference.
+
+## After a PR in the stack merges
+
+When the bottom (or any merged) PR lands, the rest of the stack needs to
+follow trunk forward and the merged branch needs to drop out. This is a
+distinct moment — don't wait for it to come up in normal "sync" cadence.
+
+Run the tool's sync command:
+
+| Tool | Command | What it does |
+| --- | --- | --- |
+| `gt` | `gt sync` then `gt submit --stack` | Fetches trunk, restacks survivors onto the new trunk tip locally, prompts to delete merged / closed branches. Then submit pushes the rebased survivors. |
+| `gh stack` | `gh stack sync` (`gh stack submit` only if you have unpushed local commits) | GitHub already cascaded the rebase server-side at merge time; sync mostly pulls that state down and updates local refs. |
+| `git town` | `git town sync --stack` | Fetches trunk, drops the merged branch, rebases the survivors onto the new trunk tip locally, and force-pushes them so the forge re-targets their PRs. |
+
+Key divergence: with `gh stack` the survivors were already rebased by the
+GitHub server when the bottom PR merged — your job is to **pull that state
+down**, not to recompute it. With `gt` the rebase is local, so `gt sync`
+does the actual work on your machine.
+
+If sync hits a conflict (trunk and a survivor touched the same lines), drop
+into the tool's conflict-recovery flow — `gt continue` / `gt abort`,
+`git town continue` / `git town skip`, or
+`gh stack rebase --continue` / `--abort`. Never reach for bare
+`git rebase --continue`; the tool's metadata won't advance.
+
+After sync succeeds, run `gt log short` / `git town branch` / `gh stack view` to confirm the
+chain looks right before the next submit.
+
+## Tool-equivalence cheat sheet
+
+| Action | `gt` | `git town` | `gh stack` |
+| --- | --- | --- | --- |
+| Initialize stack metadata | `gt init` (repo-level) | `git town config setup` (repo-level) | `gh stack init` (per-stack) |
+| Start a stack off trunk | `gt create` on trunk | `git town hack <name>` | `gh stack init` + `gh stack add` |
+| Create branch on top | `gt create -am "msg"` | `git town append <name>` (then commit) | `gh stack add -Am "msg"` |
+| Amend tip + restack children | `gt modify -a` | edit, then `git town sync --stack` | (edit, then `gh stack push`) |
+| New commit + restack children | `gt modify -cam "msg"` | commit, then `git town sync --stack` | (commit, then `gh stack push`) |
+| Inspect stack | `gt log short` (`gt ls`) | `git town branch` | `gh stack view` (`-s` short) |
+| Pull trunk + restack | `gt sync` | `git town sync --stack` | `gh stack sync` |
+| Cascade restack only | `gt restack` | `git town sync --stack --no-push` | `gh stack rebase` |
+| Submit / update PRs | `gt submit --stack` (`gt ss`) | `git town propose --stack` | `gh stack submit` |
+| Adopt a plain-git branch | `gt track` (any time) | `git town set-parent` (any time) | `gh stack init --adopt` *(init-time only)* |
+| Move up / down in stack | `gt up` / `gt down` | `git town switch` (picker) | `gh stack up` / `gh stack down` |
+| Continue after conflict | `gt continue` | `git town continue` | `gh stack rebase --continue` |
+| Abort / skip halted op | `gt abort` | `git town skip` / `git town undo` | `gh stack rebase --abort` |
+| Open existing PRs as stack | n/a | n/a (set parents, then `propose --stack`) | `gh stack link <PRs...>` |
+
+When in doubt about flags, **always defer to the per-tool reference**, not
+to memory — all three CLIs drift between versions.
+
+## Rules (apply to all three tools)
+
+- **Don't reach into `git rebase` mid-stack.** Use the tool's sync / restack /
+  modify commands so children stay parented correctly.
+- **Don't `git push` a single branch in a stack.** Use the tool's submit /
+  push command — bare push skips the parent-target wiring and leaves the
+  rest of the stack stale.
+- **Stage explicitly.** All three tools follow the staged set the way
+  `git commit` does. Stage by name; avoid `git add -A`.
+- **One concern per branch.** That's the whole point of stacking — keep each
+  PR reviewable in isolation.
+- **After a rebase conflict, use the tool's `continue` / `abort`**, never
+  bare `git rebase --continue` / `--abort` — the tool's metadata won't
+  update otherwise.
+
+## Handoffs
+
+- Staging and crafting commit messages → a discovered `/commit` skill when
+  available, plain `git commit` otherwise.
+- PR review, CI checks, merge, comments → a discovered `/gh` skill when
+  available, plain `gh` otherwise.
+- Pre-commit hooks complaining → a discovered `/prek` skill when available,
+  otherwise resolve the hook failure directly and re-stage.
+
+## When to read references
+
+- `references/gt.md` — full `gt` command surface (create / modify / sync /
+  submit / track / log), install + auth, restack recipes, conflict
+  recovery, monorepo / multi-trunk caveats. Read when detection picks `gt`.
+- `references/git-town.md` — full `git town` command surface (hack / append /
+  sync / propose / set-parent / ship), install + forge auth, conflict
+  recovery, config keys, squash-merge gotcha. Read when detection picks
+  `git town`.
+- `references/gh-stack.md` — full `gh stack` command surface, install +
+  waitlist, exit codes, conflict recovery, divergence from `gt`. Read when
+  detection picks `gh stack`.

--- a/skills/pr-stack/references/gh-stack.md
+++ b/skills/pr-stack/references/gh-stack.md
@@ -1,0 +1,315 @@
+# `gh stack` reference
+
+GitHub's first-party stacked-PR workflow, delivered as a `gh` extension
+(`github/gh-stack`). The CLI drives the local branch / PR machinery; the
+GitHub PR UI renders the stack map, enforces bottom-up merging, and runs
+cascading rebases server-side.
+
+The shared mental model and tool-selection rules live in `../SKILL.md`.
+This file is the `gh stack`-side detail.
+
+**Status (2026-05-12):** Private preview. The CLI installs anywhere, but
+remote operations fail against any repo not allow-listed via the waitlist
+at [gh.io/stacksbeta](https://gh.io/stacksbeta).
+
+Primary sources:
+
+- Landing: <https://github.github.com/gh-stack/>
+- Quick start: <https://github.github.com/gh-stack/getting-started/quick-start/>
+- Overview: <https://github.github.com/gh-stack/introduction/overview/>
+- CLI reference: <https://github.github.com/gh-stack/reference/cli/>
+- Working with stacked PRs: <https://github.github.com/gh-stack/guides/stacked-prs/>
+- Repo + README + exit codes: <https://github.com/github/gh-stack>
+
+## Install / enable
+
+```bash
+gh extension install github/gh-stack          # install
+gh extension upgrade gh-stack                 # upgrade
+gh stack alias                                # optional: install `gs` alias
+```
+
+The `gh stack alias` step writes a `gs` shell alias so users can type
+`gs init` instead of `gh stack init`. **Skills should NOT assume the alias
+is installed** — always emit `gh stack …`.
+
+Requires `gh` v2.0+. Uses standard OAuth via `gh auth login`. **Personal
+access tokens (PATs) are explicitly unsupported.**
+
+Source: <https://github.com/github/gh-stack>,
+<https://github.github.com/gh-stack/getting-started/quick-start/>.
+
+## Detection
+
+Run these in order:
+
+1. Extension installed locally:
+
+   ```bash
+   gh extension list | grep -q '^github/gh-stack\b'
+   ```
+
+   (or `gh stack --help` exits 0 — same signal, slower.)
+
+2. `gh` version OK: `gh --version` reports `>= 2.0`.
+
+3. **Repo enablement** has no documented preflight command. The only
+   reliable signal is exit code `4` from a remote op (`submit`, `sync`,
+   `link`) when the repo isn't allow-listed. Don't preflight — just run
+   the user's command and translate the failure.
+
+## Mental model
+
+A stack is an ordered chain of branches rooted on trunk (default `main`).
+Each branch's PR base is the branch below it.
+
+```
+frontend       → PR #3 (base: api-endpoints)   ← top
+api-endpoints  → PR #2 (base: auth-layer)
+auth-layer     → PR #1 (base: main)            ← bottom
+main (trunk)
+```
+
+Local metadata lives in `.git/gh-stack` (stack tracking) and
+`.git/gh-stack-rebase-state` (rebase recovery). Neither is committed.
+
+What `gh stack` does that third-party stackers don't:
+
+- The **stack map** renders inside the GitHub PR UI itself.
+- Merges are **server-enforced bottom-up** — mid-stack merges are rejected
+  by the API.
+- A **Rebase Stack** button in the UI triggers server-side cascading
+  rebase + force-push of every unmerged branch.
+
+All three merge methods (squash, merge commit, rebase) are supported, and
+stacks are merge-queue compatible.
+
+Source: <https://github.github.com/gh-stack/introduction/overview/>,
+<https://github.github.com/gh-stack/guides/stacked-prs/>.
+
+## Command surface
+
+All flags below come from the official CLI reference page unless tagged.
+
+### Stack management (local)
+
+| Command | Purpose |
+| --- | --- |
+| `gh stack init [flags] [branches...]` | Create a stack and its first branch. Flags: `-b/--base <branch>`, `-a/--adopt`, `-p/--prefix <str>`, `-n/--numbered` (requires `--prefix`). |
+| `gh stack add [flags] [branch]` | Add a new branch on top of the current stack. Must be run from the topmost branch. `-Am "msg"` folds add + stage + commit. |
+| `gh stack view [flags]` | List branches, PR links, statuses, last commit. Flags: `-s/--short`, `--json`. Output paged. |
+| `gh stack checkout [<pr-number> \| <branch>]` | Pull a stack down from GitHub by PR number or branch. |
+| `gh stack modify [flags]` | TUI to rename / drop / reorder / fold branches. Flags: `--continue`, `--abort`. Run `gh stack submit` after to push the restructure. |
+
+### Remote operations
+
+| Command | Purpose |
+| --- | --- |
+| `gh stack push [--remote <name>]` | Push every branch with `--force-with-lease --atomic`. Does NOT touch PRs. |
+| `gh stack submit [--auto] [--open] [--remote <name>]` | Push branches AND create / update PRs and the GitHub Stack object. `--auto` skips title prompts; `--open` creates non-draft PRs (default is **draft**). |
+| `gh stack rebase [flags] [branch]` | Fetch from `origin` and cascade-rebase from trunk upward. Auto-switches to `--onto` mode for merged PRs (handles squash-merges safely). Flags: `--continue`, `--abort`. |
+| `gh stack sync [--remote <name>]` | All-in-one: fetch → fast-forward trunk → cascade rebase (only if trunk moved) → push with `--force-with-lease` → sync PR state. On conflict, restores all branches and tells you to run `gh stack rebase` interactively. |
+| `gh stack unstack` | Remove the stack from GitHub and local tracking (for restructuring). |
+| `gh stack link [flags] <branches\|PR#s...>` | Open a stack of PRs from existing branches / PRs without touching local `gh-stack` tracking state. Designed for users driving local branches with `jj`, Sapling, or git-town. Flags: `--base <branch>`, `--open`, `--remote <name>`. |
+
+### Navigation
+
+| Command | Purpose |
+| --- | --- |
+| `gh stack up [n]` | Move `n` branches up (away from trunk). Default 1. From trunk, jumps to the first stack branch. |
+| `gh stack down [n]` | Move `n` branches down (toward trunk). Default 1. |
+| `gh stack top` | Check out the topmost branch. |
+| `gh stack bottom` | Check out the bottommost branch. |
+| `gh stack switch` | Interactive TUI picker. Requires a TTY. |
+
+All navigation clamps at the bounds (no-op + message).
+
+### Utilities
+
+| Command | Purpose |
+| --- | --- |
+| `gh stack alias` | Install the `gs` alias for `gh stack`. |
+| `gh stack feedback` | Submit feedback to GitHub. |
+
+## Exit codes
+
+From the README — critical for skill error handling:
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | Generic error |
+| 2 | Not in a stack / stack not found |
+| 3 | Rebase conflict |
+| 4 | GitHub API failure (use this to detect "feature not enabled for repo") |
+| 5 | Invalid arguments or flags |
+| 6 | Disambiguation required (branch belongs to multiple stacks) |
+| 7 | Rebase already in progress |
+| 8 | Stack is locked by another process |
+
+Source: <https://github.com/github/gh-stack> (exit codes table).
+
+## Conflict recovery
+
+On exit code `3`, `gh stack` halts the cascading rebase. Resolve and resume
+using the tool's own continue / abort flags, **not** bare `git rebase
+--continue`:
+
+```bash
+# 1. Resolve conflicts in the working tree
+git status                    # shows conflicted paths
+# … edit files, remove <<<<<<< markers …
+
+# 2. Stage resolved files
+git add path/to/resolved
+
+# 3. Resume the broader stack operation
+gh stack rebase --continue    # or `gh stack rebase --abort` to back out
+```
+
+If the halted operation was `gh stack modify` (mid-restructure), use
+`gh stack modify --continue` / `--abort` instead.
+
+For `sync` specifically: on conflict, `sync` restores all branches to
+their pre-sync state and instructs the user to run `gh stack rebase`
+interactively to resolve.
+
+## How it represents a stack on GitHub
+
+- One PR per branch, each with `base` set to the branch below it (each
+  PR's diff is just that layer).
+- A first-party **Stack** object linking the PRs, surfaced as a stack map
+  in the PR UI.
+- A **Rebase Stack** button in the UI triggers server-side cascading
+  rebase + force-push of every unmerged branch.
+- Merges enforced bottom-up: a contiguous group starting from the lowest
+  unmerged PR. Mid-stack merges are rejected by the server.
+- After a merge, GitHub auto-rebases the remaining PRs so the next-lowest
+  PR targets the updated base.
+- Merge methods: squash, merge commit, rebase — all supported. Merge-queue
+  compatible.
+
+Source: <https://github.github.com/gh-stack/introduction/overview/>,
+<https://github.github.com/gh-stack/guides/stacked-prs/>.
+
+## Known limitations
+
+- **Private preview** — does not work on non-allow-listed repos. Join the
+  waitlist at <https://gh.io/stacksbeta>.
+- **Forks** — community reports indicate stacked PRs still can't be opened
+  from a fork; contributors must work from branches inside the main repo.
+  Not contradicted by official docs but not explicitly confirmed either.
+- **GitHub Enterprise Server** — no GHES support documented during
+  preview. Assume GitHub.com only until confirmed.
+- **Auth** — OAuth only via `gh auth login`. PATs are explicitly
+  unsupported.
+- **Concurrency** — exit code `8` means the stack is locked by another
+  `gh stack` process. Don't run two ops in parallel against the same
+  stack.
+
+## Recipes
+
+### Open a new 2-PR stack from clean trunk
+
+```bash
+gh stack init -p feat/payments -n auth payments
+# ↑ creates feat/payments-1-auth and feat/payments-2-payments
+# … edit files in branch 1 …
+gh stack submit --open
+```
+
+Or, building one branch at a time:
+
+```bash
+gh stack init -b main feat/auth
+# … edit, commit normally …
+gh stack add -Am "feat: payments"   # adds a new top branch with that commit
+gh stack submit --open
+```
+
+### Sync trunk into your stack (also: after a sibling PR merged)
+
+This is the canonical post-merge command. When the bottom (or any) PR in
+the stack lands, GitHub has already cascaded the rebase server-side —
+`gh stack sync` pulls that state down. You only need a follow-up
+`gh stack submit` if you have local commits not yet pushed.
+
+```bash
+gh stack sync
+# if conflicts: it restores branches and tells you to run rebase manually
+gh stack rebase                     # resolve, git add, `gh stack rebase --continue`
+gh stack submit                     # re-submit after rebase
+```
+
+### Address review feedback on a non-top branch
+
+```bash
+gh stack down                       # move to the branch under review
+# … edit files, commit normally …
+git commit -am "address review"
+gh stack rebase                     # cascade the new commit up the stack
+gh stack push                       # push without re-prompting PR metadata
+```
+
+### Pull down a teammate's stack
+
+```bash
+gh stack checkout <pr-number>       # by PR number
+gh stack checkout feat/their-top    # by branch name
+gh stack view                       # confirm the chain
+```
+
+### Open a stack from branches you built with other tooling (jj / Sapling / git-town)
+
+```bash
+gh stack link --base main feat/auth feat/payments feat/ui
+# or by existing PR numbers:
+gh stack link 412 413 414
+```
+
+`gh stack link` does NOT take ownership of the branches in local
+`gh-stack` tracking — it just stacks the PRs on GitHub.
+
+### Remove the stack from GitHub (for restructuring)
+
+```bash
+gh stack unstack
+# … restructure locally, then …
+gh stack submit                     # re-creates the Stack object
+```
+
+## Agent gotchas
+
+- **Preflight**: check `gh extension list` for `github/gh-stack` and bail
+  with the install + waitlist message if missing.
+- **Detect repo enablement lazily**: don't preflight it — just run the
+  user's command and translate exit code `4` into a helpful "the Stacked
+  PRs feature isn't enabled for this repo" message.
+- **Never assume `gs`** — always emit `gh stack …`.
+- **Don't mix with `git push`**: `gh stack push` uses `--force-with-lease
+  --atomic` and knows every branch. Bare `git push` on a single stack
+  branch leaves the rest stale.
+- **Submit defaults to drafts** — pass `--open` when the user wants
+  reviewable PRs immediately.
+- **Conflict path**: on exit 3, resolve files, `git add`, then `gh stack
+  rebase --continue` (or `--abort`). For `gh stack modify`, the `--continue
+  / --abort` flags belong to `modify`, not `rebase`.
+- **Prefer `sync` for normal day-to-day**; reserve `rebase` for interactive
+  conflict resolution.
+
+## Divergence from `gt`
+
+Quick contrast for users coming from Graphite:
+
+| Concept | `gt` | `gh stack` |
+| --- | --- | --- |
+| Mental model | trunk + chain | trunk + chain (identical) |
+| Stack creation | `gt create` | `gh stack init` + `gh stack add` |
+| Submit | `gt submit` | `gh stack submit` (with PRs) / `gh stack push` (no PRs) |
+| Cascade rebase | `gt restack` / `gt sync` | `gh stack rebase` / `gh stack sync` |
+| Stack visualization | client-side | server-side stack map in PR UI |
+| Merge enforcement | client validates | GitHub server enforces bottom-up |
+| Backend account | Graphite SaaS | none — pure GitHub OAuth |
+| BYO local tooling (jj, Sapling) | partial | first-class via `gh stack link` |
+| GHES support | Enterprise plan only | not yet (preview is github.com only) |
+| Public availability | GA | private preview (waitlist) |

--- a/skills/pr-stack/references/gh-stack.md
+++ b/skills/pr-stack/references/gh-stack.md
@@ -46,7 +46,7 @@ Run these in order:
 1. Extension installed locally:
 
    ```bash
-   gh extension list | grep -q '^github/gh-stack\b'
+   gh extension list 2>/dev/null | awk -F '\t' '$2 == "github/gh-stack"' | grep -q .
    ```
 
    (or `gh stack --help` exits 0 — same signal, slower.)

--- a/skills/pr-stack/references/git-town.md
+++ b/skills/pr-stack/references/git-town.md
@@ -1,0 +1,305 @@
+# `git town` (Git Town) reference
+
+Reference for driving Git Town on behalf of a user who already has
+`git-town` installed and the repo configured. Targets `git-town` v23+.
+Flags drift between majors (v23 reworked the `up` / `down` navigation
+commands) — when in doubt, fall back to `git town <cmd> --help`.
+
+The shared mental model and tool-selection rules live in `../SKILL.md`. This
+file is the `git town`-side detail.
+
+## What makes it different
+
+- **No account, offline-first.** Unlike Graphite (`gt`), Git Town needs no
+  SaaS sign-up. All branch lineage lives in local git config — nothing is
+  stored server-side.
+- **Forge-agnostic.** Works against GitHub, GitLab, Gitea, Forgejo,
+  Bitbucket (cloud + Data Center), and Azure DevOps. Override
+  auto-detection with `git config git-town.forge-type <forge>`.
+- **Stacked changes are first-class and stable** — the docs ship a dedicated
+  "Stacked Changes" page, and `propose --stack` has been stable since the
+  v14 series (mid-2024).
+
+Source: <https://www.git-town.com/stacked-changes>,
+<https://www.git-town.com/preferences/forge-type>.
+
+## Install paths
+
+- **Homebrew** (recommended on macOS / Linux): `brew install git-town`
+- **Windows**: `choco install git-town` or `scoop install git-town`
+- **Binary**: `curl https://www.git-town.com/install.sh | sh` — review the script first (or use a package-manager path above); don't pipe an unreviewed remote script straight to `sh`.
+- **From source**: `go install github.com/git-town/git-town/v23@latest`
+  (bump the major suffix to match the installed release).
+- Version check: `git town --version`.
+
+Source: <https://www.git-town.com/install>.
+
+## First-time setup
+
+1. **Configure the repo** (once):
+
+   ```bash
+   git town config setup                  # interactive wizard (recent builds; older ones used `git town init` — confirm with `git town --help`)
+   git config --local git-town.main-branch main   # or set the trunk directly, no wizard
+   ```
+
+   The direct `git config` form is the one the detection probe below reads,
+   and works with no prompts — prefer it when driving from an agent.
+
+2. **Forge auth** — pick one:
+
+   ```bash
+   git config --local git-town.github-connector gh   # reuse the gh CLI's existing auth (cleanest if gh is set up)
+   git config --local git-town.github-token ghp_xxx  # or a PAT, stored in local git config
+   export GIT_TOWN_GITHUB_TOKEN=ghp_xxx      # or an env var (CI / ephemeral homes)
+   ```
+
+   For other forges, set `git-town.forge-type` (`gitlab` / `gitea` /
+   `bitbucket` / `forgejo` / `azuredevops`) and the matching `*-token` key
+   (e.g. `git-town.gitlab-token`).
+
+Source: <https://www.git-town.com/preferences/github-connector>,
+<https://www.git-town.com/preferences/main-branch>.
+
+### Detection probes
+
+- `git-town` installed: `command -v git-town && git town --version`
+  (non-zero if missing).
+- Repo configured: `git config --local --get git-town.main-branch` — a non-empty
+  result means Git Town knows this repo's trunk. This is the on-disk marker;
+  prefer it over running a `git town` command, which prompts when
+  unconfigured.
+- Any stack tracked: `git config --get-regexp '^git-town-branch\.'` — each
+  `git-town-branch.<name>.parent` row is one tracked branch.
+
+## Mental model recap
+
+- **Trunk** is the `git-town.main-branch` (usually `main`). Long-lived
+  shared branches are **perennial** (`git-town.perennial-branches`).
+- Each feature branch records its **parent** in git config
+  (`git-town-branch.<name>.parent`). A stack is just a parent chain — there
+  is no separate metadata file and no remote service.
+- `git town` calls real `git` underneath, so hooks, `.gitignore`, and
+  aliases still apply.
+
+## Core stack commands
+
+### Create a branch — `git town hack` / `append` / `prepend`
+
+```bash
+git town hack <name>      # new branch off MAIN/trunk — use to start a stack's root
+git town append <name>    # new branch off the CURRENT branch — extends the stack
+git town prepend <name>   # insert a new branch BETWEEN current and its parent
+```
+
+The hack-vs-append distinction is the whole stacking story: `hack` starts a
+fresh chain from trunk; `append` grows the chain you're standing on. Shared
+flags:
+
+```bash
+--prototype       # keep the branch local until you propose it
+--propose         # create and immediately open a PR
+--commit -m "…"   # commit the staged changes into the new branch
+```
+
+Source: <https://www.git-town.com/commands/hack>,
+<https://www.git-town.com/commands/append>.
+
+### Inspect the stack
+
+```bash
+git town branch                       # full branch lineage with branch types
+git town switch                       # interactive picker showing the hierarchy
+git town config get-parent [branch]   # parent of current (or named) branch
+```
+
+### `git town sync` — pull trunk, restack, push
+
+```bash
+git town sync                # current branch only
+git town sync --stack        # every branch in the current stack (-s)
+git town sync --all          # every branch in the repo
+git town sync --detached     # don't pull trunk/perennial into the stack (-d; busy monorepos)
+git town sync --no-push      # restack locally, skip the push (offline)
+git town sync --prune        # drop branches that became empty (-p)
+```
+
+`git town sync` is the workhorse: it pulls trunk, rebases each branch onto
+its parent's new tip, and force-pushes the updated branches.
+
+Source: <https://www.git-town.com/commands/sync>.
+
+### `git town propose` — open / update PRs for the stack
+
+```bash
+git town propose             # PR for the current branch; base auto-set to its parent
+git town propose --stack     # one PR per branch in the stack (-s) — the stacking command
+git town propose --title "…" --body "…"
+git town propose --body-file pr-body.md
+git town propose --no-browser
+```
+
+`propose --stack` opens (or updates) one PR per branch and sets each PR's
+base to its **immediate parent**, so the chain reviews bottom-up — the same
+shape `gt submit --stack` produces.
+
+Source: <https://www.git-town.com/stacked-changes>.
+
+### `git town set-parent` — adopt / re-parent a branch
+
+```bash
+git town set-parent              # interactive: prompts for the new parent
+git town set-parent main         # non-interactive: positional arg is the new parent
+git town set-parent --none       # detach (branch becomes perennial)
+```
+
+Use to pull a plain `git checkout -b` branch into a stack, or to move a
+branch onto a new base. Run `git town sync` afterward to pull the new
+parent's changes in.
+
+Source: <https://www.git-town.com/commands/set-parent>.
+
+### `git town ship` — merge a branch
+
+```bash
+git town ship                # ship the current branch via the forge API
+git town ship --message "…"  # custom merge-commit message
+git town ship --to-parent    # ship into a non-perennial parent
+```
+
+The **recommended** flow is to merge via the web UI and then run
+`git town sync --stack` — that keeps the forge as the source of truth and
+lets `sync` cascade the survivors. Reach for `git town ship` only when you
+want the CLI to drive the merge. Confirm available merge strategies with
+`git town ship --help` before passing one.
+
+Source: <https://www.git-town.com/commands/ship>.
+
+## Conflict recovery — `continue` / `skip` / `undo`
+
+When `sync`, `propose`, `ship`, etc. hit a rebase conflict, `git town`
+halts and records the pending step.
+
+```bash
+git town status                # show the halted state and what's available
+git town status --pending      # machine-readable: prints the pending command name (or nothing)
+
+# 1. resolve the conflict in the working tree, then:
+git add <resolved paths>       # stage resolved paths by name, not the whole tree
+# 2. resume — NOT bare git rebase --continue
+git town continue              # re-run the halted command from where it stopped
+git town skip                  # abandon the conflicting branch, continue with the rest
+git town skip --park           # skip and permanently "park" that branch
+git town undo                  # revert the last completed git-town command
+```
+
+Always use `git town continue` / `skip` / `undo`, never bare
+`git rebase --continue` / `--abort` — only Git Town knows to advance the
+rest of the branch walk and keep the parent metadata consistent.
+
+Source: <https://www.git-town.com/commands/skip>,
+<https://www.git-town.com/commands/status>.
+
+## Other branch ops
+
+```bash
+git town rename <new-name>   # rename current branch, updating lineage
+git town delete              # delete current branch and clean up its lineage
+```
+
+## Config keys (for scripting / detection)
+
+| Key | Meaning |
+| --- | --- |
+| `git-town.main-branch` | trunk branch name |
+| `git-town.perennial-branches` | space-separated long-lived branches |
+| `git-town.forge-type` | `github` / `gitlab` / `gitea` / `bitbucket` / `forgejo` / `azuredevops` |
+| `git-town.github-connector` | `gh` to reuse the gh CLI's auth |
+| `git-town.github-token` | forge PAT (per-forge key: `gitlab-token`, …) |
+| `git-town-branch.<name>.parent` | immediate parent of `<name>` |
+| `git-town-branch.<name>.branchtype` | `feature` / `prototype` / `parked` / `contribution` / `observed` |
+
+Repo defaults can also live in a committed `git-town.toml`. Environment
+overrides use the `GIT_TOWN_*` prefix (e.g. `GIT_TOWN_GITHUB_TOKEN`).
+
+## Global / agent flags (every command)
+
+- `--non-interactive` — suppress all prompts. **Essential when driving
+  `git town` from an agent**, or commands hang waiting on a TTY.
+- `--dry-run` — print what would happen without changing anything.
+- `--verbose` / `-v` — echo every underlying `git` command.
+
+## Squash-merge gotcha
+
+If the forge squash-merges PRs, Git Town can hit **phantom conflicts** when
+rebasing survivors after the bottom branch ships — the squashed commit no
+longer matches the child's history. Mitigate by enabling
+`git config git-town.auto-resolve true` or by shipping with a fast-forward
+strategy. Plain merge / rebase merges don't have this problem.
+
+Source: <https://www.git-town.com/stacked-changes>.
+
+## Recipes
+
+### Open a new 2-PR stack from clean trunk
+
+```bash
+git town hack feat-part-1            # branch off trunk
+# … edit, git add, git commit …
+git town append feat-part-2          # branch off part-1
+# … edit, git add, git commit …
+git town propose --stack             # one PR per branch, bases auto-wired
+```
+
+### Address review feedback on a lower branch
+
+```bash
+git town switch feat-part-1          # or: git checkout feat-part-1
+# … edit, git add, git commit …
+git town sync --stack                # restack feat-part-2 onto the updated feat-part-1 and push
+```
+
+### After the bottom PR merges (via web UI)
+
+```bash
+git town sync --stack                # pulls trunk, drops the merged branch, rebases + pushes survivors
+git town branch                      # confirm the chain looks right
+```
+
+### Adopt a plain-git branch as a stack base
+
+```bash
+git town sync                        # get the branch in sync first
+git town set-parent main             # record its parent
+git town append feat-next            # build on top
+git town propose --stack
+```
+
+## Agent gotchas
+
+- `git town` is **interactive by default**. Pass `--non-interactive` and
+  supply names / messages explicitly, or commands hang waiting on a TTY.
+- After a conflict, **always** `git town continue` / `skip` — never bare
+  `git rebase --continue` / `--abort`; the broader walk won't advance.
+- `git town sync` force-pushes the branches it rebases. Expected for a
+  stack, but don't run it on a branch a teammate is also pushing to without
+  coordinating.
+- Prefer reusing `gh` auth (`git-town.github-connector gh`) over a stored
+  PAT in shared / ephemeral environments.
+- `git town status --pending` is the scriptable way to tell whether a halted
+  command is waiting on you.
+
+## Primary sources
+
+- Install: <https://www.git-town.com/install>
+- Stacked changes: <https://www.git-town.com/stacked-changes>
+- Commands index: <https://www.git-town.com/commands>
+- hack / append / prepend: <https://www.git-town.com/commands/hack>
+- sync: <https://www.git-town.com/commands/sync>
+- propose: <https://www.git-town.com/commands/propose>
+- ship: <https://www.git-town.com/commands/ship>
+- set-parent: <https://www.git-town.com/commands/set-parent>
+- skip / continue / undo: <https://www.git-town.com/commands/skip>
+- status: <https://www.git-town.com/commands/status>
+- forge type: <https://www.git-town.com/preferences/forge-type>
+- github connector: <https://www.git-town.com/preferences/github-connector>

--- a/skills/pr-stack/references/gt.md
+++ b/skills/pr-stack/references/gt.md
@@ -307,7 +307,7 @@ gt submit --stack
 
 ```bash
 gt sync
-# if conflicts: resolve files, `gt add .`, `gt continue`
+# if conflicts: resolve files, `git add .`, `gt continue`
 gt submit --stack
 ```
 

--- a/skills/pr-stack/references/gt.md
+++ b/skills/pr-stack/references/gt.md
@@ -1,0 +1,387 @@
+# `gt` (Graphite CLI) reference
+
+Reference for driving the Graphite CLI on behalf of a user who already has
+`gt` installed and a repo initialized. Targets `gt` v1.8.4+. Flags drift
+between minor releases — when in doubt, fall back to `gt <cmd> --help`.
+
+The shared mental model and tool-selection rules live in `../SKILL.md`. This
+file is the `gt`-side detail.
+
+## Install paths
+
+- **Homebrew** (recommended on macOS / Linux): `brew install withgraphite/tap/graphite`
+- **npm** (cross-platform, including Windows): `npm install -g @withgraphite/graphite-cli@stable`
+- **Update**: from v1.7.6+ use `gt upgrade`; otherwise rerun the install
+  command (`brew upgrade withgraphite/tap/graphite` or
+  `npm install -g @withgraphite/graphite-cli@stable`).
+- Version check: `gt --version`.
+- Git-version override (rarely needed): set `GRAPHITE_IGNORE_GIT_VERSION=1`.
+
+Source: <https://graphite.dev/docs/install-the-cli>,
+<https://graphite.dev/docs/update-cli>.
+
+## First-time setup
+
+1. **Auth**:
+
+   ```bash
+   gt auth --token <token-from-app.graphite.com>
+   ```
+
+   The user pastes the token from <https://app.graphite.com/activate> — that
+   page shows the exact `gt auth --token …` line to copy. Token is stored
+   in `~/.graphite_user_config`.
+
+   In ephemeral / CI environments, prefer the environment variable
+   `GRAPHITE_AUTH_TOKEN` (v1.8.3+) instead of writing to disk.
+
+2. **Repo init** (once per clone):
+
+   ```bash
+   gt init
+   ```
+
+   Prompts for the trunk branch (default `main`). Writes
+   `.git/.graphite_repo_config`. If you skip `gt init`, any `gt` command
+   auto-prompts the same flow.
+
+Source: <https://graphite.dev/docs/cli-quick-start>.
+
+### Detection probes
+
+- `gt` installed: `command -v gt && gt --version` (non-zero if missing).
+- Repo initialized: `test -f "$(git rev-parse --git-dir)/.graphite_repo_config"`.
+  This is the on-disk marker — much more reliable than running `gt <cmd>`,
+  which prompts interactively when uninitialized.
+
+## Mental model recap
+
+- Each branch in a stack is one PR. Parent links live in
+  `.git/.graphite_repo_config`.
+- `gt` calls real `git` underneath — `.gitignore`, hooks, and aliases still
+  apply. `--no-verify` disables hooks for that invocation.
+- "Downstack" = ancestors (toward trunk). "Upstack" = descendants (away from
+  trunk). Both terms appear throughout the official docs.
+
+## Core stack commands
+
+### `gt create` (alias `gt c`) — new branch on top
+
+```bash
+gt create                    # interactive: prompts to stage, infers name from commit msg
+gt create -am "msg"          # stage all + commit + create branch (most common)
+gt create <name> -m "msg"    # explicit branch name
+gt create --onto <branch>    # base the new branch on <branch> instead of current
+gt create --insert           # insert mid-stack and auto-rebase upstack children
+```
+
+The canonical scripted form is `gt create --all --message "…"`.
+
+Source: <https://graphite.dev/docs/create-stack>,
+<https://graphite.dev/docs/edit-branch-order>.
+
+### `gt modify` (alias `gt m`) — amend or add to the current branch
+
+```bash
+gt modify                    # amend staged changes to current HEAD; auto-restacks upstack
+gt modify -a                 # git add -A then amend
+gt modify -c                 # NEW commit (not amend); auto-restacks upstack
+gt modify -cam "msg"         # stage all + new commit + restack (most common reviewer-feedback form)
+gt modify --into             # amend staged hunks into a downstack branch (interactive picker)
+```
+
+Always prefer `gt modify` over `git commit --amend` in a stack — bare amend
+won't fix children's parents.
+
+Source: <https://graphite.dev/docs/update-mid-stack-branches>.
+
+### `gt submit` (alias `gt s`; `gt ss` = `gt submit --stack`) — push + create / update PRs
+
+```bash
+gt submit --stack            # push every branch from trunk up to current, open / update PRs
+gt submit --stack --draft    # new PRs as drafts
+gt submit --stack --publish  # flip existing drafts to "ready for review"
+gt submit --stack --dry-run  # report what would be pushed; no branches restacked, no PRs touched
+gt submit --stack --reviewers alice,bob
+gt submit --stack -e         # interactively edit PR metadata for ALL PRs (default: only new)
+gt submit --stack -f         # true --force push instead of default --force-with-lease (use with care)
+gt ss -u                     # alias for --stack --update-only (only push branches with open PRs)
+gt submit --no-stack         # skip the "include upstack?" prompt — submit only the current branch + downstack
+```
+
+`gt submit` validates the stack is properly restacked first and **fails**
+with a conflict message if it isn't — run `gt restack` (or fix conflicts
+via `gt continue`) before retrying. Default push mode is `--force-with-lease`,
+which refuses to overwrite remote commits you haven't pulled.
+
+Source: <https://graphite.dev/docs/create-submit-prs>.
+
+### `gt sync` — pull trunk, restack, prune
+
+```bash
+gt sync                      # fetch trunk, restack all stacks onto new trunk, prompt to delete merged/closed branches
+gt sync --no-restack         # fetch + cleanup only; skip the rebase
+```
+
+`gt sync` treats remote trunk as source of truth — if your local trunk
+can't be fast-forwarded, `gt sync` overwrites it. v1.8.4+ skips non-trunk
+branches checked out in other worktrees (trunk itself is always allowed to
+update).
+
+Source: <https://graphite.dev/docs/cli-quick-start>,
+<https://graphite.dev/docs/collaborate-on-a-stack>.
+
+### `gt track` (alias `gt tr`) — adopt a plain-git branch
+
+```bash
+gt track                     # current branch, prompts for parent
+gt track <name> --parent main
+gt untrack                   # stop tracking (alias `gt utr`)
+```
+
+Use when the bottom of a stack started as a plain `git checkout -b` (e.g.
+bootstrap iteration before `gt` was installed) or when a teammate hands you
+a plain branch you want to stack on top of.
+
+Source: <https://graphite.dev/docs/collaborate-on-a-stack>.
+
+### `gt log` / `gt ls` — inspect the stack
+
+```bash
+gt log                       # full per-branch detail (PR status, worktree locations)
+gt log short                 # compact tree view
+gt ls                        # alias for `gt log short`
+gt info [branch]             # details for a single branch
+```
+
+Run `gt log short` before any restack or submit to confirm the stack looks
+as you expect.
+
+### `gt restack` — re-rebase upstack onto parent's tip
+
+Most operations (`modify`, `sync`, `move`, `reorder`) call `gt restack`
+implicitly. Run it explicitly when something feels stale after manual
+history editing.
+
+## Reorganizing the stack
+
+| Command | Effect |
+| --- | --- |
+| `gt move --onto <base>` | Re-parent current branch (and its upstack) onto `<base>`. |
+| `gt reorder` | Open editor to reorder branches in the current stack. |
+| `gt fold` | Collapse current branch into its parent. `--keep` keeps the current name; `--stack` folds the whole stack. |
+| `gt squash` (`gt sq`) | Squash all commits on current branch into one; restack upstack. |
+| `gt split` (`gt sp`) | Split current branch by commit (`-c`), hunk (`-h`), or file (`-f`). |
+| `gt absorb` (`gt ab`) | Auto-distribute staged hunks into the correct downstack commits. `-a` stages all; `--force` skips confirmation. |
+| `gt pop` | Delete branch but keep changes in working tree. |
+| `gt delete [name]` | Delete a branch. Flags: `-c/--close` (close PR), `-f/--force`, `--downstack`, `--upstack`. |
+
+Source: <https://graphite.dev/docs/edit-branch-order>,
+<https://graphite.dev/docs/squash-fold-split>.
+
+## Navigation
+
+```bash
+gt checkout         # interactive picker
+gt checkout <name>  # explicit
+gt co -s            # restrict picker to ancestors/descendants of current branch
+gt co -t            # jump to trunk
+gt up [n]           # move n branches upstack (away from trunk); alias `gt u`
+gt down [n]         # move n branches downstack; alias `gt d`
+gt top              # alias `gt t`
+gt bottom           # alias `gt b`
+gt parent / gt children
+```
+
+## Conflict recovery — the `gt continue` / `gt abort` flow
+
+When `gt modify`, `gt sync`, `gt move`, `gt reorder`, `gt restack`, etc.
+hit a rebase conflict, `gt` halts and prints which branch is being
+resolved.
+
+```bash
+# 1. Resolve the conflict in the working tree
+git status                   # shows conflicted paths
+# … edit files, remove <<<<<<< markers …
+
+# 2. Mark resolved
+git add .                    # or `git add path/to/resolved` for specific files
+
+# 3. Resume the broader Graphite operation — NOT bare git rebase --continue
+gt continue                  # -a stages everything before continuing (equivalent to step 2 + this)
+```
+
+Critical: **always use `gt continue` / `gt abort`**, never bare
+`git rebase --continue` / `--abort`. The latter only continues the
+immediate rebase step; the broader Graphite walk doesn't know to advance
+and metadata stays inconsistent.
+
+Other recovery commands:
+
+- `gt abort` — cancel the entire halted Graphite operation. `-f` skips confirmation.
+- `gt undo` — rewind the most recent Graphite mutation in **this worktree**.
+  Per-worktree history; refuses to touch a branch checked out elsewhere.
+
+Source: <https://graphite.dev/docs/update-mid-stack-branches>.
+
+There is **no documented `gt skip`** in v1.8.4. To skip a problematic
+branch during a stack-wide restack, `gt abort` and handle it in isolation.
+
+## Pulling someone else's stack — `gt get`
+
+```bash
+gt get                       # fetch teammates' submitted stacks; branches arrive frozen by default
+gt get -U                    # unfrozen (editable immediately)
+gt get -d                    # downstack only
+gt get --no-restack          # skip the trunk-restack step
+gt get --no-checkout         # don't switch branches
+gt get --delete-all          # skip cleanup prompts
+gt freeze / gt unfreeze      # toggle frozen state later
+```
+
+Source: <https://graphite.dev/docs/collaborate-on-a-stack>.
+
+## Config files
+
+| File | Scope | Contents |
+| --- | --- | --- |
+| `~/.config/graphite/user_config` | user (XDG-overridable) | user preferences, telemetry opt-out |
+| `~/.graphite_user_config` | user | auth token (set by `gt auth`) |
+| `.git/.graphite_repo_config` | repo | trunks, remote name, GitHub owner/name |
+
+`gt config` is an interactive menu — there's no `gt config --key value`
+form. Trunk, submit defaults, branch naming live behind those prompts.
+
+Environment overrides:
+
+- `GRAPHITE_AUTH_TOKEN` — auth without writing to disk (v1.8.3+).
+- `GRAPHITE_IGNORE_GIT_VERSION=1` — bypass git-version check.
+
+## Monorepo / multi-trunk / worktrees / GHES
+
+- **Multiple trunks**: add with `gt trunk --add <branch>` or via the
+  `gt config` menu. Many commands accept `--all` to operate across all
+  trunks (`gt checkout --all`, `gt log --all`).
+- **Worktrees** (v1.8.4+): `gt` refuses to mutate a branch checked out in
+  another worktree. `gt sync` and `gt get` can still update trunk across
+  worktrees. `gt undo` history is per-worktree.
+- **GitHub Enterprise Cloud**: works out of the box.
+- **GitHub Enterprise Server (self-hosted)**: requires Graphite Enterprise
+  plus IP allowlist coordination with Graphite support. No self-serve path.
+
+Source: <https://graphite.dev/docs/multiple-trunks>,
+<https://graphite.dev/docs/multiple-worktrees>,
+<https://graphite.dev/docs/github-enterprise-server>.
+
+## Global flags (every command)
+
+- `--cwd <dir>` — run as if from `<dir>`.
+- `--no-interactive` — disable prompts / pagers / editors. **Essential when
+  driving `gt` from an agent.**
+- `--no-verify` — bypass git hooks for that invocation.
+- `--quiet` — minimize output (implies `--no-interactive`).
+- `--debug` — verbose debug output.
+- `--help` / `--help --all` — list every command (the latter includes hidden ones).
+
+## Recipes
+
+### Open a new 2-PR stack from a clean trunk
+
+```bash
+gt sync                              # ensure trunk fresh
+gt create -am "feat: part 1"
+gt create -am "feat: part 2"
+gt submit --stack --reviewers alice
+```
+
+### Address review feedback on the bottom PR
+
+```bash
+gt checkout part_1
+# … edit files …
+gt modify -cam "address review"      # new commit, auto-restacks part_2
+gt submit --stack
+```
+
+### Sync trunk into your stack and resubmit
+
+```bash
+gt sync
+# if conflicts: resolve files, `gt add .`, `gt continue`
+gt submit --stack
+```
+
+### Split a sprawling branch into a stack
+
+```bash
+gt checkout big_branch
+gt split --by-commit                 # or --by-hunk / --by-file
+gt submit --stack
+```
+
+### Adopt a teammate's plain-git branch as your base
+
+```bash
+git pull
+gt track                             # prompts for parent
+gt create -am "build on top"
+gt submit --stack
+```
+
+### Bootstrap retrofit: iter 1 plain-git → adopt later
+
+When a workflow has to start before `gt` is available, use plain git for
+iteration 1 and adopt it later:
+
+```bash
+# Iteration 1 — gt not present yet
+git checkout -b feat/skill-first main
+# … work, commit …
+
+# Iteration 2+ — gt now available; bring iter 1 into the stack
+git checkout feat/skill-first
+gt track --parent main
+gt create feat/skill-second -m "feat: second slice"
+# … and so on …
+```
+
+`gt track` only edits Graphite metadata, not commits — the retrofit is
+free.
+
+### Recover from a botched operation
+
+```bash
+gt undo                              # rewind the last gt mutation
+# or, mid-conflict:
+gt abort                             # cancel the whole halted gt command
+```
+
+## Agent gotchas
+
+- `gt` is **interactive by default**. Pass `--no-interactive` and supply
+  `-m`, `-a`, branch names, etc. explicitly, or commands will hang waiting
+  on a TTY.
+- `gt submit` does a force push (default `--force-with-lease`). Only pass
+  `-f/--force` after verifying no concurrent updates.
+- After a conflict, **always** `gt continue` / `gt abort` — never bare
+  `git rebase --continue` / `--abort`.
+- `gt submit` refuses to push when branches aren't properly restacked.
+  `gt restack` (or fix conflicts via `gt continue`) before retrying.
+- In CI / ephemeral environments, set `GRAPHITE_AUTH_TOKEN` rather than
+  running `gt auth` — the latter writes to `~/.graphite_user_config` and
+  may fail when home is non-persistent.
+
+## Primary sources
+
+- Install: <https://graphite.dev/docs/install-the-cli>
+- Quick start: <https://graphite.dev/docs/cli-quick-start>
+- Create a stack: <https://graphite.dev/docs/create-stack>
+- Update mid-stack branches: <https://graphite.dev/docs/update-mid-stack-branches>
+- Submit PRs: <https://graphite.dev/docs/create-submit-prs>
+- Collaborate on a stack: <https://graphite.dev/docs/collaborate-on-a-stack>
+- Edit branch order: <https://graphite.dev/docs/edit-branch-order>
+- Squash, fold, split: <https://graphite.dev/docs/squash-fold-split>
+- Multiple trunks: <https://graphite.dev/docs/multiple-trunks>
+- Worktrees: <https://graphite.dev/docs/multiple-worktrees>
+- GHES: <https://graphite.dev/docs/github-enterprise-server>
+- Configure CLI: <https://graphite.dev/docs/configure-cli>


### PR DESCRIPTION
Imports the stacked-PR skill (SKILL.md + per-tool references for Graphite, git-town, and gh stack) so the /pr-stack handoffs in ultracook, cure, and mold resolve in-repo instead of depending on an external install. Handoff targets reworded to the discovered-skill convention (plain git/gh fallback). Registered in the plugin manifest, install fallback list, and README (skill row + install loop). Evals not imported.

Gates: validate_skills (18), manifest + reference-resolution pytest 6 passed.

Closes #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)