### PR TITLE
feat(cheese): add portable user question contract

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2579,8 +2579,8 @@ snapshots:
       github-slugger: 2.0.0
       satteri: 0.9.4
 
-  '@astrojs/mdx@7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))':
-    dependencies:
+  ? '@astrojs/mdx@7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))'
+  : dependencies:
       '@astrojs/internal-helpers': 0.10.1
       '@astrojs/markdown-remark': 7.2.1
       '@mdx-js/mdx': 3.1.1
@@ -2611,8 +2611,8 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3)':
-    dependencies:
+  ? '@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3)'
+  : dependencies:
       '@astrojs/markdown-satteri': 0.3.3
       '@astrojs/mdx': 7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))
       '@astrojs/sitemap': 3.7.3
@@ -3404,14 +3404,14 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.44.0(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2)):
-    dependencies:
+  ? astro-expressive-code@0.44.0(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))
+  : dependencies:
       astro: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2)
       rehype-expressive-code: 0.44.0
       url-extras: 0.1.0
 
-  astro-mermaid@2.1.0(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(mermaid@11.16.0):
-    dependencies:
+  ? astro-mermaid@2.1.0(astro@7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(mermaid@11.16.0)
+  : dependencies:
       astro: 7.0.6(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2)
       import-meta-resolve: 4.2.0
       mdast-util-to-string: 4.0.0

--- a/skills/briesearch/SKILL.md
+++ b/skills/briesearch/SKILL.md
@@ -15,7 +15,7 @@ Not for a single obvious file lookup or when the user already has enough evidenc
 
 ## Inputs
 
-Accept the whole user prompt as the research question. If version, framework, repo scope, or decision criteria are missing and would change the source plan, ask one clarifying question; otherwise proceed with stated assumptions.
+Accept the whole user prompt as the research question. If version, framework, repo scope, or decision criteria are missing and would change the source plan, ask one clarifying question through the shared transport in [`../cheese/references/ask-user-question.md`](../cheese/references/ask-user-question.md); otherwise proceed with stated assumptions.
 
 ## Flow
 

--- a/skills/cheese/references/ask-user-question.md
+++ b/skills/cheese/references/ask-user-question.md
@@ -1,0 +1,91 @@
+# Ask user question
+
+Use this reference whenever a skill needs user input. It owns question transport;
+workflow-specific records and consequences stay with the calling skill.
+
+## Semantic question record
+
+Build the decision before choosing a host tool:
+
+```yaml
+question:
+  id: stable-id
+  prompt: One short decision
+  recommended: option-id
+  multi: false
+  options:
+    - id: option-id
+      label: Short label
+      description: Effect or tradeoff
+```
+
+The record is the source of truth. A host rendering may change presentation, but it must preserve the prompt, recommended choice, every option's effect or tradeoff, selection mode, and a free-form `Other` path.
+
+## Capability-first rendering
+
+Use the richest callable structured question primitive that can faithfully
+encode the complete decision. Discover callability and the active primitive's
+advertised question and option capacities at runtime instead of assuming a
+harness-wide limit. Never name a host tool in the transcript unless it is
+callable in that session.
+
+Wrapper and orchestrator hosts such as Conductor and Emdash / Em Dash route to
+the selected underlying agent or provider rather than inventing a common
+question schema. Runtime capability detection always wins over the wrapper or provider name. If the expected provider primitive is absent, denied, headless,
+or too small for the complete decision, use the lossless fallback.
+
+| Harness | Prefer | Notes |
+| --- | --- | --- |
+| Claude Code | `AskUserQuestion` | Supports `questions[]` with `question`, short `header`, `options[]`, and optional `multiSelect`; hooks can fill `answers` via `updatedInput`. Source: [Claude Code hooks reference](https://docs.anthropic.com/en/docs/claude-code/hooks#askuserquestion). |
+| Codex / OpenAI app-server | `request_user_input` / `tool/requestUserInput` when exposed and lossless | In Codex CLI, use `request_user_input` only when the active tool list and current collaboration mode both allow it **and the full question fits the capacities advertised by that callable primitive**. If an active schema advertises only 2-3 explicit choices, a four-option decision does not fit: render every option with the numbered fallback, or use a lossless hybrid where every omitted button remains an explicit numbered choice. Never merge or drop options to make the tool call fit. Source: [Codex app-server reference](https://developers.openai.com/codex/app-server). |
+| Conductor | Underlying agent primitive | Conductor runs Claude Code or Codex sessions; route to the selected underlying agent's currently callable question primitive. Conductor Plan Mode exists for both, but Conductor is not a separate question API. Source: [Conductor agent modes](https://conductor.build/docs/concepts/agent-modes). |
+| OpenCode | `question` tool | The built-in `question` tool asks during execution with header, question text, options, and custom answers; ensure `permission.question` is not denied. Source: [OpenCode tools](https://opencode.ai/docs/tools#question). |
+| Pi | Visibly loaded extension question tool | Pi has no built-in model-callable question tool. Use a visibly loaded and callable extension tool only when its UI is available (`ctx.hasUI`); a Markdown skill cannot call `ctx.ui` directly. JSON/print or another headless mode must use numbered text. Sources: [Pi extensions](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md), [question extension example](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/examples/extensions/question.ts). |
+| OMP / Oh My Pi | `ask` interactive-only built-in | Each `questions[]` item carries `id`, `question`, and `options[]`, with optional `header`, `multi`, and zero-based `recommended`; `Other` is automatic. Use it only when callable in an interactive session and the complete question fits. Do not use a timeout that can auto-select a blocking approval or state-changing choice. Sources: [OMP ask reference](https://github.com/can1357/oh-my-pi/blob/main/docs/tools/ask.md), [OMP ask schema](https://github.com/can1357/oh-my-pi/blob/main/packages/coding-agent/src/tools/ask.ts). |
+| Emdash / Em Dash | Selected provider primitive | Emdash runs provider CLIs through PTY and can host ACP providers; it does not define one universal question API. Route through the selected provider's advertised primitive when callable and lossless, otherwise use numbered text. Sources: [Emdash docs](https://emdash.ai/docs), [provider integrations](https://github.com/generalaction/emdash/blob/main/agents/integrations/providers.md). |
+| GitHub Copilot CLI | `ask_user` tool | Copilot CLI lists `ask_user` as "Ask the user a question" and `--no-ask-user` disables it. Use it when available; otherwise numbered text. Source: [Copilot CLI command reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference). |
+| Gemini CLI | `ask_user` tool | Google codelab output lists `Ask User (ask_user)` in `/tools`; use it when present. Source: [Gemini CLI codelab](https://codelabs.developers.google.com/gemini-cli-hands-on). |
+| Cursor CLI / ACP | `cursor/ask_question` when exposed | Cursor ACP documents `cursor/ask_question` as a blocking extension method; use it only inside hosts that expose that ACP method. Source: [Cursor ACP docs](https://cursor.com/docs/cli/acp#cursor-extension-methods). |
+| Windsurf Cascade | Plan-mode interactive questions when in Plan Mode | Cascade Plan Mode can ask clarifying questions and present multiple options with an interactive interface. Outside that mode, use numbered text unless a host tool is exposed. Source: [Cascade modes](https://docs.windsurf.com/windsurf/cascade/modes). |
+| MCP server flows | `elicitation/create` | Use only when an MCP server is requesting user input through a client that supports elicitation. It is not a general assistant-to-user question primitive. Source: [MCP elicitation](https://modelcontextprotocol.io/specification/latest/client/elicitation). |
+| Aider and unknown harnesses | Numbered text | If no structured primitive is visible, ask a plain numbered question and wait for the next user reply. |
+
+This is native-first, not lowest-common-denominator behavior. Never merge, hide, or drop options to fit a host primitive.
+
+## Portable fallback
+
+```markdown
+Question: <one short question>
+Recommended: <label> — <why>
+
+1. <label> — <effect/tradeoff>
+2. <label> — <effect/tradeoff>
+3. <label> — <effect/tradeoff>
+4. <label> — <effect/tradeoff, when present>
+... <continue until every question option is explicit>
+Other: reply with `other: <short answer>`
+```
+
+A fallback must enumerate every option; its list is not capped at three. Use
+the label identified by `question.recommended`; do not assume it is option 1.
+A hybrid is lossless only when every action omitted from the structured control
+remains an explicit, equally actionable numbered choice.
+
+## Batching and defaults
+
+- Ask one decision by default.
+- Batch at most three related questions, and only when the callable primitive
+  explicitly supports batching.
+- Mark the recommended option; never select it merely because it is recommended.
+- Never auto-resolve a blocking approval or state-changing choice.
+- Use single-select unless the semantic record explicitly sets `multi: true`.
+
+## Normalize the answer
+
+1. Normalize the answer to an option `id`, an unambiguous option label, or a
+   free-form `other:` value.
+2. Preserve multiple selections only when `multi: true`.
+3. If the answer is ambiguous, ask one clarifying question through this same
+   transport; do not guess.
+4. Return the normalized value to the calling skill. The caller owns what
+   happens after selection.

--- a/skills/cheese/references/ask-user-question.md
+++ b/skills/cheese/references/ask-user-question.md
@@ -56,7 +56,7 @@ This is native-first, not lowest-common-denominator behavior. Never merge, hide,
 
 ```markdown
 Question: <one short question>
-Recommended: <label> — <why>
+Recommended: <label> — <recommended option's description>
 
 1. <label> — <effect/tradeoff>
 2. <label> — <effect/tradeoff>
@@ -66,8 +66,10 @@ Recommended: <label> — <why>
 Other: reply with `other: <short answer>`
 ```
 
-A fallback must enumerate every option; its list is not capped at three. Use
-the label identified by `question.recommended`; do not assume it is option 1.
+A fallback must enumerate every option; its list is not capped at three. When
+`question.recommended` names an option, render its label and description on the
+`Recommended:` line; do not assume it is option 1. When
+`question.recommended` is `none`, omit the `Recommended:` line.
 A hybrid is lossless only when every action omitted from the structured control
 remains an explicit, equally actionable numbered choice.
 
@@ -82,8 +84,9 @@ remains an explicit, equally actionable numbered choice.
 
 ## Normalize the answer
 
-1. Normalize the answer to an option `id`, an unambiguous option label, or a
-   free-form `other:` value.
+1. Map a displayed 1-based ordinal to the corresponding option `id`. Otherwise,
+   normalize an option `id`, an unambiguous option label, or a free-form
+   `other:` value.
 2. Preserve multiple selections only when `multi: true`.
 3. If the answer is ambiguous, ask one clarifying question through this same
    transport; do not guess.

--- a/skills/cheese/references/handoff-gate.md
+++ b/skills/cheese/references/handoff-gate.md
@@ -16,95 +16,95 @@ A handoff gate prevents silent dispatch. It does not mean the agent stops after 
 
 ## Gate shape
 
-Before asking, render each option as a structured record. The host UI may show this as buttons, a structured question, or a numbered list, but the semantics must be stable. The top-level key is `handoff_gate:` to distinguish it from per-option context payloads (`handoff_context:` — see below):
+Before asking, build a structured gate record. The top-level key is
+`handoff_gate:` to distinguish it from per-option context payloads
+(`handoff_context:` — see below):
 
 ```yaml
 handoff_gate:
-  source_skill: /<current-skill>
-  recommended: <label-or-none>
+  source_skill: /cook
+  id: post-cook-next-step
+  prompt: What should happen next?
+  recommended: harden-tests
+  multi: false
   options:
-    - label: Run /press <slug>
+    - id: harden-tests
+      label: Harden tests before review
+      description: Strengthen regression coverage before review.
       dispatch: /press <slug>
       context:
         slug: <slug>
         source_report: .cheese/cook/<slug>.md
         flags: []
-    - label: Modify decomposition
+    - id: modify-decomposition
+      label: Modify decomposition
+      description: Revise the current decomposition before continuing.
       continue: ask-for-decomposition-change
       context:
         scope: current-skill
-    - label: Stop
+    - id: stop
+      label: Stop
+      description: Leave the pipeline paused without starting another skill.
       dispatch: none
       context:
         reason: leave pipeline paused
 ```
 
-Every option must include:
+Every gate must include:
 
-- **Label** — the user-facing choice.
-- Exactly one of:
-  - **Dispatch** — the exact command for a skill transition (`/press <slug>`, `/age <slug> --hard`, …), including slug/path/scope and propagated flags such as `--hard`.
-  - **Continue** — a short identifier for an in-skill action the current skill knows how to execute (e.g. `ask-for-decomposition-change`, `re-run-decomposer`, `write-manifest-then-seed`).
-  - `dispatch: none` — terminal options (Stop, Pause, Compact) that return a final status and do not start another skill.
-- **Context** — any prose or structured payload the action needs but that is not part of the command line.
-- **On select** — execute the dispatch or continue action immediately after the user selects it.
+- **ID** — a stable question identifier.
+- **Prompt** — one short question.
+- **Recommended** — one option ID, or `none`.
+- **Multi** — whether multiple option IDs may be selected.
+- **Options** — each with a stable **ID**, user-facing **label**, and
+  **description** of its effect or tradeoff.
+- Exactly one action per option:
+  - **Dispatch** — the exact command for a skill transition
+    (`/press <slug>`, `/age <slug> --hard`, …), including slug/path/scope and
+    propagated flags such as `--hard`.
+  - **Continue** — a short identifier for an in-skill action the current skill
+    knows how to execute (e.g. `ask-for-decomposition-change`,
+    `re-run-decomposer`, `write-manifest-then-seed`).
+  - `dispatch: none` — a terminal option (Stop, Pause, Compact) that returns a
+    final status and does not start another skill.
+- **Context** — any payload the action needs that is not part of the command.
+- **On select** — execute the action immediately after the user selects it.
 
-`dispatch: none` is for *terminal* options only. Options that keep the current skill running must use `continue:`, not `dispatch: none`, so the gate reader can tell "stop" apart from "do something else in this skill".
+`dispatch: none` is for terminal options only. Options that keep the current
+skill running use `continue:`, so the gate reader can distinguish stopping from
+continuing within the current skill.
 
-## Host routing guide
+## Render the gate
 
-The `handoff_gate:` block is the semantic source of truth. After building it,
-choose the richest question mechanism the current harness actually exposes **and
-that can faithfully encode every option**. Inspect the active primitive's
-advertised question and option capacities rather than assuming limits from a
-particular harness version; never name a host tool in the transcript unless it
-is callable in that session.
+Project the generic question fields without renaming or inventing values:
 
-| Harness | Prefer | Notes |
-| --- | --- | --- |
-| Claude Code | `AskUserQuestion` | Supports `questions[]` with `question`, short `header`, `options[]`, and optional `multiSelect`; hooks can fill `answers` via `updatedInput`. Source: [Claude Code hooks reference](https://docs.anthropic.com/en/docs/claude-code/hooks#askuserquestion). |
-| Codex / OpenAI app-server | `request_user_input` / `tool/requestUserInput` when exposed and lossless | In Codex CLI, use `request_user_input` only when the active tool list and current collaboration mode both allow it **and the full gate fits the capacities advertised by that callable primitive**. If an active schema advertises only 2-3 explicit choices, a standard four-option forward-step menu does not fit: render every action with the numbered fallback (or a lossless hybrid where the fourth action remains an explicit numbered choice). Never merge or drop actions to make the tool call fit. Source: [Codex app-server reference](https://developers.openai.com/codex/app-server). |
-| Conductor | Underlying agent primitive | Conductor runs Claude Code or Codex sessions; route to that agent's question primitive. Conductor Plan Mode exists for both, but Conductor is not a separate question API. Source: [Conductor agent modes](https://conductor.build/docs/concepts/agent-modes). |
-| OpenCode | `question` tool | The built-in `question` tool asks during execution with header, question text, options, and custom answers; ensure `permission.question` is not denied. Source: [OpenCode tools](https://opencode.ai/docs/tools#question). |
-| GitHub Copilot CLI | `ask_user` tool | Copilot CLI lists `ask_user` as "Ask the user a question" and `--no-ask-user` disables it. Use it when available; otherwise numbered text. Source: [Copilot CLI command reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference). |
-| Gemini CLI | `ask_user` tool | Google codelab output lists `Ask User (ask_user)` in `/tools`; use it when present. Source: [Gemini CLI codelab](https://codelabs.developers.google.com/gemini-cli-hands-on). |
-| Cursor CLI / ACP | `cursor/ask_question` when exposed | Cursor ACP documents `cursor/ask_question` as a blocking extension method; use it only inside hosts that expose that ACP method. Source: [Cursor ACP docs](https://cursor.com/docs/cli/acp#cursor-extension-methods). |
-| Windsurf Cascade | Plan-mode interactive questions when in Plan Mode | Cascade Plan Mode can ask clarifying questions and present multiple options with an interactive interface. Outside that mode, fall back to numbered text unless a host tool is exposed. Source: [Cascade modes](https://docs.windsurf.com/windsurf/cascade/modes). |
-| MCP server flows | `elicitation/create` | Use only when an MCP server is requesting user input through a client that supports elicitation. It is not a general assistant-to-user question primitive. Source: [MCP elicitation](https://modelcontextprotocol.io/specification/latest/client/elicitation). |
-| Aider and unknown harnesses | Numbered text | If no structured primitive is visible, ask a plain numbered question and wait for the next user reply. |
-
-### Portable fallback format
-
-```markdown
-Question: <one short question>
-Recommended: <label> — <why>
-
-1. <label> — <effect/tradeoff>
-2. <label> — <effect/tradeoff>
-3. <label> — <effect/tradeoff>
-4. <label> — <effect/tradeoff, when present>
-... <continue until every handoff_gate option is explicit>
-Other: reply with `other: <short answer>`
+```text
+question.id = handoff_gate.id
+question.prompt = handoff_gate.prompt
+question.recommended = handoff_gate.recommended
+question.multi = handoff_gate.multi
+question.options = handoff_gate.options map { id, label, description }
 ```
 
-Use the option label from `handoff_gate.recommended`; do not assume the
-recommended option is numbered `1` unless you deliberately rendered that label
-as option 1 in this fallback.
-
-Keep gates small: one decision by default, at most three questions when the
-host primitive explicitly supports batching. Include a free-form `Other` path
-when the host supports it; otherwise spell out the `other:` fallback in text.
-
-The fallback must enumerate every option in `handoff_gate.options`; its list is not capped at three. Host option limits select the rendering mechanism—they never shrink the decision.
+Retain `source_skill`, `dispatch`, `continue`, and `context` in the gate,
+keyed by option id. After the shared
+[`ask-user-question.md`](ask-user-question.md) transport returns normalized
+option IDs, resolve those IDs against the original gate record. This projection
+preserves every question field and every action field; host capabilities only
+change presentation.
 
 ## After the answer arrives
 
-1. Normalize the answer to one option label or recognized free-text verb.
-2. If the answer is ambiguous, ask one clarifying question; do not guess.
-3. If the selected option has `dispatch: none`, stop with the relevant artifact path or pause status.
-4. If the selected option has a `continue:` identifier, execute that in-skill action immediately.
-5. If the selected option has a `dispatch:` command, immediately enter that skill with the exact command and context packet.
-6. Do not re-run `/cheese` classification unless the selected option explicitly says to do so.
+1. Normalize the answer through
+   [`ask-user-question.md`](ask-user-question.md).
+2. If the selected option has `dispatch: none`, stop with the relevant artifact
+   path or pause status.
+3. If the selected option has a `continue:` identifier, execute that in-skill
+   action immediately.
+4. If the selected option has a `dispatch:` command, immediately enter that
+   skill with the exact command and context packet.
+5. Do not re-run `/cheese` classification unless the selected option explicitly
+   says to do so.
 
 ## Context payloads
 
@@ -136,13 +136,24 @@ Outside those autonomous paths, interactive gates must not add `--auto` unless t
 
 ## Standard forward-step menu
 
-The forward command and its label vary per gate. Simple gates share one four-option shape — a forward step plus the standard tail (**Ship it**, **Checkpoint & stop**, **Stop**); gates with a richer *core* decision render that decision's options first, then append the same tail (see below):
+The forward command and its label vary per gate. A simple menu contains four options by design, not a host or button cap: one forward step plus the standard
+tail (**Ship it**, **Checkpoint & stop**, **Stop**). Gates with a richer *core*
+decision render that decision's options first, then append the same tail:
 
-- **\<forward verb\>** *(recommended)* — the plain forward command: one phase, interactive downstream (e.g. `/press <slug>`).
-- **Ship it** — the forward command plus `--auto --open-pr`: run the rest of the pipeline headless and open (or push) the PR at the terminal cure (e.g. `/press <slug> --auto --open-pr`).
-- **Checkpoint & stop** — `/wheypoint`: write a resumable handoff slug and pause, so a fresh context can resume via `/cheese --continue <slug>`.
-- **Stop** — dispatch none; leave the pipeline paused with no checkpoint.
+- **\<forward verb\>** *(recommended)* — the plain forward command: one phase,
+  interactive downstream (e.g. `/press <slug>`).
+- **Ship it** — the forward command plus `--auto --open-pr`: run the rest of the
+  pipeline headless and open (or push) the PR at the terminal cure (e.g.
+  `/press <slug> --auto --open-pr`).
+- **Checkpoint & stop** — `/wheypoint`: write a resumable handoff slug and pause,
+  so a fresh context can resume via `/cheese --continue <slug>`.
+- **Stop** — `dispatch: none`; leave the pipeline paused with no checkpoint.
 
-Propagate any in-scope `--hard` onto both runnable options (vanilla and **Ship it**). The four-option cap is why **Ship it** bundles `--auto` and `--open-pr` rather than offering them separately — `--open-pr` only acts at the terminal cure, so a standalone open-pr option at an upstream gate would not do anything until the chain reaches cure; it rides the headless chain instead.
+Propagate any in-scope `--hard` onto both runnable standard options. **Ship it**
+bundles `--auto` and `--open-pr` because `--open-pr` acts only when the chain
+reaches terminal cure; the bundling is unrelated to host option capacity.
 
-When a gate carries a richer *core* decision (e.g. `/age`'s finding selection, or `/cure`'s push-vs-re-review), render that decision's options first, then append **Ship it**, **Checkpoint & stop**, and **Stop** as the standard tail. A gate-specific alternative that does not fit the four buttons (e.g. cook's "skip press, review now") stays as prose plus the free-form `Other` path rather than displacing a standard option.
+When a gate carries a richer *core* decision, keep every gate-specific alternative as an explicit `handoff_gate.options` record, then append the
+standard tail. The shared question transport decides whether to use structured
+controls or the numbered fallback; no alternative is demoted to prose or
+`Other`.

--- a/skills/cheese/references/handoff-gate.md
+++ b/skills/cheese/references/handoff-gate.md
@@ -52,6 +52,7 @@ handoff_gate:
 
 Every gate must include:
 
+- **Source skill** — the calling workflow skill that owns the gate.
 - **ID** — a stable question identifier.
 - **Prompt** — one short question.
 - **Recommended** — one option ID, or `none`.

--- a/skills/cheese/references/harness-portability.md
+++ b/skills/cheese/references/harness-portability.md
@@ -18,14 +18,15 @@ Use the host primitive that preserves bounded context. When the host offers mult
 
 ## User interaction
 
-Build the semantic question or handoff record first, following the shared [`handoff-gate.md`](handoff-gate.md) contract. Then use the richest callable structured question primitive that can faithfully encode the complete decision. Discover callability and the active primitive's advertised question and option capacities at runtime instead of assuming a harness-wide limit:
+Build the semantic question before selecting a transport. Generic questions use
+the shared [`ask-user-question.md`](ask-user-question.md) contract. Workflow
+handoffs first build the semantic record defined by
+[`handoff-gate.md`](handoff-gate.md), then render that record through
+`ask-user-question.md`.
 
-- Claude Code: `AskUserQuestion`.
-- Codex: `request_user_input` when it is exposed, the active collaboration mode permits it, and the complete gate fits the capacities advertised by that callable primitive.
-- Other harnesses: an equivalent structured question primitive with enough option capacity for every action.
-- When no structured primitive is callable **or its limits cannot represent every action**: use the lossless numbered-text fallback from the handoff gate. If an active primitive advertises only 2-3 explicit choices, a four-option gate is one case that requires the fallback or a hybrid. A hybrid is valid only if every omitted button remains an explicit, equally actionable numbered choice alongside the structured prompt.
-
-This is a native-first priority order, not a lowest-common-denominator rule. Never merge, hide, or drop actions to fit a host primitive. Preserve the recommended choice, every option's effect or tradeoff, a free-form `Other` path, and immediate execution of the selected non-stop action across every rendering. Degrade only as far as the active harness requires.
+The question reference owns capability detection, host mappings, lossless
+fallbacks, batching, defaults, and answer normalization. Keep those details out
+of workflow skills and this portability overview.
 
 ## Sub-agent dispatch
 

--- a/tests/python/test_docs_emphasis_guard.py
+++ b/tests/python/test_docs_emphasis_guard.py
@@ -250,49 +250,95 @@ def test_harness_portability_reference_covers_the_portability_contract():
 
 
 def test_question_routing_is_native_first_and_lossless():
+    questions = (REPO_ROOT / "skills/cheese/references/ask-user-question.md").read_text(
+        encoding="utf-8"
+    )
     portability = (REPO_ROOT / "skills/cheese/references/harness-portability.md").read_text(
         encoding="utf-8"
     )
     gate = (REPO_ROOT / "skills/cheese/references/handoff-gate.md").read_text(encoding="utf-8")
 
-    # Native structured controls stay first-class on both primary harnesses.
-    assert "Claude Code: `AskUserQuestion`" in portability
-    assert "Codex: `request_user_input`" in portability
-    assert "active collaboration mode permits it" in portability
-    assert "richest callable structured question primitive" in portability
+    # Ownership stays explicit: generic transport lives in one shared reference.
+    assert "ask-user-question.md" in portability
+    assert "handoff-gate.md" in portability
+    assert "ask-user-question.md" in gate
+    assert "AskUserQuestion" not in portability
+    assert "| Claude Code |" not in gate
 
-    # Routing discovers the callable primitive and its live advertised capacities.
-    for body in (portability, gate):
-        assert "callable" in body
-        assert "advertised question and option capacities" in body
-    assert "active tool list and current collaboration mode both allow it" in gate
-    assert "capacities advertised by that callable primitive" in gate
+    # Handoff records project losslessly into the generic question schema.
+    for required in (
+        "id: post-cook-next-step",
+        "prompt: What should happen next?",
+        "recommended: harden-tests",
+        "multi: false",
+        "description: Strengthen regression coverage before review.",
+    ):
+        assert required in gate
+    assert "question.id = handoff_gate.id" in gate
+    assert "question.options = handoff_gate.options" in gate
+    assert "keyed by option id" in gate
 
-    # A four-option gate is conditional on the active schema, never a Codex-wide limit.
-    for body in (portability, gate):
-        assert "If an active" in body
-        assert "2-3 explicit choices" in body
-        assert "four-option" in body
-        assert "2-3 explicit-choice limit" not in body
+    # Four standard semantic options are a menu design, never a transport cap.
+    assert "four options by design, not a host or button cap" in gate
+    assert "every gate-specific alternative" in gate
+    assert "four-option cap" not in gate
+    assert "stays as prose plus the free-form `Other` path" not in gate
 
-    # Every rendering preserves the semantic decision without dropping fidelity.
-    assert "faithfully encode the complete decision" in portability
-    assert "limits cannot represent every action" in portability
-    assert "lossless numbered-text fallback" in portability
-    assert "Never merge, hide, or drop actions" in portability
+    # Runtime discovery uses the richest lossless callable primitive.
+    assert "richest callable structured question primitive" in questions
+    assert "advertised question and option capacities" in questions
+    assert "Runtime capability detection always wins over the wrapper or provider name." in questions
+    assert "selected underlying agent or provider" in questions
+
+    # Codex capacities are live, mode-aware, and never shrink four-option decisions.
+    assert "active tool list and current collaboration mode both allow it" in questions
+    assert "capacities advertised by that callable primitive" in questions
+    assert "If an active" in questions
+    assert "2-3 explicit choices" in questions
+    assert "four-option" in questions
+    assert "2-3 explicit-choice limit" not in questions
+
+    # Every rendering preserves the complete semantic question.
+    assert "Never merge, hide, or drop options" in questions
+    assert "fallback must enumerate every option" in questions
     for required in (
         "recommended choice",
         "every option's effect or tradeoff",
         "free-form `Other`",
-        "immediate execution",
     ):
-        assert required in portability
-    assert "faithfully encode every option" in gate
-    assert "Never merge or drop actions" in gate
-    assert "fallback must enumerate every option" in gate
-    assert "free-form `Other` path" in gate
-    assert "execute that in-skill action immediately" in gate
-    assert "immediately enter that skill" in gate
+        assert required in questions
+
+    # Every named harness keeps an explicit, capability-driven route.
+    for harness in (
+        "Claude Code",
+        "Codex / OpenAI app-server",
+        "Conductor",
+        "OpenCode",
+        "Pi",
+        "OMP / Oh My Pi",
+        "Emdash / Em Dash",
+        "Cursor CLI / ACP",
+    ):
+        assert f"| {harness} |" in questions
+
+    # Pi needs a loaded extension; OMP owns a distinct interactive built-in.
+    assert "visibly loaded and callable extension tool" in questions
+    assert "`ctx.hasUI`" in questions
+    assert "Markdown skill cannot call `ctx.ui` directly" in questions
+    assert "interactive-only built-in" in questions
+    assert "`id`, `question`, and `options[]`" in questions
+    assert "`Other` is automatic" in questions
+
+    # Emdash is a provider host, not another universal question schema.
+    assert "does not define one universal question API" in questions
+    assert "selected provider's advertised primitive" in questions
+
+    # Generic batching, defaults, and answer normalization stay with transport.
+    assert "Ask one decision by default" in questions
+    assert "at most three related questions" in questions
+    assert "Never auto-resolve a blocking approval" in questions
+    assert "Normalize the answer" in questions
+    assert "If the answer is ambiguous" in questions
 
 
 @pytest.mark.parametrize(
@@ -314,6 +360,13 @@ def test_core_workflow_question_sites_reference_shared_handoff_gate(skill: str):
     body = (REPO_ROOT / f"skills/{skill}/SKILL.md").read_text(encoding="utf-8")
 
     assert "handoff-gate.md" in body
+
+
+def test_briesearch_clarifying_questions_reference_shared_question_transport():
+    body = (REPO_ROOT / "skills/briesearch/SKILL.md").read_text(encoding="utf-8")
+
+    assert "ask-user-question.md" in body
+    assert "handoff-gate.md" not in body
 
 
 def test_core_cheese_questions_use_the_shared_handoff_gate():

--- a/tests/python/test_docs_emphasis_guard.py
+++ b/tests/python/test_docs_emphasis_guard.py
@@ -267,6 +267,8 @@ def test_question_routing_is_native_first_and_lossless():
 
     # Handoff records project losslessly into the generic question schema.
     for required in (
+        "source_skill: /cook",
+        "**Source skill**",
         "id: post-cook-next-step",
         "prompt: What should happen next?",
         "recommended: harden-tests",
@@ -305,6 +307,9 @@ def test_question_routing_is_native_first_and_lossless():
         "recommended choice",
         "every option's effect or tradeoff",
         "free-form `Other`",
+        "recommended option's description",
+        "omit the `Recommended:` line",
+        "displayed 1-based ordinal",
     ):
         assert required in questions
 


### PR DESCRIPTION
## Summary

- add a shared `ask-user-question.md` transport contract for portable skill prompts
- map Claude, Codex, Pi, OMP, Conductor, Emdash, OpenCode, and Cursor to capability-detected native questions or a lossless numbered fallback
- keep workflow handoff semantics separate and route `/briesearch` clarifications through the shared transport

## Testing

- `just check`
- fresh-context portability review
