### PR TITLE
feat(ci): wiki-convention validator with golden tests

### DIFF
--- a/.github/scripts/test_validate_wiki.py
+++ b/.github/scripts/test_validate_wiki.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Golden-fixture tests for validate_wiki.py."""
+from __future__ import annotations
+
+import io
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import validate_wiki  # noqa: E402
+
+WIKI = ".hallouminate/wiki"
+
+ROOT_INDEX = """# Wiki index
+
+<!-- HALLOUMINATE:INDEX-START -->
+- [adr/](./adr/index.md) — adr
+- [topic-one](./topic-one.md) — Topic one
+<!-- HALLOUMINATE:INDEX-END -->
+"""
+
+ADR_INDEX = """# adr
+
+<!-- HALLOUMINATE:INDEX-START -->
+- [decision-001](./decision-001.md) — ADR: a decision
+<!-- HALLOUMINATE:INDEX-END -->
+"""
+
+
+class ValidateWikiTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._cwd = Path.cwd()
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="validate-wiki-"))
+        self.addCleanup(self._restore)
+        os.chdir(self.tmpdir)
+
+    def _restore(self) -> None:
+        os.chdir(self._cwd)
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write(self, rel: str, content: str) -> None:
+        path = self.tmpdir / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def _write_valid_wiki(self) -> None:
+        self._write(f"{WIKI}/index.md", ROOT_INDEX)
+        self._write(f"{WIKI}/topic-one.md", "# Topic one\n\nbody\n")
+        self._write(f"{WIKI}/adr/index.md", ADR_INDEX)
+        self._write(f"{WIKI}/adr/decision-001.md", "# ADR: a decision\n\nbody\n")
+
+    def _run(self) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = validate_wiki.main()
+        return rc, out.getvalue(), err.getvalue()
+
+    def test_valid_wiki_passes(self) -> None:
+        self._write_valid_wiki()
+        rc, out, err = self._run()
+        self.assertEqual(rc, 0, err)
+        self.assertIn("validated 4 wiki page(s)", out)
+
+    def test_wiki_dir_missing_fails_loud(self) -> None:
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn(f"ERROR: {WIKI}/ directory not found", err)
+
+    def test_empty_wiki_dir_fails_loud(self) -> None:
+        (self.tmpdir / WIKI).mkdir(parents=True)
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn("ERROR: no wiki pages found", err)
+
+    def test_missing_h1_fails(self) -> None:
+        self._write_valid_wiki()
+        self._write(f"{WIKI}/topic-one.md", "prose before the heading\n\n# Topic one\n")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn("ERROR:", err)
+        self.assertIn(f"{WIKI}/topic-one.md: first non-blank line is not a single '# ' H1", err)
+
+    def test_h2_first_line_fails(self) -> None:
+        self._write_valid_wiki()
+        self._write(f"{WIKI}/topic-one.md", "## Topic one\n\nbody\n")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn("not a single '# ' H1", err)
+
+    def test_h1_without_space_fails(self) -> None:
+        self._write_valid_wiki()
+        self._write(f"{WIKI}/topic-one.md", "#Topic one\n\nbody\n")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn("not a single '# ' H1", err)
+
+    def test_bare_hash_heading_fails(self) -> None:
+        self._write_valid_wiki()
+        self._write(f"{WIKI}/topic-one.md", "# \n\nbody\n")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn("not a single '# ' H1", err)
+
+    def test_index_without_h1_fails(self) -> None:
+        self._write_valid_wiki()
+        self._write(f"{WIKI}/adr/index.md", ADR_INDEX.replace("# adr\n", "adr\n"))
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn(f"{WIKI}/adr/index.md: first non-blank line is not a single '# ' H1", err)
+
+    def test_empty_page_fails(self) -> None:
+        self._write_valid_wiki()
+        self._write(f"{WIKI}/topic-one.md", "\n\n")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn(f"{WIKI}/topic-one.md: page is empty", err)
+
+    def test_leading_blank_lines_before_h1_pass(self) -> None:
+        self._write_valid_wiki()
+        self._write(f"{WIKI}/topic-one.md", "\n\n# Topic one\n\nbody\n")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 0, err)
+
+    def test_non_kebab_stem_fails(self) -> None:
+        self._write_valid_wiki()
+        self._write(f"{WIKI}/Bad_Stem.md", "# Bad stem\n")
+        self._write(
+            f"{WIKI}/index.md",
+            ROOT_INDEX.replace(
+                "<!-- HALLOUMINATE:INDEX-END -->",
+                "- [Bad_Stem](./Bad_Stem.md) — bad\n<!-- HALLOUMINATE:INDEX-END -->",
+            ),
+        )
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn(f"{WIKI}/Bad_Stem.md: file stem 'Bad_Stem' is not a kebab-case slug", err)
+
+    def test_page_absent_from_index_fails(self) -> None:
+        self._write_valid_wiki()
+        self._write(f"{WIKI}/adr/decision-002.md", "# ADR: another decision\n")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            f"{WIKI}/adr/decision-002.md: page is not listed in {WIKI}/adr/index.md", err
+        )
+
+    def test_index_entry_missing_file_fails(self) -> None:
+        self._write_valid_wiki()
+        self._write(
+            f"{WIKI}/adr/index.md",
+            ADR_INDEX.replace(
+                "<!-- HALLOUMINATE:INDEX-END -->",
+                "- [ghost](./ghost.md) — gone\n<!-- HALLOUMINATE:INDEX-END -->",
+            ),
+        )
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            f"{WIKI}/adr/index.md: index entry './ghost.md' points at a missing file", err
+        )
+
+    def test_index_missing_markers_fails(self) -> None:
+        self._write_valid_wiki()
+        self._write(f"{WIKI}/adr/index.md", "# adr\n\n- [decision-001](./decision-001.md)\n")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn(f"{WIKI}/adr/index.md: missing HALLOUMINATE index markers", err)
+
+    def test_markers_out_of_order_fails(self) -> None:
+        self._write_valid_wiki()
+        self._write(
+            f"{WIKI}/adr/index.md",
+            "# adr\n\n<!-- HALLOUMINATE:INDEX-END -->\n"
+            "- [decision-001](./decision-001.md)\n<!-- HALLOUMINATE:INDEX-START -->\n",
+        )
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn("HALLOUMINATE index markers are out of order", err)
+
+    def test_directory_without_index_fails(self) -> None:
+        self._write_valid_wiki()
+        self._write(f"{WIKI}/orphans/lost-page.md", "# Lost page\n")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn(f"{WIKI}/orphans: directory has wiki pages but no index.md", err)
+
+    def test_subdir_index_entry_resolves_through_parent(self) -> None:
+        # The root index's [adr/](./adr/index.md) entry must resolve; deleting
+        # the subtree makes it dangle.
+        self._write_valid_wiki()
+        shutil.rmtree(self.tmpdir / WIKI / "adr")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn(
+            f"{WIKI}/index.md: index entry './adr/index.md' points at a missing file", err
+        )
+
+    def test_dangling_entry_and_unlisted_page_both_reported(self) -> None:
+        # A dangling entry must not mask the unlisted-page check for the same dir.
+        self._write_valid_wiki()
+        self._write(
+            f"{WIKI}/adr/index.md",
+            ADR_INDEX.replace(
+                "<!-- HALLOUMINATE:INDEX-END -->",
+                "- [ghost](./ghost.md) — gone\n<!-- HALLOUMINATE:INDEX-END -->",
+            ),
+        )
+        self._write(f"{WIKI}/adr/decision-002.md", "# ADR: another decision\n")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn("'./ghost.md' points at a missing file", err)
+        self.assertIn("decision-002.md: page is not listed", err)
+
+    def test_multiple_errors_all_reported(self) -> None:
+        self._write_valid_wiki()
+        self._write(f"{WIKI}/topic-one.md", "no heading\n")
+        self._write(f"{WIKI}/adr/decision-002.md", "# ADR: another decision\n")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn("not a single '# ' H1", err)
+        self.assertIn("decision-002.md: page is not listed", err)
+        self.assertIn("FAIL: 2 error(s)", err)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_validate_wiki.py
+++ b/.github/scripts/test_validate_wiki.py
@@ -50,6 +50,11 @@ class ValidateWikiTest(unittest.TestCase):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content, encoding="utf-8")
 
+    def _write_bytes(self, rel: str, content: bytes) -> None:
+        path = self.tmpdir / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+
     def _write_valid_wiki(self) -> None:
         self._write(f"{WIKI}/index.md", ROOT_INDEX)
         self._write(f"{WIKI}/topic-one.md", "# Topic one\n\nbody\n")
@@ -227,6 +232,24 @@ class ValidateWikiTest(unittest.TestCase):
         self.assertIn("not a single '# ' H1", err)
         self.assertIn("decision-002.md: page is not listed", err)
         self.assertIn("FAIL: 2 error(s)", err)
+
+    def test_non_utf8_page_reported_as_error(self) -> None:
+        # A non-UTF-8 page must join the ERROR: report, not traceback.
+        self._write_valid_wiki()
+        self._write_bytes(f"{WIKI}/topic-one.md", b"\xff\xfe# Topic one\n")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn(f"ERROR: {WIKI}/topic-one.md: page is not valid UTF-8", err)
+        self.assertIn("FAIL: 1 error(s)", err)
+
+    def test_non_utf8_index_reported_as_error(self) -> None:
+        # A non-UTF-8 index must not traceback in the entry check either.
+        self._write_valid_wiki()
+        self._write_bytes(f"{WIKI}/adr/index.md", b"\xff\xfe# adr\n")
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn(f"ERROR: {WIKI}/adr/index.md: page is not valid UTF-8", err)
+        self.assertIn("cannot check index entries", err)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/validate_wiki.py
+++ b/.github/scripts/validate_wiki.py
@@ -40,8 +40,13 @@ def validate_page(path: Path) -> list[str]:
             f"(1-64 chars, lowercase a-z 0-9, no leading/trailing/consecutive hyphens)"
         )
 
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        errors.append(f"{path}: page is not valid UTF-8 ({exc.reason} at byte {exc.start})")
+        return errors
     first_line = next(
-        (line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()),
+        (line for line in text.splitlines() if line.strip()),
         None,
     )
     if first_line is None:
@@ -60,7 +65,12 @@ def index_link_targets(index: Path) -> tuple[list[Path] | None, list[str]]:
     Targets are None only when the markers themselves are missing or out of
     order; a dangling entry is reported but does not stop target collection.
     """
