### PR TITLE
feat(cheese,briesearch,age): query-time wiki retrieval, rendered visibly

### DIFF
--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -115,7 +115,7 @@ Beyond `cheez-*` there are review-specific tools:
 | Diff inspection | `delta` | `git diff --unified=3` |
 | Caller/dependency impact + curated review context | `tilth_deps` + `/cheez-search` `kind: "callers"` | manual scoping |
 | Architecture / hotspot framing for large diffs | changed-file map + caller/dependency evidence | skip and note in confidence |
-| Design rationale for encapsulation/spec dimensions (optional) | `mcp__hallouminate__list_corpora` / `mcp__hallouminate__ground` on `repo:<repo>:wiki` corpus — if available, ground design intent before grading encapsulation and spec findings | skip; proceed with diff + code evidence only; cap at `speculating` when rationale is the primary evidence |
+| Design rationale for encapsulation/spec dimensions (optional) | `mcp__hallouminate__list_corpora` / `mcp__hallouminate__ground` on `repo:<repo>:wiki` corpus — if available, derive the query from the diff and the spec or issue in scope, ground design intent before grading encapsulation and spec findings, and render the consulted pages in the report's `## Wiki context` section so the pages that informed the review are visible | skip; omit `## Wiki context`; proceed with diff + code evidence only; cap at `speculating` when rationale is the primary evidence |
 | GitHub/PR context | `gh` | local git commands or user-provided PR data |
 | Merge/conflict awareness | mergiraf | manual conflict checks |
 
@@ -178,6 +178,9 @@ press: skipped
 
 ## Press findings
 <omit this section when `.cheese/press/<slug>.md` does not exist. When it does, summarise unresolved press items in one or two bullets so `/cure` (which never reads the press report directly) sees them. When it does not exist but `.cheese/cook/<slug>.md` does, omit this section but add `press: skipped` as the first body line after the handoff slug (see above) instead.>
+
+## Wiki context
+<omit this section when hallouminate is absent or grounding returned no hits. When wiki pages informed the review context, list one bullet per consulted page — `<wiki page path>:<line>` — <one-line why it informed the review> — so the user can see, and challenge, what grounded the review.>
 
 ## Blocker
 - **[encapsulation:blocker]** `src/users/index.ts:42` — `index` re-exports `SqlPgUser` (infra ORM type) across slice boundary. 3 consumer slices already import it.

--- a/skills/briesearch/SKILL.md
+++ b/skills/briesearch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: briesearch
-description: Research questions external to the codebase across library docs (Context7), the web (Tavily), local code (cheez-search), and GitHub examples (gh), then synthesize with explicit confidence. Use whenever the user asks to research, look up, compare, or investigate something — phrases like "research X", "look up the API for Y", "compare libraries", "what does the doc say about Z", "find examples of how to do W", "is this library maintained", or "before I implement, what's the right approach". Use even when the user only mentions a library name without saying "research". Do NOT use for a single obvious file lookup or when the user already has enough evidence.
+description: Research questions external to the codebase across library docs (Context7), the web (Tavily), local code (cheez-search), GitHub examples (gh), and the repo wiki (hallouminate), then synthesize with explicit confidence. Use whenever the user asks to research, look up, compare, or investigate something — phrases like "research X", "look up the API for Y", "compare libraries", "what does the doc say about Z", "find examples of how to do W", "is this library maintained", or "before I implement, what's the right approach". Use even when the user only mentions a library name without saying "research". Do NOT use for a single obvious file lookup or when the user already has enough evidence.
 license: MIT
 ---
 

--- a/skills/briesearch/references/routing.md
+++ b/skills/briesearch/references/routing.md
@@ -14,6 +14,9 @@ Is it a factual / current / vendor / "what or who or when" question?
 Is it "how should I…" or a best-practice question?
   YES → Tavily advanced  (+ Context7 when a named library is in scope)
 
+Is it about a past decision or rationale in this repo?
+  YES → Wiki  (hallouminate `ground`)
+
 Is it about patterns in this repo?
   YES → Codebase  (cheez-search + cheez-read)
 
@@ -31,6 +34,7 @@ Is it deep, multi-source, comparative, or "compare X vs Y / market analysis / li
 | Context7 (MCP) | Library APIs, config, migration notes for indexed open-source dependencies | Tools: `resolve-library-id` (`libraryName` + `query`) → `query-docs` (`libraryId` + `query`). Both require a `query`. See "Context7 method" below. |
 | Tavily (MCP) | Current facts, technical articles, vendor docs, best practices, deep multi-source synthesis | Use the method matrix to pick the right rung. |
 | Codebase | Local conventions, existing usage, constraints | Use `cheez-search` and `cheez-read`. |
