### PR TITLE
feat(wiki): add durable memory boundary

### DIFF
--- a/.hallouminate/config.toml
+++ b/.hallouminate/config.toml
@@ -1,0 +1,14 @@
+# Repo-layer hallouminate config.
+#
+# Declares this repo as a hallouminate tenant so the wiki under
+# .hallouminate/wiki/ is searchable as the `repo:easy-cheese:wiki` corpus.
+# `path = "."` resolves against the repo root (the parent of .hallouminate/),
+# so this works from any checkout or worktree without per-machine config —
+# the daemon reads the repo layer fresh on every request (no restart needed).
+#
+# Do NOT also declare `[[repository]] name = "easy-cheese"` in the XDG
+# baseline: both layers would derive `repo:easy-cheese:wiki` and collide on
+# the duplicate-name check.
+[[repository]]
+name = "easy-cheese"
+path = "."

--- a/.hallouminate/wiki/architecture.md
+++ b/.hallouminate/wiki/architecture.md
@@ -1,0 +1,90 @@
+# Architecture of easy-cheese
+
+easy-cheese is a **skills-only collection**: there is no application
+binary, no long-running service, no library to import. Every change adds,
+edits, or supports a skill under `skills/<name>/`, following the
+[Agent Skills spec](https://agentskills.io/specification). The product
+*is* the set of markdown-plus-scripts skills a coding agent loads at
+runtime (`AGENTS.md:25`).
+
+## The unit: a skill
+
+A skill is a directory whose shape encodes progressive disclosure
+(`README.md:42-53`):
+
+```text
+skills/<skill-name>/
+├── SKILL.md          # required: YAML frontmatter (name + description) + body
+├── references/       # optional: detail pulled in on demand
+├── scripts/          # optional: executable helpers (often a .pyz bundle)
+└── assets/           # optional: templates / static resources
+```
+
+`SKILL.md` is the always-loaded surface. Its frontmatter `description`
+is what the host matches against a user request to decide whether to
+invoke the skill, so it carries trigger phrases. The body is the
+operating procedure; anything heavy is pushed into `references/` and
+pulled in only when the flow reaches it. Example: `/mold` keeps its
+two-key handshake checklist in `references/handshake.md` and links it
+from the body rather than inlining it (`skills/mold/SKILL.md:21`).
+
+## Progressive disclosure
+
+The pattern is deliberate context economy: the agent reads `SKILL.md`
+first, then descends into `references/<topic>.md` only for the step it
+is on. Cross-cutting material that many skills share lives at the
+top-level `shared/` directory (`shared/handoff-gate.md`,
+`shared/formatting.md`) and is referenced by relative path
+`../../shared/<file>.md` (`README.md:53`).
+
+Skills that depend on `shared/scripts/` ship a pre-bundled `.pyz` so the
+shared helpers are self-contained at install time — invoked as
+`python3 ${CLAUDE_SKILL_DIR}/scripts/<skill>.pyz <subcommand>`
+(`skills/mold/SKILL.md:22`). Bundles exist for affinage, briesearch,
+cheese-factory, cook, melt, and mold; `build-pyz.yml` rebuilds them on
+every relevant push to `main`.
+
+## The cheese pipeline
+
+The workflow skills compose into one pipeline, ordered
+**culture → mold → cook → press → age → cure → ship**
+(`skills/mold/SKILL.md:125`, `skills/cook/SKILL.md:90`):
+
+| Skill | Role in the pipeline |
+|---|---|
+| `/cheese` | Front door — classifies input, routes to the right skill |
+| `/culture` | No-write thinking / exploration |
+| `/mold` | Converge a fuzzy idea into an approved spec |
+| `/cook` | TDD-disciplined implementation of a spec |
+| `/press` | Adversarial test hardening |
+| `/age` | Ten-dimension review → severity-grouped findings |
+| `/cure` | Apply selected findings as focused fixes |
+| `/cheese-factory` | Fan an approved spec into parallel curds → PRs |
+
+Lower-level **tool skills** sit beneath the pipeline: `/cheez-search`,
+`/cheez-read`, `/cheez-write` (tilth-backed primitives), plus the
+`/ultracook` composite that chains cook → press → age → cure
+non-interactively (`AGENTS.md:42-49`).
+
+## Portability is the design center
+
+No repo-wide MCP requirement. Workflow skills *suggest* tools (tilth,
+Context7, Tavily, code-review-graph) but carry host-native fallbacks, so
+the collection runs on any compliant agent host (`README.md:161`).
+
+The one deliberate exception is the `cheez-*` tool skills: they require
+tilth MCP and **hard-fail** when it is unavailable rather than silently
+degrade to `grep`/`cat`/`Edit` (`AGENTS.md:73`, `README.md:87`). That
+asymmetry is intentional — the workflow skills stay universal; the tool
+skills trade portability for AST-grounded precision and announce the
+trade by refusing to run without it (`skills/cheez-search/SKILL.md:3-5`).
+
+## Why a wiki at all
+
+Transient task output lives in `.cheese/` (gitignored). Durable
+architecture/convention/rationale knowledge needs a git-tracked home
+that survives the task that produced it — that is this wiki. The split
+is enforced as a git-tracking boundary; see
+[wiki-conventions](./wiki-conventions.md) for the classification rule and
+[workflow-invariants](./workflow-invariants.md) for where it sits among
+the other pipeline invariants.

--- a/.hallouminate/wiki/index.md
+++ b/.hallouminate/wiki/index.md
@@ -1,0 +1,30 @@
+# easy-cheese wiki — index
+
+This wiki is the durable memory lane for the `easy-cheese` repo. It lives
+at `.hallouminate/wiki/`, is **git-tracked**, and is indexed as the
+`repo:easy-cheese:wiki` corpus — distinct from the per-task scratch under
+`.cheese/` (corpus `cheese-local`, gitignored). Write here when a fact is
+worth remembering across sessions: architecture, protocols, conventions,
+and "why this design not that one" rationale.
+
+## Topics
+
+<!-- HALLOUMINATE:INDEX-START -->
+- [architecture](./architecture.md) — skills-only collection, progressive disclosure, the cheese pipeline, portability design center.
+- [tooling](./tooling.md) — `just check`/`just ci`, validators, tilth/`cheez-*` hard-fail, `.pyz` bundles, CI workflows.
+- [wiki-conventions](./wiki-conventions.md) — how to author entries here, plus the durable-vs-transient boundary table.
+- [workflow-invariants](./workflow-invariants.md) — pipeline ordering, two-key handshake, handoff gates, `just check` single gate.
+<!-- HALLOUMINATE:INDEX-END -->
+
+## How to use this index
+
+`index.md` is a table of contents, not a topic. New pages join the list
+above with a one-line gloss; anything substantive belongs in its own
+topic file. The daemon rewrites the link list between the
+`HALLOUMINATE:INDEX` markers after every `add_markdown` — curated prose
+outside the markers is preserved.
+
+If the index looks stale, run `list_files` against the
+`repo:easy-cheese:wiki` corpus — the directory is the source of truth.
+Start with [wiki-conventions](./wiki-conventions.md) before writing your
+first entry.

--- a/.hallouminate/wiki/index.md
+++ b/.hallouminate/wiki/index.md
@@ -14,6 +14,7 @@ and "why this design not that one" rationale.
 - [tooling](./tooling.md) — `just check`/`just ci`, validators, tilth/`cheez-*` hard-fail, `.pyz` bundles, CI workflows.
 - [wiki-conventions](./wiki-conventions.md) — how to author entries here, plus the durable-vs-transient boundary table.
 - [workflow-invariants](./workflow-invariants.md) — pipeline ordering, two-key handshake, handoff gates, `just check` single gate.
+- [spec-workflow-comparison](./spec-workflow-comparison.md) — /mold vs Matt Pocock grill-with-docs vs Superpowers brainstorming vs spec.md, plus Spec Kit/Kiro/BMAD/Taskmaster/Agent OS/OpenSpec/Tessl.
 <!-- HALLOUMINATE:INDEX-END -->
 
 ## How to use this index

--- a/.hallouminate/wiki/spec-workflow-comparison.md
+++ b/.hallouminate/wiki/spec-workflow-comparison.md
@@ -1,0 +1,205 @@
+# Spec / brainstorm-to-spec workflow comparison
+
+The takeaway up front: `/mold`, the older `spec.md` command, Matt Pocock's
+`grill-with-docs`, and Superpowers' `brainstorming` skill have **independently
+converged** on the same five moves — (1) interrogate one question at a time,
+(2) always pair each question with a *recommended* answer, (3) ground claims
+against the actual codebase before deciding, (4) enforce a hard approval gate
+before any code, (5) emit a durable spec artifact that drives implementation.
+They are siblings with the same DNA; the differences are about *where each
+spends its rigor*.
+
+This page captures a `/briesearch` comparison run (2026-06-13) so the next agent
+shaping `/mold` doesn't re-research the field. Sources are cited inline by URL.
+
+See also: [workflow-invariants](./workflow-invariants.md) (the cheese pipeline
+and two-key handshake), [architecture](./architecture.md).
+
+## Where each workflow spends its rigor
+
+- **Matt Pocock** — *fidelity escape hatches.* When a question can't be answered
+  by talk, drop into a throwaway `/prototype`, capture the answer (not the
+  code), then resume grilling. Also unique in treating model-tier and
+  context-window hygiene as first-class.
+- **Superpowers (Jesse Vincent / obra)** — *enforceability.* The process is
+  encoded as a Graphviz dot-graph inside the SKILL.md so the only legal exit
+  node is `writing-plans`. Thesis: "Prose is documentation. Checklists and
+  graphs are instructions."
+- **`/mold`** — *anti-drift.* The agent-introduced-scope grep gate (every
+  distinguishing noun in the spec must trace to a literal user message) is a
+  mechanic **none of the others have**, plus the formal two-key handshake and
+  shape-check blast-radius numbers.
+- **`spec.md` (older home-grown cmd)** — *justification.* "Beat 0: Defend the
+  Why" (JTBD, Why Now, Do Nothing) is a mandatory gate before design starts.
+
+## Master comparison table
+
+| Workflow | Maker | Brainstorm-first gate? | Question style | Codebase grounding | Approval mechanism | Artifact + path | Phase sequence | Distinguishing mechanic |
+|---|---|---|---|---|---|---|---|---|
+| **`/mold`** (cheese-flow) | this repo | Yes — no code, hands to `/cook` | One-at-a-time (Grill), lettered options (Explore), always recommends | Mandatory: `cheez-search` callers + `tilth_deps` shape-check, verdict low/med/high | **Two-key handshake** (explicit user verb + agent coherence checklist) | `.cheese/specs/<slug>.md` | Explore→Ground→Shape→Sketch→Grill→Diagnose→Curdle | **agent-introduced-scope grep gate**; blast-radius numbers gate Grill |
+| **`spec.md`** (older home-grown) | this repo | Yes | Lettered A/B/C/D ("1A, 2C"), 3-6 round Q-research-Q loop | 4 parallel research agents in round 2 (cheez-search, Serena, GH) | Beat-0 "Defend the Why" gate; uncertainty markers | ~800-word prose spec, `.claude/specs/<slug>.md` + opt. GH issue | Beat 0 (Why) → Ask → Research → Summarize loop | **"Defend the Why"** (5 JTBD framing questions) as hard pre-gate |
+| **Matt Pocock `grill-with-docs`** | Matt Pocock (aihero.dev) | Yes — grill before PRD | **One at a time, recommends each answer**, explores codebase instead of asking when it can | Challenges input against `CONTEXT.md` glossary; writes ADRs inline | Conversational; PRD synthesized at end via `/to-prd` | `CONTEXT.md` + ADRs → PRD → GH issues | Idea→Research→Prototype→Grill→PRD→Issues→Execute→QA | **`/prototype` escape hatch** for "ungrillable" questions; canonical-term challenge |
+| **Superpowers `brainstorming`** | Jesse Vincent (obra) | **Hardest gate**: "Do NOT…take any implementation action until…user has approved" | One question per message, prefer multiple-choice | Step 1 explores files/docs/commits; 2-3 approaches w/ trade-offs | User approves each design section; spec self-review checklist | `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` (committed) | brainstorm→worktrees→writing-plans→execute(TDD)→review→finish | **dot-graph enforcement** — only legal exit node is `writing-plans` |
+| **GitHub Spec Kit** | GitHub | No (constitution-first, not ideation) | Slash-command driven | Via constitution principles | Phase artifacts reviewed | `spec.md`/`plan.md`/`tasks.md` in `.specify/` | constitution→specify→plan→tasks→implement | **`constitution.md`** governing doc referenced by every phase |
+| **AWS Kiro** | AWS | No | IDE prompt | IDE-integrated | Human approval gate between each phase | `requirements.md`/`design.md`/`tasks.md` | requirements→design→tasks→implement | **EARS notation** (`WHEN…THE SYSTEM SHALL…`) → property tests |
+| **BMAD-METHOD** | bmad-code-org | **Yes** (`/bmad-brainstorming`) | Per-persona | Per-persona | Document-driven persona handoffs | `product-brief.md`/`PRD.md`/`architecture.md`/stories | brainstorm→PRD→architecture→stories→code | **19+ named agent personas** (Analyst/PM/Architect…) |
+| **Taskmaster AI** | eyaltoledano | No | PRD-driven | `--research` web grounding | Dependency graph gates task order | `.taskmaster/` JSON tasks | PRD→parse→expand→next_task | **dependency-aware task graph** |
+| **Agent OS v3** | Brian Casel (Builder Methods) | No (enhances plan mode) | Host agent's plan mode | **Standards discovery/injection** | Host plan-mode approval | `agent-os/product/*.md` | discover→inject→shape→implement | **standards management** (build to team conventions) |
+| **OpenSpec** | Fission-AI | No (brownfield-first) | Slash commands | Delta-based | Three-phase state machine | `openspec/changes/` (proposal/specs/design/tasks) | propose→apply→archive | **strict propose→apply→archive state machine** |
+| **Tessl** | Tessl (Guy Podjarny) | No | Dev- or AI-written spec | Spec Registry usage specs | Tests as hard guardrails | spec is source-of-truth; code is regenerable | define spec → agents code against spec+tests | **spec-as-source** (code stamped GENERATED, regenerable) — Framework closed beta as of mid-2026 |
+
+## Deep dive — Matt Pocock
+
+Public skill set: `github.com/mattpocock/skills`. End-to-end model is **7
+phases**: Idea → Research (`research.md`) → Prototype → Grill → PRD → Kanban (GH
+issues) → Execute → QA (<https://www.aihero.dev/my-7-phases-of-ai-development>).
+
+Two mechanics worth stealing:
+
+1. **`grill-with-docs`** — literal prompt:
+   > "Interview me relentlessly about every aspect of this plan until we reach a
+   > shared understanding. Walk down each branch of the design tree, resolving
+   > dependencies between decisions one-by-one. For each question, provide your
+   > recommended answer. Ask the questions one at a time. If a question can be
+   > answered by exploring the codebase, explore the codebase instead."
+   (github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md)
+   The `-with-docs` variant adds glossary discipline: when your term conflicts
+   with `CONTEXT.md`, it calls it out and proposes a canonical term, writing
+   ADRs inline. **Nearly identical to `/mold`'s Grill + Ground canonical-term
+   resolution** — independent convergence.
+2. **`/prototype` as a grilling escape hatch** — on an "ungrillable" question
+   (UI feel, ambiguous state model) stop talking and build a throwaway: either a
+   tiny terminal app for a state machine/reducer, or several switchable UI
+   variations on one route. The keeper is *the answer*, captured in an
+   ADR/NOTES.md, not the code; then resume grilling
+   (<https://www.aihero.dev/skills-prototype>;
+   <https://www.aihero.dev/things-people-get-wrong-with-grill-me-and-grill-with-docs>).
+   `/mold` has no equivalent — Diagnose builds a reproduction loop, but there is
+   no "build to resolve a design unknown" branch.
+
+Sharp opinions (talk transcript, finance.biggo.com/podcast/e7209c094224b09c):
+pure spec-to-code degrades fast ("first passable, third was garbage" — software
+entropy); **codebase quality is the ceiling** on agent output (Ousterhout deep
+modules); use a *smart* model for grilling and a smaller one for implementation;
+never clear context just to write the PRD ("throwing away all your design
+work"); keep grilling under ~120k tokens (the model "dumb zone"). Work is sliced
+into vertical "tracer bullet" issues (cross-layer, not horizontal) forming a DAG
+for parallel agent execution. The "design tree" concept cites Brooks' *The
+Design of Design*; ubiquitous language cites Evans' *DDD*.
+
+Other published skills (June 2026): `grill-with-docs`, `grill-me`,
+`domain-model` (now the recommended front-of-workflow step), `to-prd`,
+`to-issues`, `prototype`, `handoff`, `tdd`, `improve-codebase-architecture`,
+`triage`, `zoom-out`, `diagnose`.
+
+## Deep dive — Superpowers (Jesse Vincent / obra)
+
+The `brainstorming` skill is the **hardest pre-implementation gate** reviewed:
+> "Do NOT invoke any implementation skill, write any code, scaffold any project,
+> or take any implementation action until you have presented a design and the
+> user has approved it."
+(raw.githubusercontent.com/obra/superpowers/main/skills/brainstorming/SKILL.md).
+A one-liner utility goes through the same gate as a platform — there's a named
+anti-pattern section, "This Is Too Simple To Need A Design."
+
+The 9 steps: explore context → (optional visual companion, requires consent) →
+ask clarifying questions **one at a time, prefer multiple-choice** → propose 2-3
+approaches with a recommendation → present design in sections, approve each →
+write `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` (committed) → 4-item
+spec self-review → user reviews file → invoke `writing-plans`.
+
+Distinguishing insight: **enforceability through structure**. In v4.3.0 Jesse +
+Claude found prose descriptions of good process were being rationalized away. The
+fix wasn't better prose — it was encoding the process as a numbered checklist
+plus a Graphviz dot-graph *inside the SKILL.md*, where the only exit node from
+the brainstorm subgraph is `writing-plans`
+(blog.fsck.com/agent-blog/2026/02/12/superpowers-v4-3-0). Stated principle:
+"Prose is documentation. Checklists and graphs are instructions."
+
+Full pipeline: `brainstorm → using-git-worktrees → writing-plans →
+executing-plans | subagent-driven-development → (TDD red/green per task) →
+requesting-code-review → finishing-a-development-branch`. The plan from
+`writing-plans` carries a fixed header (Goal / Architecture / Tech Stack) and an
+agentic-worker instruction; tasks are TDD red→green and handed to a fresh
+subagent per task (recommended) or inline execution.
+
+Design philosophy (blog.fsck.com/2025/10/09/superpowers): "If Claude thinks
+you're trying to start a project or task, it should default into talking through
+a plan with you before it starts down the path of implementation."
+
+## How the two home-grown skills relate
+
+`spec.md` and `/mold` are the **same lineage** — `spec.md` reads like an earlier
+parallel design that `/mold` refined:
+
+- `spec.md`'s "Beat 0: Defend the Why" (JTBD / Why Now / Do Nothing) → survives
+  as `/mold`'s **Explore mode** JTBD frame and the mandatory "Do Nothing always
+  included" in Shape.
+- `spec.md`'s lettered A/B/C/D options → `/mold` keeps lettered options in
+  Explore.
+- `spec.md`'s round-2 parallel research agents → `/mold`'s Validate Cycle +
+  sub-agent context gate (now budgeted: 2 `/briesearch` calls per session).
+- `spec.md`'s `[?]` / `[TBD]` / `[BLOCKED]` markers → carried verbatim into
+  `/mold`, plus a new `[CONFLICT]`.
+
+What `/mold` **adds** that `spec.md` lacks: the two-key handshake
+(`skills/mold/references/handshake.md`), shape-check blast-radius numbers gating
+Grill (`skills/mold/references/shape-check.md`), the agent-introduced-scope grep
+gate, and a computed handoff (`curd-count` → `/cook` / `/ultracook` /
+`/cheese-factory`). What `spec.md` has that `/mold` softened: the explicit
+~800-word / 2-minute-read prose target and optional GitHub-issue emission.
+
+## Where `/mold` is ahead — and what it could borrow
+
+**Ahead of all 10 tools:** the agent-introduced-scope grep gate is unique. No
+one else greps prior user turns to catch the "Tavily snippet → shipped config
+knob" drift (`skills/mold/references/handshake.md` § Agent-introduced scope). The
+shape-check producing *arguable numbers* (caller count, importer count) rather
+than a guessed verdict is also stronger than anyone's grounding step.
+
+**Borrow candidates** (open questions, not mandates — alternatives raised by
+sources):
+
+- Matt Pocock's **`/prototype` escape hatch** — a "build to resolve a design
+  unknown, then resume" branch `/mold` lacks.
+- Superpowers' **dot-graph hard exit** — encoding `/mold`'s gates as a
+  machine-readable graph rather than a prose checklist, since Jesse's whole
+  v4.3.0 finding was that prose gates get rationalized past.
+- **EARS-style acceptance notation** (Kiro) for the spec's Acceptance section to
+  make criteria test-generable.
+
+## Other widely-used spec tools (survey)
+
+- **GitHub Spec Kit** (github/spec-kit, MIT) — constitution → specify → plan →
+  tasks → implement; `constitution.md` at `.specify/memory/constitution.md`
+  governs every phase; `[P]` marks parallel tasks; agent-agnostic.
+- **AWS Kiro** (kiro.dev, proprietary IDE, July 2025) — requirements.md (EARS) →
+  design.md → tasks.md → implement; human approval gate per phase; hooks are
+  event-driven quality automations; IDE-locked (Code OSS).
+- **BMAD-METHOD** (bmad-code-org, 40k+ stars, MIT) — brainstorm-first via
+  `/bmad-brainstorming`; 19+ agent personas (Analyst → PM → Architect → PO/SM →
+  Developer); document-driven handoffs; "epic sharding" splits PRDs.
+- **Taskmaster AI** (eyaltoledano/claude-task-master, 25k+ stars) — PRD →
+  `parse_prd` → dependency-aware hierarchical tasks in `.taskmaster/`;
+  `next_task` respects the graph; main/research/fallback model tiers.
+- **Agent OS v3** (buildermethods.com, Brian Casel, Jan 2026) — discover →
+  inject → shape (via host plan mode) → implement; v3 delegates spec-writing to
+  the host agent and focuses on standards discovery/injection.
+- **OpenSpec** (Fission-AI/OpenSpec) — strict propose → apply → archive state
+  machine; `openspec/specs/` is source-of-truth, `changes/` holds proposals;
+  brownfield-first; `openspec validate --strict`.
+- **Tessl** (tessl.io, Guy Podjarny / ex-Snyk) — spec-as-source: code is
+  regenerable output stamped `GENERATED FROM SPEC`; Spec Registry has 10k+ OSS
+  usage specs; Framework was closed/private beta as of mid-2026.
+
+Further reading: Martin Fowler / Birgitta Böckeler, "Understanding Spec-Driven
+Development: Kiro, spec-kit, and Tessl" (martinfowler.com, 15 Oct 2025).
+
+## Confidence & gaps
+
+High overall. Matt Pocock and Superpowers claims are from primary SKILL.md files
+and the authors' own blogs/transcripts; `/mold` and `spec.md` were read
+directly. Gaps: Pocock's `domain-model` / `to-issues` / `tdd` skill internals
+weren't fetched; Superpowers' exact v5.x spec-review loop (inline checklist vs.
+subagent) is unconfirmed; Tessl's workflow is closed-beta and unverifiable;
+OpenSpec star count is from a secondary source.

--- a/.hallouminate/wiki/tooling.md
+++ b/.hallouminate/wiki/tooling.md
@@ -1,0 +1,98 @@
+# Tooling
+
+The build, validation, and tool-dependency surface for easy-cheese. The
+guiding rule: one local gate (`just check`), mirrored read-only in CI
+(`just ci`).
+
+## `just check` vs `just ci`
+
+`just check` is the local pre-flight; `just ci` is the same gate without
+autofixes (`justfile:51-54`). Run `just check` before any commit, push,
+PR, or hand-off (`AGENTS.md:7`).
+
+| | `just check` | `just ci` |
+|---|---|---|
+| markdown | `lint-md-fix` (autofix) | `lint-md` (check only) |
+| yaml | `lint-yaml-fix` + `lint-yaml` | `lint-yaml` |
+| python | `lint-py-fix` (`uvx ruff --fix`) | — |
+| shell | `lint-sh` (`shellcheck scripts/install.sh`) | `lint-sh` |
+| tests | `test` | `test` |
+| docs | `docs-build` (`mkdocs build --strict`) | `docs-build` |
+
+The `test` recipe runs the validator self-test, `validate_skills.py`,
+the pytest suites (`tests/python`, `tests/shared/python`,
+`tests/cheese-factory/python`), and the bats suites
+(`tests/bash/test_install.bats`, the cheese-factory bats)
+(`justfile:8-16`).
+
+Note the markdownlint globs are `skills/**/*.md` and `*.md`
+(`justfile:31-35`) — files outside those globs (for example this wiki
+under `.hallouminate/wiki/`) are not linted by the gate, so keep their
+markdown clean by hand.
+
+## Validators
+
+`.github/scripts/validate_skills.py` enforces the skill contract on every
+`skills/<name>/SKILL.md` (`.github/scripts/validate_skills.py`):
+
+- Path must be exactly `skills/<name>/SKILL.md` — nested sub-skills
+  rejected (line 43).
+- YAML frontmatter present, parseable, and a mapping (lines 53-62).
+- `name` required, kebab-case
+  (`^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?$`), and equal to the parent
+  directory name (lines 69-82).
+- `description` required, non-empty, ≤ 1024 chars — the Codex limit
+  (lines 84-92).
+- No keys outside the allow-list (`name`, `description`, `license`,
+  `compatibility`, `metadata`, `allowed-tools`, `version`,
+  `argument-hint`, `disable-model-invocation`, `user-invocable`, `model`,
+  `context`, `agent`, `hooks`) (lines 18-33, 94-96).
+
+`test_validate_skills.py` is the unittest suite covering those rules.
+
+## tilth / cheez-* hard-fail vs optional MCP
+
+Tool dependency is asymmetric by design:
+
+- **`cheez-*` skills require tilth MCP and hard-fail without it.** They
+  refuse to fall back to `grep`/`cat`/`Edit`
+  (`skills/cheez-search/SKILL.md:3-5`, `AGENTS.md:73`).
+- **Every other skill stays portable** and degrades to host-native tools.
+  Workflow skills only *suggest* tilth, Context7, Tavily, and
+  code-review-graph; there is no repo-wide MCP requirement
+  (`README.md:87,161`).
+
+The trade is intentional: the tool skills buy AST-grounded precision and
+announce the cost by refusing to run without it; the workflow skills stay
+universal.
+
+## `.pyz` bundles
+
+Skills that consume `shared/scripts/` ship a pre-built `.pyz` so the
+shared helpers are self-contained at install time, invoked as
+`python3 ${CLAUDE_SKILL_DIR}/scripts/<skill>.pyz <subcommand>`
+(`skills/mold/SKILL.md:22`). Bundles exist for affinage, briesearch,
+cheese-factory, cook, melt, and mold. `just bundle` rebuilds them locally
+(`scripts/build_pyz.py`); `build-pyz.yml` rebuilds and commits them on
+every relevant push to `main` (`justfile:18-19`).
+
+## CI workflows
+
+Under `.github/workflows/`:
+
+| Workflow | Trigger | Does |
+|---|---|---|
+| `validate.yml` | push main, all PRs | frontmatter validation, pytest, install.sh bats + smoke, lint |
+| `build-pyz.yml` | push main (`src/**`, `shared/scripts/**`, build script) | rebuild + commit `.pyz` bundles |
+| `release.yml` | tag `v[0-9]*` | stage slim tree, force-push `release` branch, GitHub release |
+| `docs.yml` | push/PR on docs paths, dispatch | `mkdocs build --strict`, deploy Pages on main |
+| `codeql.yml` | PRs, push main, weekly | CodeQL on python + actions |
+| `dependency-review.yml` | PRs to main | block vulnerable / disallowed-license deps |
+| `scorecard.yml` | push main, weekly | OpenSSF Scorecard → SARIF |
+| `copilot-review.yml` | PR opened/reopened/ready | add Copilot as reviewer |
+
+### Prerequisites
+
+`just`, `uv` (for `uvx ruff`), plus `yamllint`, `yamlfmt`,
+`markdownlint-cli2`, `shellcheck`, and `bats` — see `README.md` for
+install hints (`AGENTS.md:18-21`).

--- a/.hallouminate/wiki/wiki-conventions.md
+++ b/.hallouminate/wiki/wiki-conventions.md
@@ -1,0 +1,120 @@
+# Wiki conventions for easy-cheese
+
+You — the agent writing entries in this wiki — are bound by a few
+conventions the hallouminate indexer counts on, plus the durable-vs-
+transient boundary that decides whether a fact belongs here at all.
+
+This page is silent on per-entry lifecycle and frontmatter schema. That
+contract is owned by a separate seam; do not invent frontmatter fields
+here.
+
+## Durable vs transient — the boundary that decides everything
+
+Before writing anything, decide which lane the fact belongs in. This is
+the single most important rule in this repo's memory model.
+
+| Where | Indexed as | Git | Lifecycle | Use for |
+|---|---|---|---|---|
+| `.hallouminate/wiki/` | `repo:easy-cheese:wiki` | **tracked** | durable across sessions | architecture, protocols, conventions, "why this design not that one" |
+| `.cheese/` | `cheese-local` | **gitignored** | transient per-task | `/cook` `/age` `/press` `/cure` output, specs, handoffs, exploration |
+
+**The durable/transient split is the git-tracking split.** If a fact is
+worth committing for the next agent who lands here cold, it is durable —
+write it to the wiki. If it only makes sense inside one task, it is
+transient — leave it in `.cheese/` (which `.gitignore` keeps out of the
+tree, see `.gitignore:2`).
+
+Rule of thumb: *would a future agent benefit from this note with zero
+context about the task that produced it?* Yes → wiki. No → `.cheese/`.
+
+Concrete classification examples:
+
+- "The pipeline order is culture → mold → cook → press → age → cure" → **durable**.
+- "Curd #3 of the durable-memory spec failed its press pass" → **transient**.
+- "cheez-* skills hard-fail without tilth MCP; everything else degrades" → **durable**.
+- "The age report for PR #107 flagged two medium findings" → **transient**.
+
+## One topic per file
+
+A wiki entry is a slice of knowledge with a clear scope. If you find
+yourself drafting two unrelated topics in one file, split them. The
+chunker breaks markdown by H1/H2/H3 headings — a file with two H1
+sections will still chunk, but `ground` will rank both sections together,
+which is almost never what you want.
+
+## First non-blank line is the H1
+
+The first non-blank line of every entry must be `# Topic Name`. The
+chunker uses the H1 as the breadcrumb root for every chunk in the file,
+and the auto-index reads it as the trailing gloss on the file's link
+row. Skip the H1 and breadcrumbs degrade and the index row is ungloss'd.
+
+## File stem matches the slug
+
+Topic "Workflow invariants" → file `workflow-invariants.md`. Lowercase,
+kebab-case, no spaces, no capitals, `.md` only. The stem is what other
+pages link to and what shows up in `ground` outline paths.
+
+## Idempotent writes
+
+`add_markdown` rejects existing files by default. To update:
+
+1. `read_markdown` to inspect current content.
+2. Decide what changes.
+3. `add_markdown` with `overwrite: true`.
+
+This forces a look at current state before clobbering, so concurrent
+authors don't silently lose each other's edits.
+
+## Tree layout & progressive disclosure
+
+Top-level files hold foundational topics (`architecture.md`,
+`workflow-invariants.md`, `tooling.md`, `wiki-conventions.md`). Group
+related entries under subdirectories as the wiki grows
+(`add_markdown` accepts nested paths and creates parents on demand).
+
+Every directory carries an `index.md`: the first H1 names the subtopic,
+the body holds curated prose plus a link list to siblings and children.
+The daemon scaffolds and maintains the link list between
+`<!-- HALLOUMINATE:INDEX-START -->` / `<!-- HALLOUMINATE:INDEX-END -->`
+markers — prose outside the markers is preserved verbatim. Remove the
+marker pair to opt a file out of auto-indexing.
+
+### Link convention
+
+- `[stem](./stem.md)` for files in the same directory.
+- `[subdir/](./subdir/index.md)` for child directories.
+- Relative paths only — the wiki should survive moving the whole tree.
+
+## When to update — the post-land cadence
+
+`AGENTS.md` instructs every agent to refresh this wiki **after a change
+lands on `main`**, but only when the change altered durable knowledge:
+architecture, protocols, conventions, or a "why this design not that one"
+decision. Routine bug fixes and per-task output stay in `.cheese/`.
+
+Do the update through the hallouminate MCP (`read_markdown` →
+`add_markdown { overwrite: true }`), not raw file edits, so the LanceDB
+index and ancestor `index.md` link lists stay in sync.
+
+## The authoring loop
+
+```text
+1. list_tree                            (see the existing shape)
+2. ground "<topic adjacent search>"     (find related entries)
+3. read_markdown index.md               (confirm naming + style)
+4. draft the page (H1 first line, kebab slug, link siblings)
+5. add_markdown { corpus: "repo:easy-cheese:wiki",
+                  path: "<slug>.md", content: "<markdown>",
+                  overwrite: false }
+6. (the daemon rewrites ancestor index.md link lists for you)
+```
+
+## Style
+
+- Lead with the conclusion. Don't bury the point under preamble.
+- Cite files and line ranges by path: `skills/mold/references/handshake.md:1-3`.
+- Cite commits by SHA when behavior depends on history.
+- Prefer concrete examples to abstract description.
+- Keep entries short — ~50–150 lines is the right band. A wiki page is
+  not a tutorial.

--- a/.hallouminate/wiki/workflow-invariants.md
+++ b/.hallouminate/wiki/workflow-invariants.md
@@ -1,0 +1,89 @@
+# Workflow invariants
+
+These are the rules the cheese pipeline holds constant across every task.
+Break one and the pipeline's guarantees stop holding, so treat them as
+contracts, not conventions.
+
+## Pipeline ordering
+
+The canonical order is fixed
+(`skills/mold/SKILL.md:125`, `skills/cook/SKILL.md:90`):
+
+```text
+culture → mold → cook → press → age → cure → ship
+```
+
+- **culture** — no-write thinking; never edits code, never the gate.
+- **mold** — converges a fuzzy idea into an approved spec under
+  `.cheese/specs/<slug>.md` (or the durable resolver path).
+- **cook** — TDD-disciplined implementation of that spec.
+- **press** — adversarial test hardening of the cooked diff.
+- **age** — ten-dimension review producing a findings report.
+- **cure** — applies the selected findings as focused fixes.
+- **ship** — push / open PR once `just check` is green.
+
+Skipping forward is allowed (e.g. cook → age, skipping press) but the
+relative order never inverts: you do not cure before age, or press before
+cook. Each phase hands off through a gate (below), and writes a handoff
+slug the next phase reads.
+
+## The two-key handshake (mold's curdle gate)
+
+`/mold` will not extract a spec until **both keys** turn
+(`skills/mold/references/handshake.md:1-3`):
+
+1. **User key** — the user says an explicit extraction verb: `curdle`,
+   `ship it`, `extract`, `that's enough`. A vague "ok let's go" does not
+   count (`handshake.md:5-9`).
+2. **Agent key** — the agent prints a 10-item coherence self-check
+   (problem grounded, ≥2 options weighed including Do Nothing, interface
+   sketches with pseudocode signatures, Validate Cycles judged, Grill run
+   for high-blast-radius work, open questions marked, quality gates
+   specified) and every box must be checked, or the user issues an
+   explicit `curdle anyway` override (`handshake.md:11-27`).
+
+Mandatory gates fire even before the keys: Ground (≥1 citation), Shape
+(≥1 option block), Sketch (when >1 module is touched), Grill (when blast
+radius is `high`), and the agent-introduced-scope gate — every
+distinguishing noun in the spec must trace to a user mention or get
+explicit per-term approval (`handshake.md:31-64`).
+
+The handshake is **bypassed** in mold's agent-invoked mini-spec mode,
+i.e. when `/cheese` calls `/mold` internally to materialise a spec for an
+already-clear task (`skills/mold/SKILL.md:12,46`).
+
+## Handoff gates between phases
+
+Phases never dispatch the next phase silently. Each ends at a handoff
+gate defined by `shared/handoff-gate.md`: a `handoff_gate:` block naming
+the `source_skill`, a `recommended` option, and an `options` list, each
+option carrying a `label` plus a `dispatch` / `continue` / `dispatch:
+none` action (`shared/handoff-gate.md:18-40`). Context for the next phase
+rides alongside as `handoff_context:` (`shared/handoff-gate.md:69-85`).
+A gate prevents silent dispatch; it does **not** mean the agent halts
+after the user chooses (`shared/handoff-gate.md:7`).
+
+`--auto` propagates through the chain to skip these gates for autonomous
+runs. `/ultracook` runs the chain
+`cook → press → age → cure → age → cure → age` (all `--auto`), capped at
+**two cure passes** (`skills/cook/SKILL.md:132`, `README.md:72`).
+
+## `just check` is the single quality gate
+
+There is exactly one shippability signal: green from `just check`
+(`AGENTS.md:7`). It autofixes lint (markdown, yaml, python via ruff) then
+runs skill-frontmatter validation, shell lint, the python + bash test
+suites, and `mkdocs build --strict`. CI runs `just ci` — the same gates,
+no autofixes. **Never commit or push on a red `just check`**, and never
+weaken or skip a test to force green. See [tooling](./tooling.md) for the
+recipe breakdown.
+
+## The durable/transient boundary
+
+Durable knowledge (architecture, protocols, conventions, rationale) is
+git-tracked under `.hallouminate/wiki/`. Transient task output (specs,
+`/cook` `/age` `/press` `/cure` reports, handoffs) is gitignored under
+`.cheese/` (`.gitignore:2`). The split is the git-tracking split — see
+[wiki-conventions](./wiki-conventions.md) for the classification rule.
+This invariant exists so later integration seams cannot dump transient
+noise into durable memory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,22 @@ This is a skills-only collection following the [Agent Skills spec](https://agent
 
 See `README.md` for the full workflow and the suggested skill ordering.
 
+## Durable memory
+
+This repo keeps a durable-knowledge wiki at `.hallouminate/wiki/`
+(git-tracked, corpus `repo:easy-cheese:wiki`), separate from the
+transient per-task scratch under `.cheese/` (gitignored). **Recommended
+default:** after a change lands on `main` that altered durable
+knowledge — architecture, protocols, conventions, or a "why this design
+not that one" decision — query the wiki and update it. Routine fixes and
+per-task output stay in `.cheese/`.
+
+This is a recommended default, not a hard gate: updating the wiki
+requires the [hallouminate](https://github.com/paulnsorensen/hallouminate)
+MCP server. When it is unavailable, skip the update — do not hand-edit
+the LanceDB-indexed tree. See `.hallouminate/wiki/wiki-conventions.md`
+for the durable-vs-transient boundary and the authoring loop.
+
 ## Development notes
 
 - Python validators in `.github/scripts/` allow only `pyyaml` and `pytest` as third-party deps — see `.github/instructions/python.instructions.md`.


### PR DESCRIPTION
## Summary
- add a repo-tracked Hallouminate wiki as the durable-memory boundary
- document the rules for durable versus transient agent knowledge
- preserve researched comparisons of specification workflows for future `/mold` work

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 just test`: Python suites and skill validators passed; five pre-existing Bats assertions failed because the environment exposes real tool binaries that the mocked-PATH tests expect absent
- `just docs-build`: passed
- `just ci`: blocked before tests because the host Python `pytest_httpx` plugin imports a missing `certifi` package