-    lines = index.read_text(encoding="utf-8").splitlines()
+    try:
+        lines = index.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        # validate_page already reported the encoding error for this file;
+        # entry checks cannot run without decodable content.
+        return None, [f"{index}: index is not valid UTF-8; cannot check index entries"]
     try:
         start = lines.index(INDEX_START)
         end = lines.index(INDEX_END)

--- a/.github/scripts/validate_wiki.py
+++ b/.github/scripts/validate_wiki.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Validate wiki page conventions under .hallouminate/wiki/. Exit 0 on success, 1 on any failure.
+
+Checks (per .hallouminate/wiki/wiki-conventions.md):
+- first non-blank line of every page is a single `# ` H1
+- file stem is a kebab-case slug
+- every directory with pages carries an index.md with HALLOUMINATE index markers
+- every index entry between the markers resolves to an existing file
+- every non-index page appears in its directory's index between the markers
+
+Discovery is hardcoded to .hallouminate/wiki/ (ADR hallouminate-wiring-stack-004);
+frontmatter/lifecycle checks are a separate seam (issue #206) and must not be added here.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SHARED_SCRIPTS = SCRIPT_DIR.parents[1] / "shared" / "scripts"
+if str(SHARED_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SHARED_SCRIPTS))
+
+from paths import KEBAB_SLUG  # noqa: E402
+
+WIKI_ROOT = Path(".hallouminate/wiki")
+INDEX_START = "<!-- HALLOUMINATE:INDEX-START -->"
+INDEX_END = "<!-- HALLOUMINATE:INDEX-END -->"
+LINK_TARGET_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+
+def validate_page(path: Path) -> list[str]:
+    errors: list[str] = []
+
+    stem = path.stem
+    if not KEBAB_SLUG.match(stem):
+        errors.append(
+            f"{path}: file stem '{stem}' is not a kebab-case slug "
+            f"(1-64 chars, lowercase a-z 0-9, no leading/trailing/consecutive hyphens)"
+        )
+
+    first_line = next(
+        (line for line in path.read_text(encoding="utf-8").splitlines() if line.strip()),
+        None,
+    )
+    if first_line is None:
+        errors.append(f"{path}: page is empty (first non-blank line must be a single '# ' H1)")
+    elif not re.match(r"# \S", first_line):
+        errors.append(
+            f"{path}: first non-blank line is not a single '# ' H1 (got: {first_line[:60]!r})"
+        )
+
+    return errors
+
+
+def index_link_targets(index: Path) -> tuple[list[Path] | None, list[str]]:
+    """Resolved targets of the links between the HALLOUMINATE markers, plus errors.
+
+    Targets are None only when the markers themselves are missing or out of
+    order; a dangling entry is reported but does not stop target collection.
+    """
+    lines = index.read_text(encoding="utf-8").splitlines()
+    try:
+        start = lines.index(INDEX_START)
+        end = lines.index(INDEX_END)
+    except ValueError:
+        return None, [f"{index}: missing HALLOUMINATE index markers ({INDEX_START} / {INDEX_END})"]
+    if end < start:
+        return None, [f"{index}: HALLOUMINATE index markers are out of order"]
+
+    errors: list[str] = []
+    targets: list[Path] = []
+    for line in lines[start + 1 : end]:
+        for raw_target in LINK_TARGET_RE.findall(line):
+            target = index.parent / raw_target
+            if not target.is_file():
+                errors.append(
+                    f"{index}: index entry '{raw_target}' points at a missing file"
+                )
+            targets.append(target.resolve())
+    return targets, errors
+
+
+def validate_directory(directory: Path, pages: list[Path]) -> list[str]:
+    index = directory / "index.md"
+    if index not in pages:
+        return [f"{directory}: directory has wiki pages but no index.md"]
+
+    targets, errors = index_link_targets(index)
+    if targets is None:
+        return errors
+
+    listed = set(targets)
+    for page in pages:
+        if page.name != "index.md" and page.resolve() not in listed:
+            errors.append(
+                f"{page}: page is not listed in {index} between the HALLOUMINATE markers"
+            )
+    return errors
+
+
+def main() -> int:
+    if not WIKI_ROOT.is_dir():
+        print(f"ERROR: {WIKI_ROOT}/ directory not found", file=sys.stderr)
+        return 1
+
+    pages = sorted(WIKI_ROOT.rglob("*.md"))
+    if not pages:
+        print(f"ERROR: no wiki pages found under {WIKI_ROOT}/", file=sys.stderr)
+        return 1
+
+    all_errors: list[str] = []
+    for page in pages:
+        all_errors.extend(validate_page(page))
+
+    by_dir: dict[Path, list[Path]] = {}
+    for page in pages:
+        by_dir.setdefault(page.parent, []).append(page)
+    for directory in sorted(by_dir):
+        all_errors.extend(validate_directory(directory, by_dir[directory]))
+
+    if all_errors:
+        for e in all_errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        print(
+            f"\nFAIL: {len(all_errors)} error(s) across {len(pages)} wiki page(s)",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: validated {len(pages)} wiki page(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.hallouminate/wiki/adr/hallouminate-wiring-stack-001.md
+++ b/.hallouminate/wiki/adr/hallouminate-wiring-stack-001.md
@@ -1,0 +1,8 @@
+# ADR: hallouminate wiring ships as a stacked 4-PR build, one PR per issue
+
+**Status:** accepted (2026-07-16)
+
+- **Context:** Issues #201/#202/#203/#205 could ship as one PR, two PRs (prose vs CI), or a 4-PR stack. #202 and #203 both edit `skills/age/SKILL.md`, so full parallelism was never available; #205 is fully file-disjoint.
+- **Decision:** Stacked build, bottom → top: #205 (CI validator, disjoint base) → #201 (mold/culture grounding) → #203 (query-time retrieval) → #202 (durable-change gates). Each PR closes exactly one issue.
+- **Alternatives:** One PR — fastest but mixes a Python validator with prose skill wiring in one review and squashes four issues into one commit. Two PRs — still bundles three issues into one wiring review.
+- **Consequences:** Four reviewable units with clean issue closure; the shared-file overlap is sequenced instead of conflicted. Costs stack maintenance (restacks on review changes to lower PRs).

--- a/.hallouminate/wiki/adr/hallouminate-wiring-stack-002.md
+++ b/.hallouminate/wiki/adr/hallouminate-wiring-stack-002.md
@@ -1,0 +1,8 @@
+# ADR: cook and age record durable-change flags; only the publication boundary writes the wiki
+
+**Status:** accepted (2026-07-16)
+
+- **Context:** Issue #202 reads literally as "post-land write-back hooks in /cook, /cure, and /age". Cure's write-back already landed (deb89a2, `skills/cure/SKILL.md:141-150`). Mirroring it into cook and age would create up to three writers for one change when the phases chain, and /age is otherwise a read-only reviewer. The `[TBD]` at `cure/SKILL.md:150` already leans toward consolidating the write trigger at one publication seam (/plate).
+- **Decision:** Cook and age get a conservative flag-only gate — a `durable_flags:` key in their handoff slugs recording durable-knowledge candidates (architecture/protocol/convention/rationale deltas only, default `none`). The single wiki write stays at the publication boundary (cure/plate/affinage), which consumes upstream flags as its candidate list.
+- **Alternatives:** Literal mirror (each phase writes independently) — rejected for duplicate writes and breaking /age's read-only contract. Cook-writes/age-flags middle ground — rejected as two writers where one suffices; standalone cooks still reach a publication boundary via /plate.
+- **Consequences:** One writer, no duplicate wiki entries, /age stays read-only, and the existing `[TBD]`'s plate-consolidation direction is preserved. Costs: a standalone cook whose session never publishes leaves flags unconsumed in its slug — acceptable, the slug is durable and the next publish reads it.

--- a/.hallouminate/wiki/adr/hallouminate-wiring-stack-003.md
+++ b/.hallouminate/wiki/adr/hallouminate-wiring-stack-003.md
@@ -1,0 +1,8 @@
+# ADR: liberal wiki grounding in mold/culture is prose guidance, not a coherence gate
+
+**Status:** accepted (2026-07-16)
+
+- **Context:** Issue #201 wants /mold probing the wiki at every decision point and /culture probing during evidence-gathering. Enforcement could be prose trigger-list guidance or a new lockstep-tested `COHERENCE_GATES` item ("wiki probed before curdle") like deb89a2's durable-writes gate.
+- **Decision:** Prose guidance: extend `skills/mold/references/grounding.md`'s probe-trigger list to decision/question/rationale points across Dialogue modes, and add a light probe to `skills/culture/SKILL.md:30`. No new gate node.
+- **Alternatives:** Coherence gate — enforced and drift-proof, but touches the gate graph plus lockstep test and fires even when the wiki has nothing relevant, adding ceremony to every mold session.
+- **Consequences:** Matches the issue's `triage/clear-fix` weight and keeps mold sessions light; costs the possibility of prose drift, which the wiki-probe habit in review can catch later. A gate can be added in a follow-up if drift is observed.

--- a/.hallouminate/wiki/adr/hallouminate-wiring-stack-004.md
+++ b/.hallouminate/wiki/adr/hallouminate-wiring-stack-004.md
@@ -1,0 +1,8 @@
+# ADR: validate_wiki.py hardcodes .hallouminate/wiki/ discovery, ignoring config.toml corpus_paths
+
+**Status:** accepted (2026-07-16)
+
+- **Context:** `.hallouminate/config.toml` declares `corpus_paths = ["skills"]` while its own comment says the wiki under `.hallouminate/wiki/` is the searchable corpus — the value and comment disagree, and whether the daemon indexes the wiki dir implicitly is unverified. The CI validator (#205) needs a file-discovery root.
+- **Decision:** The validator discovers `.hallouminate/wiki/**/*.md` directly — the conventions it lints (`wiki-conventions.md`) are defined for that directory, independent of what the daemon indexes.
+- **Alternatives:** Parse `corpus_paths` from config.toml — rejected: as written it points at `skills/`, which would lint the wrong tree, and coupling CI to daemon config semantics we haven't verified makes the check fragile.
+- **Consequences:** The validator stays correct even if config.toml is wrong or changes; the config discrepancy is tracked separately (side-channel issue `hallouminate-wiring-stack-001`) instead of silently shaping CI behavior.

--- a/.hallouminate/wiki/adr/index.md
+++ b/.hallouminate/wiki/adr/index.md
@@ -5,6 +5,10 @@
 - [cheese-kernel-shared-refs-002](./cheese-kernel-shared-refs-002.md) — ADR: owner-homed cross-skill content stays with its owner
 - [codex-omp-portability-001](./codex-omp-portability-001.md) — ADR: Shared harness portability reference
 - [culture-wheypoint-collaboration-001](./culture-wheypoint-collaboration-001.md) — ADR: /culture delegates its end-of-session artifact to /wheypoint
+- [hallouminate-wiring-stack-001](./hallouminate-wiring-stack-001.md) — ADR: hallouminate wiring ships as a stacked 4-PR build, one PR per issue
+- [hallouminate-wiring-stack-002](./hallouminate-wiring-stack-002.md) — ADR: cook and age record durable-change flags; only the publication boundary writes the wiki
+- [hallouminate-wiring-stack-003](./hallouminate-wiring-stack-003.md) — ADR: liberal wiki grounding in mold/culture is prose guidance, not a coherence gate
+- [hallouminate-wiring-stack-004](./hallouminate-wiring-stack-004.md) — ADR: validate_wiki.py hardcodes .hallouminate/wiki/ discovery, ignoring config.toml corpus_paths
 - [hard-cheese-retained-001](./hard-cheese-retained-001.md) — ADR: hard-cheese retained despite local zero-use signal
 - [mold-follow-up-routing-001](./mold-follow-up-routing-001.md) — ADR: every non-goal enters a disposition batch before Curdle
 - [mold-follow-up-routing-002](./mold-follow-up-routing-002.md) — ADR: route follow-ups per deliverable unit instead of choosing one backlog

--- a/.hallouminate/wiki/index.md
+++ b/.hallouminate/wiki/index.md
@@ -16,6 +16,7 @@ git-tracking axis (`skills/cheese/references/formatting.md:103`).
 - [adr/](./adr/index.md) — adr
 - [architecture](./architecture.md) — Architecture of easy-cheese
 - [fanout-engine-entities](./fanout-engine-entities.md) — Fan-out engine entities
+- [post-pr-wiki-writeback](./post-pr-wiki-writeback.md) — Post-PR wiki write-back — plan and followups
 - [skill-parity-analysis](./skill-parity-analysis.md) — Skill-parity analysis
 - [spec-workflow-comparison](./spec-workflow-comparison.md) — Spec / brainstorm-to-spec workflow comparison
 - [tooling](./tooling.md) — Tooling

--- a/justfile
+++ b/justfile
@@ -13,6 +13,7 @@ export PYTEST_DISABLE_PLUGIN_AUTOLOAD := "1"
 # Run all tests (skill validators + melt + shared + fan-out suites + bash install tests + fan-out bats + JS)
 test:
     python3 .github/scripts/test_validate_skills.py -v
+    python3 .github/scripts/test_validate_wiki.py
     python3 .github/scripts/validate_skills.py
     python3 .github/scripts/validate_wiki.py
     python3 -m pytest tests/python -q

--- a/justfile
+++ b/justfile
@@ -14,6 +14,7 @@ export PYTEST_DISABLE_PLUGIN_AUTOLOAD := "1"
 test:
     python3 .github/scripts/test_validate_skills.py -v
     python3 .github/scripts/validate_skills.py
+    python3 .github/scripts/validate_wiki.py
     python3 -m pytest tests/python -q
     python3 -m pytest tests/shared/python -q
     python3 -m pytest tests/fanout/python -q


### PR DESCRIPTION
Adds `.github/scripts/validate_wiki.py` enforcing the wiki page conventions (H1-first, kebab slug == file stem, HALLOUMINATE index-marker consistency, loud failure on a missing wiki dir) over hardcoded `.hallouminate/wiki/` discovery, wired into `just test` with a 21-test golden suite. Also carries the mold-session ADRs recording this build's design decisions, and fixes a pre-existing root-index gap the new validator caught. No frontmatter/lifecycle checks — that seam is reserved for #206.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