+| Wiki (hallouminate MCP) | Past decisions, rationale, ADRs, conventions recorded in the repo wiki | Tool: `ground` against the repo's wiki corpus. Optional — when hallouminate is absent, degrade per `../../cheese/references/optional-plugins.md`: skip, note once, cap confidence. |
 | GitHub | Real-world OSS usage patterns | `gh` CLI or harness GitHub integration. Treat as supporting evidence unless the user asked for OSS precedent. |
 
 ## Context7 method

--- a/skills/briesearch/references/synthesis.md
+++ b/skills/briesearch/references/synthesis.md
@@ -59,7 +59,7 @@ Skip verification only for: (a) inline file references (`file:line`), (b) the us
 | Sources disagree | `don't know` — and surface the disagreement |
 | Single source per claim | cap at `speculating` unless authoritative (see lone-Context7 caveat above) |
 
-**"Independent" means distinct origin, not distinct URL.** Before counting sources toward the cap, dedup by origin: collapse to one source any that share a root domain, or that quote/paraphrase the same upstream (three blogs reprinting one vendor post are one source, not three). Count only the surviving distinct origins. Criticality depends on the question. Context7 is critical for version-specific API claims, Tavily is critical for freshness-sensitive facts, Codebase is critical for local precedent questions, and GitHub is usually supporting evidence unless the user asked for real-world examples.
+**"Independent" means distinct origin, not distinct URL.** Before counting sources toward the cap, dedup by origin: collapse to one source any that share a root domain, or that quote/paraphrase the same upstream (three blogs reprinting one vendor post are one source, not three). Count only the surviving distinct origins. Criticality depends on the question. Context7 is critical for version-specific API claims, Tavily is critical for freshness-sensitive facts, Codebase is critical for local precedent questions, the wiki is critical for prior-decision/rationale questions (when hallouminate is absent, degrade per `../../cheese/references/optional-plugins.md` — skip, note once, cap at `speculating`), and GitHub is usually supporting evidence unless the user asked for real-world examples.
 
 ## Absence and negative claims
 

