### PR TITLE
docs(wiki): fix mkdocs→Astro drift, stale justfile citations, corrupted paragraph

### DIFF
--- a/.hallouminate/wiki/architecture.md
+++ b/.hallouminate/wiki/architecture.md
@@ -32,7 +32,8 @@ from the body rather than inlining it (`skills/mold/SKILL.md:21`).
 
 The pattern is deliberate context economy: the agent reads `SKILL.md`
 first, then descends into `references/<topic>.md` only for the step it
-always-installed `cheese` skill's `references/` directory
+reaches. Content shared *across* skills lives in the always-installed
+`cheese` skill's `references/` directory
 (`skills/cheese/references/handoff-gate.md`, `skills/cheese/references/formatting.md`) and
 is referenced by sibling-relative path (`../cheese/references/<file>.md`
 from a `SKILL.md`, `../../cheese/references/<file>.md` from a

--- a/.hallouminate/wiki/fanout-engine-entities.md
+++ b/.hallouminate/wiki/fanout-engine-entities.md
@@ -45,8 +45,8 @@ has a single definition rather than being split across the two validators:
 
 - `src/fanout/curd.py` — `behaviour_errors` (`curd.py:59`), `lifecycle_errors`
   (`curd.py:69`), `disjoint_files_errors` (`curd.py:90`).
-- `src/fanout/wiring.py` — `graph_errors` (`wiring.py:25`), `lifecycle_errors`
-  (`wiring.py:72`).
+- `src/fanout/wiring.py` — `graph_errors` (`wiring.py:26`), `lifecycle_errors`
+  (`wiring.py:58`).
 
 The always-on layer is named per entity, not forced symmetric: a Curd's is
 *content* (`behaviour_errors`), a Wiring node's is *graph* (`graph_errors`).

--- a/.hallouminate/wiki/tooling.md
+++ b/.hallouminate/wiki/tooling.md
@@ -7,7 +7,7 @@ guiding rule: one local gate (`just check`), mirrored read-only in CI
 ## `just check` vs `just ci`
 
 `just check` is the local pre-flight; `just ci` is the same gate without
-autofixes (`justfile:51-54`). Run `just check` before any commit, push,
+autofixes (`justfile:62-65`). Run `just check` before any commit, push,
 PR, or hand-off (`AGENTS.md:7`).
 
 | | `just check` | `just ci` |
@@ -17,16 +17,19 @@ PR, or hand-off (`AGENTS.md:7`).
 | python | `lint-py-fix` (`uvx ruff check --fix .`) | — |
 | shell | `lint-sh` (`shellcheck scripts/install.sh`) | `lint-sh` |
 | tests | `test` | `test` |
-| docs | `docs-build` (`mkdocs build --strict`) | `docs-build` |
+| docs | `docs-build` (`pnpm run docs:build` → Astro/Starlight) | `docs-build` |
 
-The `test` recipe runs the validator self-test, `validate_skills.py`,
-the pytest suites (`tests/python`, `tests/shared/python`,
-`tests/fanout/python`), and the bats suites
+The `test` recipe runs the skill + wiki validator self-tests and
+validators (`test_validate_skills.py`, `test_validate_wiki.py`,
+`validate_skills.py`, `validate_wiki.py`), the pytest suites
+(`tests/python`, `tests/shared/python`, `tests/fanout/python`,
+`tests/hard-cheese/python`, `tests/pasteurize/python`), the JS suite
+(`node --test tests/js`), and the bats suites
 (`tests/bash/test_install.bats`, the fan-out bats)
-(`justfile:8-16`).
+(`justfile:14-26`).
 
 Note the markdownlint globs are `skills/**/*.md` and `*.md`
-(`justfile:31-35`) — files outside those globs (for example this wiki
+(`justfile:42-47`) — files outside those globs (for example this wiki
 under `.hallouminate/wiki/`) are not linted by the gate, so keep their
 markdown clean by hand.
 
@@ -73,7 +76,7 @@ shared helpers are self-contained at install time, invoked as
 (`skills/mold/SKILL.md:22`). Bundles exist for affinage, briesearch,
 cook, melt, mold, and ultracook. `just bundle` rebuilds them locally
 (`scripts/build_pyz.py`); `build-pyz.yml` rebuilds and commits them on
-every relevant push to `main` (`justfile:18-19`).
+every relevant push to `main` (`justfile:28-30`).
 
 ## CI workflows
 
@@ -84,7 +87,7 @@ Under `.github/workflows/`:
 | `validate.yml` | push main, all PRs | frontmatter validation, pytest, install.sh bats + smoke, lint |
 | `build-pyz.yml` | push main (`src/**`, `shared/scripts/**`, build script) | rebuild + commit `.pyz` bundles |
 | `release.yml` | tag `v[0-9]*` | stage slim tree, force-push `release` branch, GitHub release |
-| `docs.yml` | push/PR on docs paths, dispatch | `mkdocs build --strict`, deploy Pages on main |
+| `docs.yml` | push/PR on docs paths, dispatch | `pnpm run docs:build` (Astro/Starlight), deploy Pages on main |
 | `codeql.yml` | PRs, push main, weekly | CodeQL on python + actions |
 | `dependency-review.yml` | PRs to main | block vulnerable / disallowed-license deps |
 | `scorecard.yml` | push main, weekly | OpenSSF Scorecard → SARIF |

--- a/.hallouminate/wiki/workflow-invariants.md
+++ b/.hallouminate/wiki/workflow-invariants.md
@@ -98,8 +98,9 @@ explicit wiring branch.
 
 There is exactly one shippability signal: green from `just check`
 (`AGENTS.md:7`). It autofixes lint (markdown, yaml, python via ruff) then
-runs skill-frontmatter validation, shell lint, the python + bash test
-suites, and `mkdocs build --strict`. CI runs `just ci` — the same gates,
+runs skill- and wiki-frontmatter validation, shell lint, the python +
+bash + JS test suites, and the Astro/Starlight docs build
+(`pnpm run docs:build`). CI runs `just ci` — the same gates,
 no autofixes. **Never commit or push on a red `just check`**, and never
 weaken or skip a test to force green. See [tooling](./tooling.md) for the
 recipe breakdown.


### PR DESCRIPTION
## What changed

Conservative curation pass on the `.hallouminate/wiki/` hallouminate wiki — four files, all fixing claims that have drifted from the current tree. No new pages, no restructuring.

- **architecture.md** — repair a corrupted "Progressive disclosure" paragraph that spliced two ideas together and dropped a clause ("…only for the step it **always-installed cheese skill's references/ directory**"). Reconstructed the two-sentence form from `README.md:53`.
- **tooling.md** + **workflow-invariants.md** — the docs build cut over from `mkdocs build --strict` to Astro/Starlight (`pnpm run docs:build`), but the wiki still named mkdocs in three places: the check/ci table, the CI-workflows table (`docs.yml`), and the `just check` gate prose. Fixed all three.
- **tooling.md** — refresh stale `justfile` line citations (check/ci `62-65`, test `14-26`, markdownlint globs `42-47`, bundle `28-30`) and complete the `test`-recipe description, which now also runs the wiki validators, `tests/hard-cheese/python`, `tests/pasteurize/python`, and the JS `node --test` suite.
- **fanout-engine-entities.md** — correct `wiring.py` line citations (`graph_errors` 26, `lifecycle_errors` 58).

## Why

The wiki is durable memory for the repo; drifted build claims (mkdocs vs Astro) and stale line citations mislead future agents grounding against it. The `starlight-docs-cutover-001` ADR already records the docs cutover — the reference pages hadn't caught up. AGENTS.md itself still says mkdocs, but that is source, out of scope for a wiki-only curation pass.

## How to verify

- `git diff main...wiki-harvest/curate-2026-07-19 -- .hallouminate/wiki/`
- Cross-check the ground truth: `justfile` (recipes `check`/`ci`/`test`/`bundle`), `package.json` (`docs:build` → `astro build`), `astro.config.mjs`, `src/fanout/wiring.py` (def line numbers), `README.md:53`.
- All internal `[[links]]` and relative `.md` links were enumerated and verified to resolve; no link edits were needed.

## Risk / rollout notes

None. Documentation-only, scoped to `.hallouminate/wiki/`. No code, no skills, no config touched.

## Checklist

- [x] Conventional Commits PR title (`docs:`)
- [x] Tests added or updated (or N/A) — N/A (wiki markdown only)
- [x] Documentation updated (or N/A) — this PR *is* the doc update
- [x] No secrets or credentials added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lpjm7t61LDRfxuL1dmdgwe)_