### PR TITLE
feat(cheese): add deterministic spec-discovery scoring helper (#267)

### DIFF
--- a/shared/scripts/spec_match.py
+++ b/shared/scripts/spec_match.py
@@ -1,0 +1,58 @@
+"""Deterministic keyword-match scoring for existing-artifact reuse scans.
+
+Shared by the two /cheese glob+score checks that look for a candidate
+markdown artifact matching an incoming request: spec-discovery
+(.cheese/specs/*.md) and rejected-directions (.cheese/.out-of-scope/*.md).
+Both scans have the identical shape -- glob candidates, score against a few
+text fields, act on the top score -- so the scoring itself lives once here.
+
+Stdlib only (difflib.SequenceMatcher); no interactive picker.
+"""
+
+from __future__ import annotations
+
+import difflib
+
+# Score threshold for a 'high' tier match, and the minimum margin over the
+# second-best candidate required to call it unambiguous. Tunable -- see the
+# call sites in skills/cheese/SKILL.md for how each tier is acted on.
+HIGH_SCORE_THRESHOLD = 0.60
+HIGH_MARGIN_THRESHOLD = 0.15
+
+
+def _field_score(request_text: str, candidate: dict) -> float:
+    """Max SequenceMatcher ratio of request_text against slug/title/first_heading."""
+    fields = (
+        candidate.get("slug") or "",
+        candidate.get("title") or "",
+        candidate.get("first_heading") or "",
+    )
+    return max(
+        difflib.SequenceMatcher(None, request_text, field).ratio() for field in fields
+    )
+
+
+def score_candidates(request_text: str, candidates: list[dict]) -> list[dict]:
+    """Rank candidates against request_text; return [{path, score, tier}] desc by score.
+
+    Each candidate carries {slug, title, first_heading, path}. Tier is 'high'
+    when the top score >= HIGH_SCORE_THRESHOLD *and* its margin over the
+    second-best score >= HIGH_MARGIN_THRESHOLD; every other candidate (and the
+    top one when either condition fails) is 'weak'. An empty candidate list
+    returns an empty result.
+    """
+    scored = [
+        {"path": c["path"], "score": round(_field_score(request_text, c), 3)}
+        for c in candidates
+    ]
+    scored.sort(key=lambda r: (-r["score"], r["path"]))
+    if not scored:
+        return []
+    top = scored[0]["score"]
+    margin = top - (scored[1]["score"] if len(scored) > 1 else 0.0)
+    top_is_high = top >= HIGH_SCORE_THRESHOLD and margin >= HIGH_MARGIN_THRESHOLD
+    results = []
+    for i, r in enumerate(scored):
+        tier = "high" if (i == 0 and top_is_high) else "weak"
+        results.append({"path": r["path"], "score": r["score"], "tier": tier})
+    return results

--- a/shared/scripts/spec_match.py
+++ b/shared/scripts/spec_match.py
@@ -42,17 +42,17 @@ def score_candidates(request_text: str, candidates: list[dict]) -> list[dict]:
     returns an empty result.
     """
     scored = [
-        {"path": c["path"], "score": round(_field_score(request_text, c), 3)}
+        {"path": c["path"], "raw": _field_score(request_text, c)}
         for c in candidates
     ]
-    scored.sort(key=lambda r: (-r["score"], r["path"]))
+    scored.sort(key=lambda r: (-r["raw"], r["path"]))
     if not scored:
         return []
-    top = scored[0]["score"]
-    margin = top - (scored[1]["score"] if len(scored) > 1 else 0.0)
+    top = scored[0]["raw"]
+    margin = top - (scored[1]["raw"] if len(scored) > 1 else 0.0)
     top_is_high = top >= HIGH_SCORE_THRESHOLD and margin >= HIGH_MARGIN_THRESHOLD
     results = []
     for i, r in enumerate(scored):
         tier = "high" if (i == 0 and top_is_high) else "weak"
-        results.append({"path": r["path"], "score": r["score"], "tier": tier})
+        results.append({"path": r["path"], "score": round(r["raw"], 3), "tier": tier})
     return results

--- a/shared/scripts/spec_match_cli.py
+++ b/shared/scripts/spec_match_cli.py
@@ -37,7 +37,7 @@ def _strip_front_matter(text: str) -> str:
 
 
 def _build_candidate(path: Path) -> dict:
-    text = path.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8", errors="replace")
     front_matter_match = _FRONT_MATTER.match(text)
     slug_match = _SLUG_FIELD.search(front_matter_match.group(1)) if front_matter_match else None
     slug = slug_match.group(1) if slug_match else path.stem
@@ -60,7 +60,12 @@ def _cmd_rank(args: argparse.Namespace) -> None:
     if not directory.is_dir():
         cli.emit([], json_mode=True)
         return
-    candidates = [_build_candidate(p) for p in sorted(directory.glob("*.md"))]
+    candidates = []
+    for p in sorted(directory.glob("*.md")):
+        try:
+            candidates.append(_build_candidate(p))
+        except OSError:
+            continue
     results = spec_match.score_candidates(args.request, candidates)
     cli.emit(results, json_mode=True)
 

--- a/shared/scripts/spec_match_cli.py
+++ b/shared/scripts/spec_match_cli.py
@@ -1,0 +1,80 @@
+"""CLI wrapper around shared/scripts/spec_match.py -- rank markdown candidates.
+
+Subcommand:
+
+    spec_match_cli.py rank --request "add retry" --dir .cheese/specs
+    -> [{"path": "...", "score": 0.62, "tier": "high"}, ...]
+
+Builds candidates from every ``*.md`` file directly under --dir: slug from the
+YAML front matter's ``slug:`` field (falling back to the file stem), title
+from the first ``# `` (H1) heading, and first_heading from the first line of
+content under the first ``## `` (H2) heading -- for a rejection record that
+line is the one-line description under ``## Direction``; for a spec it is the
+opening line of its first section. Missing --dir (or no *.md files in it)
+emits an empty JSON list -- the call sites skip silently in that case.
+
+Stdlib-only; delegates scoring to spec_match.py so the ranking rule stays
+single-source.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+import cli
+import spec_match
+
+_FRONT_MATTER = re.compile(r"\A---\n(.*?\n)---\n", re.DOTALL)
+_SLUG_FIELD = re.compile(r"^slug:\s*(.+?)\s*$", re.MULTILINE)
+_H1 = re.compile(r"^#\s+(.+?)\s*$", re.MULTILINE)
+_H2_BODY = re.compile(r"^##\s+.+?\s*\n+(.+?)\s*$", re.MULTILINE)
+
+
+def _strip_front_matter(text: str) -> str:
+    match = _FRONT_MATTER.match(text)
+    return text[match.end():] if match else text
+
+
+def _build_candidate(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    front_matter_match = _FRONT_MATTER.match(text)
+    slug_match = _SLUG_FIELD.search(front_matter_match.group(1)) if front_matter_match else None
+    slug = slug_match.group(1) if slug_match else path.stem
+
+    body = _strip_front_matter(text)
+    title_match = _H1.search(body)
+    h2_match = _H2_BODY.search(body)
+    return {
+        "slug": slug,
+        "title": title_match.group(1) if title_match else "",
+        "first_heading": h2_match.group(1) if h2_match else "",
+        "path": str(path),
+    }
+
+
+def _cmd_rank(args: argparse.Namespace) -> None:
+    if not args.request:
+        raise cli.CliError("rank requires non-empty --request")
+    directory = Path(args.dir)
+    if not directory.is_dir():
+        cli.emit([], json_mode=True)
+        return
+    candidates = [_build_candidate(p) for p in sorted(directory.glob("*.md"))]
+    results = spec_match.score_candidates(args.request, candidates)
+    cli.emit(results, json_mode=True)
+
+
+def _setup(parser: argparse.ArgumentParser) -> None:
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    rank = sub.add_parser(
+        "rank", help="rank *.md candidates in --dir against --request"
+    )
+    rank.add_argument("--request", required=True, help="incoming request text to match")
+    rank.add_argument("--dir", required=True, help="directory to glob *.md candidates from")
+    rank.set_defaults(func=_cmd_rank)
+
+
+if __name__ == "__main__":
+    cli.run(_setup)

--- a/skills/cheese/SKILL.md
+++ b/skills/cheese/SKILL.md
@@ -63,24 +63,24 @@ Non-implementation intents bypass the escalation entirely. Their target skills o
 
 ## Rejected-directions check
 
-Before dispatching any `mold` intent, scan `.cheese/.out-of-scope/` for rejection records whose `## Direction` section's one-line description substantially matches the incoming request. If a match is found:
+Before dispatching any `mold` intent, scan `.cheese/.out-of-scope/` for rejection records whose `## Direction` section's one-line description substantially matches the incoming request:
 
 1. Surface the previously-rejected direction and its rationale in one line.
 2. Ask the user whether to proceed with the new request or take a different angle.
 3. Do not suppress or re-propose the rejected direction silently.
 
-This check is lightweight — a glob + keyword scan over `.cheese/.out-of-scope/*.md`. Skip silently when the directory does not exist. Non-`mold` intents skip this check.
+This check is deterministic — `python3 shared/scripts/spec_match_cli.py rank --request "<incoming request>" --dir .cheese/.out-of-scope` ranks every `*.md` record's slug/title/first_heading (the record's `first_heading` is the one-line description under `## Direction`) against the request. Treat `high` tier as a match to surface per the steps above; `weak` tier means no substantial match. Skip silently when the directory does not exist (the CLI itself emits `[]` for a missing `--dir`). Non-`mold` intents skip this check.
 
 ## Spec-discovery check
 
-Before minting a new mini-spec for a tier-1 `cook` or `mold` dispatch, look for an existing spec that already covers the request. Glob `.cheese/specs/*.md` and score each candidate on a lightweight keyword match against its slug, title, and first heading — a plain filename glob plus a text scan (host `rg` / read), not `cheez-search`, which is scoped to tracked source files and skips Markdown specs. This mirrors the rejected-directions scan and stays headless, so it runs on the autonomous path and across harnesses.
+Before minting a new mini-spec for a tier-1 `cook` or `mold` dispatch, look for an existing spec that already covers the request. Rank `.cheese/specs/*.md` against the request with `python3 shared/scripts/spec_match_cli.py rank --request "<incoming request>" --dir .cheese/specs`, which scores each candidate's slug/title/first_heading via `shared/scripts/spec_match.py` (stdlib `difflib.SequenceMatcher`, `high` tier requires top score ≥ 0.60 and margin to the runner-up ≥ 0.15 — see issue #267). This mirrors the rejected-directions scan and stays headless, so it runs on the autonomous path and across harnesses.
 
-Act on the score, do not guess:
+Act on the tier, do not guess:
 
-1. **One clear match (high confidence)** — surface the spec path in one line and dispatch against it (`/cook --auto .cheese/specs/<slug>.md`) instead of writing a duplicate.
-2. **Multiple plausible matches, or a weak best match** — under `--safe`, present the candidates in the handoff gate for the user to pick; without `--safe`, fall back to minting a fresh mini-spec rather than risk dispatching against the wrong spec.
+1. **One clear match (`high` tier)** — surface the spec path in one line and dispatch against it (`/cook --auto .cheese/specs/<slug>.md`) instead of writing a duplicate.
+2. **Multiple plausible matches, or a weak best match (`weak` tier)** — under `--safe`, present the candidates in the handoff gate for the user to pick; without `--safe`, fall back to minting a fresh mini-spec rather than risk dispatching against the wrong spec.
 
-Skip silently when `.cheese/specs/` is empty or absent, and when the user already named a spec path there (the path is authoritative). A dedicated Python scoring helper (stdlib `difflib.get_close_matches` over the slug/title list) would give deterministic ranking with zero dependencies and keep this check consistent with the rejected-directions scan — tracked in issue #267.
+Skip silently when `.cheese/specs/` is empty or absent (the CLI emits `[]` for a missing `--dir`), and when the user already named a spec path there (the path is authoritative).
 
 ## --continue
 

--- a/skills/cheese/references/classification.md
+++ b/skills/cheese/references/classification.md
@@ -91,7 +91,7 @@ Clear, scoped implementation request meeting the standalone fast-path checks.
 
 When two of the three fast-path checks are clear but the third is borderline, downgrade to `mold`.
 
-Before minting a fresh mini-spec for a tier-1 `cook`/`mold` dispatch, the router runs the `## Spec-discovery check` in `skills/cheese/SKILL.md` — a keyword glob over `.cheese/specs/*.md` that reuses an existing matching spec instead of writing a duplicate.
+Before minting a fresh mini-spec for a tier-1 `cook`/`mold` dispatch, the router runs the `## Spec-discovery check` in `skills/cheese/SKILL.md` — a deterministic `shared/scripts/spec_match_cli.py rank` scan over `.cheese/specs/*.md` (issue #267) that reuses an existing matching spec instead of writing a duplicate.
 
 ### debug (`/pasteurize --auto` → `/cook --auto`)
 

--- a/tests/shared/python/conftest.py
+++ b/tests/shared/python/conftest.py
@@ -77,3 +77,13 @@ def handoff_cli_mod() -> ModuleType:
 @pytest.fixture(scope="session")
 def paths_cli_mod() -> ModuleType:
     return importlib.import_module("paths_cli")
+
+
+@pytest.fixture(scope="session")
+def spec_match() -> ModuleType:
+    return importlib.import_module("spec_match")
+
+
+@pytest.fixture(scope="session")
+def spec_match_cli_mod() -> ModuleType:
+    return importlib.import_module("spec_match_cli")

--- a/tests/shared/python/test_spec_match.py
+++ b/tests/shared/python/test_spec_match.py
@@ -1,0 +1,161 @@
+"""Tests for shared/scripts/spec_match.py + spec_match_cli.py.
+
+Covers the design contract from issue #267: ranking order, the 'high' tier
+boundary (score + margin), and the 'weak' fallback -- plus the CLI's
+front-matter/heading extraction and its rank subcommand end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SPEC_MATCH_CLI = REPO_ROOT / "shared" / "scripts" / "spec_match_cli.py"
+
+
+def _candidate(path: str, slug: str = "", title: str = "", first_heading: str = "") -> dict:
+    return {"path": path, "slug": slug, "title": title, "first_heading": first_heading}
+
+
+class TestScoreCandidatesRanking:
+    def test_ranks_best_match_first(self, spec_match: ModuleType) -> None:
+        candidates = [
+            _candidate("a.md", slug="unrelated-topic"),
+            _candidate("b.md", slug="retry-logic-for-uploads"),
+            _candidate("c.md", slug="cheese-flavor-picker"),
+        ]
+        results = spec_match.score_candidates("add retry logic for uploads", candidates)
+        assert [r["path"] for r in results] == ["b.md", "a.md", "c.md"]
+        assert results[0]["score"] >= results[1]["score"] >= results[2]["score"]
+
+    def test_result_shape(self, spec_match: ModuleType) -> None:
+        results = spec_match.score_candidates(
+            "add retry logic", [_candidate("only.md", slug="add retry logic")]
+        )
+        assert results == [{"path": "only.md", "score": 1.0, "tier": "high"}]
+
+    def test_empty_candidates_returns_empty(self, spec_match: ModuleType) -> None:
+        assert spec_match.score_candidates("anything", []) == []
+
+    def test_scores_max_across_fields(self, spec_match: ModuleType) -> None:
+        # slug/title are noise; first_heading is the real match.
+        candidate = _candidate(
+            "x.md",
+            slug="zzz",
+            title="zzz",
+            first_heading="add retry logic for uploads",
+        )
+        results = spec_match.score_candidates("add retry logic for uploads", [candidate])
+        assert results[0]["score"] == 1.0
+
+
+class TestHighTierBoundary:
+    def test_high_when_score_and_margin_both_clear(self, spec_match: ModuleType) -> None:
+        candidates = [
+            _candidate("strong.md", slug="add retry logic for uploads"),
+            _candidate("weak.md", slug="zzz completely unrelated qqq"),
+        ]
+        results = spec_match.score_candidates("add retry logic for uploads", candidates)
+        assert results[0]["score"] >= spec_match.HIGH_SCORE_THRESHOLD
+        assert results[0]["score"] - results[1]["score"] >= spec_match.HIGH_MARGIN_THRESHOLD
+        assert results[0]["tier"] == "high"
+        assert results[1]["tier"] == "weak"
+
+    def test_weak_when_score_below_threshold(self, spec_match: ModuleType) -> None:
+        candidates = [_candidate("only.md", slug="totally different subject matter")]
+        results = spec_match.score_candidates("add retry logic", candidates)
+        assert results[0]["score"] < spec_match.HIGH_SCORE_THRESHOLD
+        assert results[0]["tier"] == "weak"
+
+    def test_weak_when_margin_too_small_despite_high_score(
+        self, spec_match: ModuleType
+    ) -> None:
+        # Two near-duplicate slugs: top score clears the threshold but the
+        # runner-up is close enough that reuse would be ambiguous.
+        candidates = [
+            _candidate("a.md", slug="add-retry-logic-for-uploads"),
+            _candidate("b.md", slug="add-retry-logic-for-downloads"),
+        ]
+        results = spec_match.score_candidates("add retry logic for uploads", candidates)
+        assert results[0]["score"] >= spec_match.HIGH_SCORE_THRESHOLD
+        assert results[0]["score"] - results[1]["score"] < spec_match.HIGH_MARGIN_THRESHOLD
+        assert results[0]["tier"] == "weak"
+        assert results[1]["tier"] == "weak"
+
+    def test_high_when_score_exactly_at_threshold(self, spec_match: ModuleType) -> None:
+        # SequenceMatcher.ratio() = 2*M/T is exact here: "abc" vs "abcdefg"
+        # shares a 3-char prefix out of a total length 10 -> ratio == 0.60
+        # exactly. A regression from >= to > on the score check would flip
+        # this candidate from 'high' to 'weak'.
+        candidates = [
+            _candidate("top.md", slug="abcdefg"),
+            _candidate("other.md", slug="zzzzzzzzzzzzzzzzzzzz"),
+        ]
+        results = spec_match.score_candidates("abc", candidates)
+        assert results[0]["score"] == spec_match.HIGH_SCORE_THRESHOLD
+        assert results[0]["tier"] == "high"
+
+
+def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SPEC_MATCH_CLI), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_spec(tmp_path: Path, filename: str, slug: str, title: str, first_body_line: str) -> None:
+    (tmp_path / filename).write_text(
+        f"---\nslug: {slug}\nsource: test\n---\n\n# {title}\n\n## Contract\n\n{first_body_line}\n"
+    )
+
+
+class TestRankCli:
+    def test_missing_dir_emits_empty_list(self, tmp_path: Path) -> None:
+        result = _run_cli("rank", "--request", "add retry", "--dir", str(tmp_path / "nope"))
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout) == []
+
+    def test_empty_request_errors(self, tmp_path: Path) -> None:
+        result = _run_cli("rank", "--request", "", "--dir", str(tmp_path))
+        assert result.returncode == 2
+        assert "ERROR:" in result.stderr
+
+    def test_ranks_specs_from_front_matter_and_headings(self, tmp_path: Path) -> None:
+        _write_spec(
+            tmp_path,
+            "retry-uploads.md",
+            slug="retry-uploads",
+            title="Retry uploads",
+            first_body_line="Add retry logic for flaky uploads.",
+        )
+        _write_spec(
+            tmp_path,
+            "cheese-flavors.md",
+            slug="cheese-flavors",
+            title="Cheese flavor picker",
+            first_body_line="Let users pick a cheese flavor.",
+        )
+        result = _run_cli("rank", "--request", "add retry logic for flaky uploads", "--dir", str(tmp_path))
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload[0]["path"] == str(tmp_path / "retry-uploads.md")
+        assert payload[0]["tier"] == "high"
+        assert payload[1]["path"] == str(tmp_path / "cheese-flavors.md")
+
+    def test_falls_back_to_filename_stem_without_front_matter(self, tmp_path: Path) -> None:
+        (tmp_path / "no-front-matter.md").write_text("# Some title\n\n## Section\n\nbody text\n")
+        result = _run_cli("rank", "--request", "some title", "--dir", str(tmp_path))
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload[0]["path"] == str(tmp_path / "no-front-matter.md")
+
+
+class TestModuleImports:
+    def test_loads_via_importlib(self, spec_match_cli_mod: ModuleType) -> None:
+        assert callable(spec_match_cli_mod._cmd_rank)
+        assert callable(spec_match_cli_mod._build_candidate)

--- a/tests/shared/python/test_spec_match.py
+++ b/tests/shared/python/test_spec_match.py
@@ -99,6 +99,40 @@ class TestHighTierBoundary:
         assert results[0]["score"] == spec_match.HIGH_SCORE_THRESHOLD
         assert results[0]["tier"] == "high"
 
+    def test_high_when_margin_at_smallest_achievable_value(
+        self, spec_match: ModuleType
+    ) -> None:
+        # req "xxx" vs "xxxyy" (3 matching x's, len 5): ratio = 2*3/8 = 0.75,
+        # clearing HIGH_SCORE_THRESHOLD. vs "xxxyyyy" (3 matching x's, len 7):
+        # ratio = 2*3/10 = 0.60. Margin is 0.75 - 0.60 == 0.15000000000000002,
+        # the smallest margin >= HIGH_MARGIN_THRESHOLD reachable through this
+        # string API (an exact-0.15 margin is unreachable, so this does not
+        # distinguish >= from > on the margin check -- it pins the boundary
+        # from the achievable side).
+        candidates = [
+            _candidate("top.md", slug="xxxyy"),
+            _candidate("other.md", slug="xxxyyyy"),
+        ]
+        results = spec_match.score_candidates("xxx", candidates)
+        assert results[0]["score"] >= spec_match.HIGH_SCORE_THRESHOLD
+        assert results[0]["score"] - results[1]["score"] >= spec_match.HIGH_MARGIN_THRESHOLD
+        assert results[0]["tier"] == "high"
+
+    def test_weak_when_margin_just_below_threshold(self, spec_match: ModuleType) -> None:
+        # req "xxx" vs "xxxyyy" (3 matching x's, len 6): ratio = 2*3/9 ==
+        # 0.6666..., clearing HIGH_SCORE_THRESHOLD. vs "xxxyyyyy" (3 matching
+        # x's, len 8): ratio = 2*3/11 == 0.5454..., margin == 0.1212...,
+        # clearly below HIGH_MARGIN_THRESHOLD despite the top score clearing
+        # HIGH_SCORE_THRESHOLD -- the margin gate alone drops it to 'weak'.
+        candidates = [
+            _candidate("top.md", slug="xxxyyy"),
+            _candidate("other.md", slug="xxxyyyyy"),
+        ]
+        results = spec_match.score_candidates("xxx", candidates)
+        assert results[0]["score"] >= spec_match.HIGH_SCORE_THRESHOLD
+        assert results[0]["score"] - results[1]["score"] < spec_match.HIGH_MARGIN_THRESHOLD
+        assert results[0]["tier"] == "weak"
+
 
 def _run_cli(*args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(


### PR DESCRIPTION
Fixes #267. Split out of #282 (2 of 3).

Replaces the prose-only spec-discovery scoring note with one shared, stdlib-only helper (`shared/scripts/spec_match.py` + `spec_match_cli.py`) using `difflib.SequenceMatcher`. `tier=high` when top score ≥ 0.60 **and** margin to 2nd ≥ 0.15, else `weak`. Wired into **both** the spec-discovery and rejected-directions scans. Tests cover ranking order, the tier boundary (incl. an exact score==0.60 pin verified against a `>=`→`>` mutation), and the weak fallback.

No `.pyz` change (spec_match is imported by no bundled skill).

## Verification
- `just test`: 649 + 352 + 259 + 31 + 35 passed, 1 skipped, 0 failed
- `uvx ruff check .`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