--- a/skills/cheese/SKILL.md
+++ b/skills/cheese/SKILL.md
@@ -33,9 +33,10 @@ If `$ARGUMENTS` is missing entirely and there is no recent context to lean on, a
 2. **Classify** — match `$ARGUMENTS` against the intent shapes in `references/classification.md`. Pick the highest-confidence shape; below the threshold, route to `clarify` (handled by the tier-3 escalation in step 4).
 3. **Clarity check (implementation intents only).** Run cook's fast-path check for `cook` and `mold`. Direct `plate` intents bypass it.
 4. **Escalate (if needed).** Tier 1 dispatches the chosen target (writing a mini-spec via `/mold`'s agent-invoked mode when the dispatch is `/cook --auto` and no spec path was supplied). Tier 2 autonomously invokes `/culture` and/or `/briesearch` in internal mode, then re-runs the clarity check. Tier 3 blocks on a single targeted host-routed question and re-enters classification on the answer. See `## Escalation`.
-5. **Announce** — print a short three-line block (Intent / Reason / Target) per the format in `## Output`. Cite the signal that drove the routing decision.
-6. **Self-check** — run the coherence questions in `references/coherence-check.md`. If any fails, downgrade to `clarify` (tier 3) or `research`.
-7. **Dispatch** — without `--safe`, run the chosen skill immediately with its exact dispatch command and context packet, in the same turn as the announce. With `--safe`, issue a handoff gate per [`references/handoff-gate.md`](references/handoff-gate.md) (recommended target pre-selected, at least one alternative, `Stop`) and wait for the user's selection before dispatching.
+5. **Wiki grounding (when hallouminate is present).** Derive a search query from the dropped-in input, ground it against the wiki corpus — at most one `mcp__hallouminate__ground` call, corpus resolved via `list_corpora` (probe shape: `skills/mold/references/grounding.md`) — and fold the top hits into the dispatch packet as `handoff_context.wiki_hits` (`[{page, line, why}]`; see [`references/handoff-gate.md`](references/handoff-gate.md) § Context payloads). When hallouminate is absent or no wiki corpus exists, skip and degrade per [`references/optional-plugins.md`](references/optional-plugins.md).
+6. **Announce** — print a short block (Intent / Reason / Target, plus wiki hits when present) per the format in `## Output`. Cite the signal that drove the routing decision.
+7. **Self-check** — run the coherence questions in `references/coherence-check.md`. If any fails, downgrade to `clarify` (tier 3) or `research`.
+8. **Dispatch** — without `--safe`, run the chosen skill immediately with its exact dispatch command and context packet, in the same turn as the announce. With `--safe`, issue a handoff gate per [`references/handoff-gate.md`](references/handoff-gate.md) (recommended target pre-selected, at least one alternative, `Stop`) and wait for the user's selection before dispatching.
 
 `/cheese` is a router, not a worker: it never edits files, runs tests, or opens PRs. Use only the host's read, search, and dispatch capabilities. The sole exception is invoking `/mold`'s agent-invoked mini-spec mode in tier 1 when `/cook --auto` needs a spec first; that write happens inside `/mold`'s own capability scope, not the router's.
 
@@ -127,7 +128,7 @@ Beyond `cheez-*` there are router-specific tools:
 | PR / issue context | `gh` | the URL or numbers the user provided |
 | Confirming routing target with the user (only under `--safe` or `clarify`) | host-routed structured question per [`references/handoff-gate.md`](references/handoff-gate.md) | a numbered list with explicit dispatch commands |
 
-`/cheese` keeps tool use light. Treat anything heavier than a single-file read or one search call as a sign the work belongs in the downstream skill, not in the router.
+`/cheese` keeps tool use light. Beyond the single wiki-grounding probe in `## Flow`, treat anything heavier than a single-file read or one search call as a sign the work belongs in the downstream skill, not in the router.
 
 ## Output
 
@@ -136,6 +137,7 @@ Always emit, in order:
 1. **Detected intent** — one line, e.g. `Intent: cook (clear single-file fix)`.
 2. **Reason** — one line citing the signal (`reason: spec path .cheese/specs/foo.md`).
 3. **Target** — the chosen skill, e.g. `Target: /cook .cheese/specs/foo.md`.
+4. **Wiki hits** — when `handoff_context.wiki_hits` is non-empty, one line per hit: `wiki: <page>:<line> — <why>` — always rendered before dispatch so the user sees what memory informed the routing and can challenge stale hits. Omit the section when hallouminate is absent.
 
 Then dispatch in the same turn (or, under `--safe`, via the handoff gate). If `clarify` is chosen, replace the dispatch with the single clarifying question.
 

--- a/skills/cheese/references/handoff-gate.md
+++ b/skills/cheese/references/handoff-gate.md
@@ -117,6 +117,8 @@ handoff_context:
   source_report: .cheese/age/<slug>.md
   selection: "1,3,5"
   resolved_ids: [1, 3, 5]
+  wiki_hits:
+    - {page: .hallouminate/wiki/adr/foo-001.md, line: 12, why: "prior decision on X"}
 ```
 
 Examples of when to attach a `handoff_context:` block:
@@ -124,6 +126,9 @@ Examples of when to attach a `handoff_context:` block:
 - `/age -> /cure` selection ids travel as context, not as a `--select` flag.
 - `/culture -> /cook` carries the compact contract that emerged from discussion.
 - `/melt -> upstream skill` carries the interrupted operation and original skill invocation.
+- `/cheese -> <target>` carries `wiki_hits` grounded from the wiki corpus at routing time.
+
+`wiki_hits` is the query-time wiki retrieval key — a list of `{page, line, why}` entries grounded from the `repo:<repo>:wiki` corpus when hallouminate is present (probe and degrade contract: [`optional-plugins.md`](optional-plugins.md)). The attaching skill always renders the hits to the user at dispatch so memory use is visible and stale hits can be challenged; when hallouminate is absent, omit the key.
 
 Keep payloads short and factual. If a payload would exceed a compact screenful, write or reference a `.cheese/.../<slug>.md` handoff artifact and pass the path instead.
 


### PR DESCRIPTION
Query-time wiki retrieval, rendered visibly: `/cheese` carries `wiki_hits` (`[{page, line, why}]`) in `handoff_context` and shows the user what memory was used; `/briesearch` routes prior-decision/rationale questions to the wiki (routing table, decision tree, synthesis criticality); `/age` renders which wiki pages informed the review in a `## Wiki context` section. The `/culture` slice of #203 landed with #201's PR per the issue's reconciliation note.

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
