### PR TITLE
fix(docs): isolate local PyYAML dependency

### DIFF
--- a/justfile
+++ b/justfile
@@ -67,12 +67,13 @@ ci: lint-md lint-yaml lint-sh test docs-build
 # Install docs build dependencies
 docs-install:
     corepack pnpm install --frozen-lockfile
-    pip install --no-cache-dir pyyaml==6.0.2
+    python3 -m venv .venv
+    .venv/bin/python -m pip install --no-cache-dir pyyaml==6.0.2
 
 # Build the docs site (output: dist/)
 docs-build: docs-install
-    corepack pnpm run docs:build
+    PATH="$PWD/.venv/bin:$PATH" corepack pnpm run docs:build
 
 # Serve docs locally on http://localhost:4321 with live reload
 docs-serve: docs-install
-    corepack pnpm run docs:dev
+    PATH="$PWD/.venv/bin:$PATH" corepack pnpm run docs:dev


### PR DESCRIPTION
## Why

markdownlint-cli2 v0.23.1 (markdownlint v0.41.1)
Finding: skills/**/*.md *.md
Linting: 89 files
Summary: 0 issues in 0 files
./pnpm-lock.yaml
  2614:201  warning  line too long (207 > 200 characters)  (line-length)

All checks passed!
OK: validated 19 SKILL.md file(s)
OK: validated 36 wiki page(s)
........................................................................ [ 11%]
........................................................................ [ 22%]
............................................s........................... [ 33%]
........................................................................ [ 44%]
........................................................................ [ 55%]
........................................................................ [ 66%]
........................................................................ [ 77%]
........................................................................ [ 88%]
........................................................................ [ 99%]
...                                                                      [100%]
650 passed, 1 skipped in 3.90s
........................................................................ [ 19%]
........................................................................ [ 39%]
........................................................................ [ 59%]
........................................................................ [ 78%]
........................................................................ [ 98%]
.....                                                                    [100%]
365 passed in 4.80s
........................................................................ [ 27%]
........................................................................ [ 55%]
........................................................................ [ 83%]
...........................................                              [100%]
259 passed in 5.38s
...............................                                          [100%]
31 passed in 2.45s
...................................                                      [100%]
35 passed in 1.04s
✔ active skill link with h2s expands into a group excluding the synthetic _top node (0.943209ms)
✔ page with no h2s leaves the tree unchanged (0.098292ms)
✔ undefined toc items does not throw and leaves the tree unchanged (0.058792ms)
✔ non-active links stay flat even when h2s exist (0.380583ms)
✔ active README-style page with h2s is not expanded (skill pages only, ADR-002) (0.085667ms)
ℹ tests 5
ℹ suites 0
ℹ pass 5
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 38.928375
1..98
ok 1 ec_tool_binary maps formula names to binaries
ok 2 ec_validate_selection accepts subset of allowed list
ok 3 ec_validate_selection rejects unknown token
ok 4 ec_validate_selection accepts the special 'none' MCP token
ok 5 ec_parse_args defaults to all tools including tilth, and tilth,context7,hallouminate MCP
ok 6 ec_parse_args --tools with value parses comma list
ok 7 ec_parse_args --tools=value parses inline value
ok 8 ec_parse_args --skip-mcp sets MCP to none
ok 9 ec_parse_args --no-edit clears WITH_EDIT
ok 10 ec_parse_args --dry-run sets DRY_RUN
ok 11 ec_parse_args --harness overrides default harness
ok 12 ec_parse_args --harness accepts comma-separated harness list
ok 13 ec_parse_args -h sets DO_HELP
ok 14 ec_parse_args --help sets DO_HELP
ok 15 ec_parse_args rejects unknown flag with exit code 2
ok 16 ec_parse_args rejects positional arg with exit code 2
ok 17 ec_parse_args --tools without value fails
ok 18 ec_parse_args --mcp without value fails
ok 19 ec_parse_args rejects unknown tool selection
ok 20 ec_parse_args rejects unknown mcp selection
ok 21 ec_parse_args -- terminates option parsing
ok 22 ec_detect_os returns 0 when uname reports Darwin
ok 23 ec_detect_os returns 1 when uname reports Linux
ok 24 ec_ensure_homebrew passes when brew exists
ok 25 ec_ensure_homebrew fails with hint when brew missing
ok 26 ec_brew_install_if_missing skips when binary already on PATH
ok 27 ec_brew_install_if_missing dry-run prints would-run line
ok 28 ec_brew_install_if_missing invokes brew when missing
ok 29 ec_brew_install_if_missing surfaces brew failure
ok 30 ec_install_tools (dry-run) iterates each formula in the list
ok 31 ec_install_tools routes tilth through ec_install_tilth, not brew
ok 32 ec_install_tilth short-circuits when tilth already on PATH
ok 33 ec_install_tilth dry-run installs via the npm nightly package
ok 34 ec_install_tilth invokes npm install -g when not dry-run
ok 35 ec_install_tilth fails clearly when npm is not present
ok 36 default MCP selection registers tilth, context7, and hallouminate
ok 37 --mcp hallouminate installs the hallouminate plugin on claude-code
ok 38 --mcp tilth still installs and registers tilth
ok 39 ec_install_mcp_tilth fails clearly when tilth CLI missing
ok 40 ec_install_mcp_tilth dry-run shows install command with --edit
ok 41 ec_install_mcp_tilth dry-run omits --edit when WITH_EDIT=0
ok 42 ec_install_mcp_tilth invokes tilth install when not dry-run
ok 43 ec_install_mcp_context7 warns and skips for non-claude harness
ok 44 ec_install_mcp_context7 fails when claude CLI missing
ok 45 ec_install_mcp_context7 dry-run prints would-run with package name
ok 46 ec_install_mcp_context7 dry-run shows resolved $claude / $npx paths
ok 47 ec_install_mcp_context7 honors EC_NPX in real invocation
ok 48 ec_install_mcp_tavily warns when TAVILY_API_KEY unset (dry-run)
ok 49 ec_install_mcp_tavily dry-run shows resolved $claude / $npx paths
ok 50 ec_install_mcp_hallouminate warns and returns 0 for a non-plugin harness
ok 51 ec_install_mcp_hallouminate codex dry-run shows the codex plugin marketplace add + add commands
ok 52 ec_install_mcp_hallouminate codex real invocation logs correct argv
ok 53 ec_install_mcp_hallouminate codex warns to restart when plugin add fails
ok 54 ec_install_mcp_hallouminate codex fails when codex CLI missing
ok 55 ec_install_mcp_hallouminate treats a failed marketplace add as non-fatal and still installs
ok 56 ec_install_mcp_hallouminate dry-run shows the plugin marketplace add + install commands
ok 57 ec_install_mcp_milknado warns and skips for non-claude harness
ok 58 ec_install_mcp_milknado gracefully skips when uvx binary missing
ok 59 ec_install_mcp_milknado dry-run shows resolved claude and uvx paths
ok 60 ec_install_mcp_hallouminate real invocation logs correct argv
ok 61 ec_install_mcp_milknado real invocation logs correct argv
ok 62 ec_parse_args accepts --mcp hallouminate,milknado
ok 63 ec_install_mcp_hallouminate fails when claude CLI missing
ok 64 ec_install_mcp_milknado fails when claude CLI missing
ok 65 ec_setup_cheese_corpus resolves the skill via gh skill list and runs global --apply
ok 66 ec_setup_cheese_corpus warns and returns 0 when gh skill list resolves nothing
ok 67 ec_setup_cheese_corpus dry-run logs the plan and never invokes gh
ok 68 ec_setup_cheese_corpus warns and returns 0 when gh CLI is missing
ok 69 ec_detect_harnesses finds installed main-line harness CLIs
ok 70 ec_resolve_harnesses auto returns every detected harness
ok 71 ec_resolve_harnesses auto falls back to claude-code when nothing detected
ok 72 ec_resolve_harnesses keeps explicit comma-separated harnesses
ok 73 ec_install_skills warns and returns 0 when gh CLI missing
ok 74 ec_install_skills dry-run lists every shipped skill with --force
ok 75 ec_install_skills dry-run honors picked harness
ok 76 ec_install_skills_for_harnesses installs every skill into every harness
ok 77 ec_install_skills warns and returns 1 when gh is unauthenticated
ok 78 ec_discover_skills returns names from gh api stdout
ok 79 ec_discover_skills pins ref when EC_SKILL_REF is set
ok 80 ec_discover_skills returns empty when gh api fails
ok 81 ec_install_skills uses live list when gh api discovery succeeds
ok 82 ec_install_skills falls back to embedded list when gh api fails
ok 83 ec_install_skills falls back to embedded list when gh api returns empty
ok 84 ec_install_skills passes --pin when EC_SKILL_REF is set
ok 85 ec_install_skills dry-run echoes --pin in the would-run line when EC_SKILL_REF is set
ok 86 ec_install_skills returns non-zero when any skill install fails
ok 87 ec_install_mcp dispatches 'none' as a no-op log line
ok 88 ec_install_mcp rejects unknown server
ok 89 ec_main --help prints usage and exits 0
ok 90 ec_main rejects non-Darwin OS
ok 91 ec_main fails when Homebrew missing on macOS
ok 92 ec_main full --dry-run on macOS prints all tool, skill, and MCP actions
ok 93 ec_main auto-installs skills into each detected main-line harness
ok 94 ec_main --skip-tools --mcp tilth registers only tilth (still runs skills)
ok 95 EC_FALLBACK_SKILLS matches the skills/ directories exactly
ok 96 hermetic PATH: non-allowlisted host tools are unreachable
ok 97 hermetic PATH: stubs shadow allowlisted essentials
ok 98 hermetic PATH: allowlisted essentials resolve from the essentials dir
1..18
ok 1 script is executable
ok 2 script accepts --help with exit 0
ok 3 script -h prints usage and exits 0
ok 4 script rejects missing file with exit 1
ok 5 single shape emits one branch, two cherry-picks, one PR
ok 6 single shape also accepts a JSON plan file
ok 7 orthogonal_flat emits N PRs each with base main
ok 8 orthogonal_flat emits exactly one cherry-pick per curd
ok 9 stacked_linear emits each PR with previous branch as base
ok 10 diamond_stack emits seed-rooted parallel curd PRs and a wiring tip
ok 11 script rejects unknown shape
ok 12 script rejects empty groups
ok 13 script rejects missing shape field
ok 14 script rejects option-shaped commit token at integration layer
ok 15 script reads from stdin when no argument given
ok 16 emitted commands round-trip through bash when title contains an apostrophe
ok 17 idempotency guard skips gh pr create when gh pr view succeeds
ok 18 emitted commands round-trip through bash when body contains quotes and newlines
Lockfile is up to date, resolution step is skipped
Already up to date

Done in 367ms using pnpm v10.13.1
Requirement already satisfied: pyyaml==6.0.2 in ./.venv/lib/python3.14/site-packages (6.0.2)

> easy-cheese-docs@0.0.0 docs:build /Users/paul/conductor/workspaces/easy-cheese/toronto
> python3 scripts/gen_docs.py && astro build

23:10:30 [astro-mermaid] Setting up Mermaid integration
23:10:30 [astro-mermaid] Existing rehype plugins:
23:10:30 [astro-mermaid] Skipping ELK support
23:10:31 [content] Syncing content
23:10:31 [content] Synced content
23:10:31 [types] Generated 274ms
23:10:31 [build] output: "static"
23:10:31 [build] mode: "static"
23:10:31 [build] directory: /Users/paul/conductor/workspaces/easy-cheese/toronto/dist/
23:10:31 [build] Collecting build info...
23:10:31 [build] ✓ Completed in 377ms.
23:10:31 [build] Building static entrypoints...
23:10:31 [vite] ✓ built in 291ms
23:10:31 [WARN] [vite] [plugin builtin:vite-reporter] 
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
23:10:31 [vite] ✓ built in 247ms
23:10:31 [build] Rearranging server assets...

 generating static routes 
23:10:31   ├─ /404.html (+11ms) 
23:10:31   ├─ /code-of-conduct/index.html (+3ms) 
23:10:31   ├─ /contributing/index.html (+1ms) 
23:10:31   ├─ /index.html (+4ms) 
23:10:31   ├─ /install/index.html (+2ms) 
23:10:31   ├─ /readme/index.html (+1ms) 
23:10:31   ├─ /security/index.html (+1ms) 
23:10:31   ├─ /skills/index.html (+2ms) 
23:10:31   ├─ /skills/affinage/index.html (+3ms) 
23:10:31   ├─ /skills/age/index.html (+3ms) 
23:10:31   ├─ /skills/briesearch/index.html (+3ms) 
23:10:31   ├─ /skills/cheese/index.html (+7ms) 
23:10:31   ├─ /skills/cheez-read/index.html (+6ms) 
23:10:31   ├─ /skills/cheez-search/index.html (+19ms) 
23:10:31   ├─ /skills/cheez-write/index.html (+3ms) 
23:10:31   ├─ /skills/cook/index.html (+3ms) 
23:10:31   ├─ /skills/culture/index.html (+2ms) 
23:10:31   ├─ /skills/cure/index.html (+2ms) 
23:10:31   ├─ /skills/easy-cheese-setup/index.html (+3ms) 
23:10:31   ├─ /skills/hard-cheese/index.html (+10ms) 
23:10:31   ├─ /skills/melt/index.html (+3ms) 
23:10:31   ├─ /skills/mold/index.html (+8ms) 
23:10:31   ├─ /skills/pasteurize/index.html (+3ms) 
23:10:31   ├─ /skills/plate/index.html (+5ms) 
23:10:31   ├─ /skills/press/index.html (+3ms) 
23:10:31   ├─ /skills/ultracook/index.html (+5ms) 
23:10:31   ├─ /skills/wheypoint/index.html (+4ms) 
23:10:31 ✓ Completed in 152ms.

 generating optimized images 
23:10:31   ▶ /_astro/favicon.Baa5x8TM_SMe1d.svg (reused cache entry) (+4ms) (1/1)
23:10:31 ✓ Completed in 4ms.

23:10:31 [build] ✓ Completed in 715ms.
23:10:31 [starlight:pagefind] Building search index with Pagefind...
23:10:32 [starlight:pagefind] Found 27 HTML files.
23:10:32 [starlight:pagefind] Finished building search index in 312ms.
23:10:32 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
23:10:32 [build] 27 page(s) built in 1.42s
23:10:32 [build] Complete! installed PyYAML into the Homebrew-managed Python environment, which fails under PEP 668.

## Change

Create a gitignored local virtual environment for the docs dependency and put it first on  for docs build and serve commands.

## Verification

- markdownlint-cli2 v0.23.1 (markdownlint v0.41.1)
Finding: skills/**/*.md *.md
Linting: 89 files
Summary: 0 issues in 0 files
./pnpm-lock.yaml
  2614:201  warning  line too long (207 > 200 characters)  (line-length)

All checks passed!
OK: validated 19 SKILL.md file(s)
OK: validated 36 wiki page(s)
........................................................................ [ 11%]
........................................................................ [ 22%]
............................................s........................... [ 33%]
........................................................................ [ 44%]
........................................................................ [ 55%]
........................................................................ [ 66%]
........................................................................ [ 77%]
........................................................................ [ 88%]
........................................................................ [ 99%]
...                                                                      [100%]
650 passed, 1 skipped in 4.08s
........................................................................ [ 19%]
........................................................................ [ 39%]
........................................................................ [ 59%]
........................................................................ [ 78%]
........................................................................ [ 98%]
.....                                                                    [100%]
365 passed in 4.81s
........................................................................ [ 27%]
........................................................................ [ 55%]
........................................................................ [ 83%]
...........................................                              [100%]
259 passed in 5.23s
...............................                                          [100%]
31 passed in 2.05s
...................................                                      [100%]
35 passed in 0.99s
✔ active skill link with h2s expands into a group excluding the synthetic _top node (0.682667ms)
✔ page with no h2s leaves the tree unchanged (0.084459ms)
✔ undefined toc items does not throw and leaves the tree unchanged (0.054417ms)
✔ non-active links stay flat even when h2s exist (0.297458ms)
✔ active README-style page with h2s is not expanded (skill pages only, ADR-002) (0.052ms)
ℹ tests 5
ℹ suites 0
ℹ pass 5
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 38.388542
1..98
ok 1 ec_tool_binary maps formula names to binaries
ok 2 ec_validate_selection accepts subset of allowed list
ok 3 ec_validate_selection rejects unknown token
ok 4 ec_validate_selection accepts the special 'none' MCP token
ok 5 ec_parse_args defaults to all tools including tilth, and tilth,context7,hallouminate MCP
ok 6 ec_parse_args --tools with value parses comma list
ok 7 ec_parse_args --tools=value parses inline value
ok 8 ec_parse_args --skip-mcp sets MCP to none
ok 9 ec_parse_args --no-edit clears WITH_EDIT
ok 10 ec_parse_args --dry-run sets DRY_RUN
ok 11 ec_parse_args --harness overrides default harness
ok 12 ec_parse_args --harness accepts comma-separated harness list
ok 13 ec_parse_args -h sets DO_HELP
ok 14 ec_parse_args --help sets DO_HELP
ok 15 ec_parse_args rejects unknown flag with exit code 2
ok 16 ec_parse_args rejects positional arg with exit code 2
ok 17 ec_parse_args --tools without value fails
ok 18 ec_parse_args --mcp without value fails
ok 19 ec_parse_args rejects unknown tool selection
ok 20 ec_parse_args rejects unknown mcp selection
ok 21 ec_parse_args -- terminates option parsing
ok 22 ec_detect_os returns 0 when uname reports Darwin
ok 23 ec_detect_os returns 1 when uname reports Linux
ok 24 ec_ensure_homebrew passes when brew exists
ok 25 ec_ensure_homebrew fails with hint when brew missing
ok 26 ec_brew_install_if_missing skips when binary already on PATH
ok 27 ec_brew_install_if_missing dry-run prints would-run line
ok 28 ec_brew_install_if_missing invokes brew when missing
ok 29 ec_brew_install_if_missing surfaces brew failure
ok 30 ec_install_tools (dry-run) iterates each formula in the list
ok 31 ec_install_tools routes tilth through ec_install_tilth, not brew
ok 32 ec_install_tilth short-circuits when tilth already on PATH
ok 33 ec_install_tilth dry-run installs via the npm nightly package
ok 34 ec_install_tilth invokes npm install -g when not dry-run
ok 35 ec_install_tilth fails clearly when npm is not present
ok 36 default MCP selection registers tilth, context7, and hallouminate
ok 37 --mcp hallouminate installs the hallouminate plugin on claude-code
ok 38 --mcp tilth still installs and registers tilth
ok 39 ec_install_mcp_tilth fails clearly when tilth CLI missing
ok 40 ec_install_mcp_tilth dry-run shows install command with --edit
ok 41 ec_install_mcp_tilth dry-run omits --edit when WITH_EDIT=0
ok 42 ec_install_mcp_tilth invokes tilth install when not dry-run
ok 43 ec_install_mcp_context7 warns and skips for non-claude harness
ok 44 ec_install_mcp_context7 fails when claude CLI missing
ok 45 ec_install_mcp_context7 dry-run prints would-run with package name
ok 46 ec_install_mcp_context7 dry-run shows resolved $claude / $npx paths
ok 47 ec_install_mcp_context7 honors EC_NPX in real invocation
ok 48 ec_install_mcp_tavily warns when TAVILY_API_KEY unset (dry-run)
ok 49 ec_install_mcp_tavily dry-run shows resolved $claude / $npx paths
ok 50 ec_install_mcp_hallouminate warns and returns 0 for a non-plugin harness
ok 51 ec_install_mcp_hallouminate codex dry-run shows the codex plugin marketplace add + add commands
ok 52 ec_install_mcp_hallouminate codex real invocation logs correct argv
ok 53 ec_install_mcp_hallouminate codex warns to restart when plugin add fails
ok 54 ec_install_mcp_hallouminate codex fails when codex CLI missing
ok 55 ec_install_mcp_hallouminate treats a failed marketplace add as non-fatal and still installs
ok 56 ec_install_mcp_hallouminate dry-run shows the plugin marketplace add + install commands
ok 57 ec_install_mcp_milknado warns and skips for non-claude harness
ok 58 ec_install_mcp_milknado gracefully skips when uvx binary missing
ok 59 ec_install_mcp_milknado dry-run shows resolved claude and uvx paths
ok 60 ec_install_mcp_hallouminate real invocation logs correct argv
ok 61 ec_install_mcp_milknado real invocation logs correct argv
ok 62 ec_parse_args accepts --mcp hallouminate,milknado
ok 63 ec_install_mcp_hallouminate fails when claude CLI missing
ok 64 ec_install_mcp_milknado fails when claude CLI missing
ok 65 ec_setup_cheese_corpus resolves the skill via gh skill list and runs global --apply
ok 66 ec_setup_cheese_corpus warns and returns 0 when gh skill list resolves nothing
ok 67 ec_setup_cheese_corpus dry-run logs the plan and never invokes gh
ok 68 ec_setup_cheese_corpus warns and returns 0 when gh CLI is missing
ok 69 ec_detect_harnesses finds installed main-line harness CLIs
ok 70 ec_resolve_harnesses auto returns every detected harness
ok 71 ec_resolve_harnesses auto falls back to claude-code when nothing detected
ok 72 ec_resolve_harnesses keeps explicit comma-separated harnesses
ok 73 ec_install_skills warns and returns 0 when gh CLI missing
ok 74 ec_install_skills dry-run lists every shipped skill with --force
ok 75 ec_install_skills dry-run honors picked harness
ok 76 ec_install_skills_for_harnesses installs every skill into every harness
ok 77 ec_install_skills warns and returns 1 when gh is unauthenticated
ok 78 ec_discover_skills returns names from gh api stdout
ok 79 ec_discover_skills pins ref when EC_SKILL_REF is set
ok 80 ec_discover_skills returns empty when gh api fails
ok 81 ec_install_skills uses live list when gh api discovery succeeds
ok 82 ec_install_skills falls back to embedded list when gh api fails
ok 83 ec_install_skills falls back to embedded list when gh api returns empty
ok 84 ec_install_skills passes --pin when EC_SKILL_REF is set
ok 85 ec_install_skills dry-run echoes --pin in the would-run line when EC_SKILL_REF is set
ok 86 ec_install_skills returns non-zero when any skill install fails
ok 87 ec_install_mcp dispatches 'none' as a no-op log line
ok 88 ec_install_mcp rejects unknown server
ok 89 ec_main --help prints usage and exits 0
ok 90 ec_main rejects non-Darwin OS
ok 91 ec_main fails when Homebrew missing on macOS
ok 92 ec_main full --dry-run on macOS prints all tool, skill, and MCP actions
ok 93 ec_main auto-installs skills into each detected main-line harness
ok 94 ec_main --skip-tools --mcp tilth registers only tilth (still runs skills)
ok 95 EC_FALLBACK_SKILLS matches the skills/ directories exactly
ok 96 hermetic PATH: non-allowlisted host tools are unreachable
ok 97 hermetic PATH: stubs shadow allowlisted essentials
ok 98 hermetic PATH: allowlisted essentials resolve from the essentials dir
1..18
ok 1 script is executable
ok 2 script accepts --help with exit 0
ok 3 script -h prints usage and exits 0
ok 4 script rejects missing file with exit 1
ok 5 single shape emits one branch, two cherry-picks, one PR
ok 6 single shape also accepts a JSON plan file
ok 7 orthogonal_flat emits N PRs each with base main
ok 8 orthogonal_flat emits exactly one cherry-pick per curd
ok 9 stacked_linear emits each PR with previous branch as base
ok 10 diamond_stack emits seed-rooted parallel curd PRs and a wiring tip
ok 11 script rejects unknown shape
ok 12 script rejects empty groups
ok 13 script rejects missing shape field
ok 14 script rejects option-shaped commit token at integration layer
ok 15 script reads from stdin when no argument given
ok 16 emitted commands round-trip through bash when title contains an apostrophe
ok 17 idempotency guard skips gh pr create when gh pr view succeeds
ok 18 emitted commands round-trip through bash when body contains quotes and newlines
Lockfile is up to date, resolution step is skipped
Already up to date

Done in 326ms using pnpm v10.13.1
Requirement already satisfied: pyyaml==6.0.2 in ./.venv/lib/python3.14/site-packages (6.0.2)

> easy-cheese-docs@0.0.0 docs:build /Users/paul/conductor/workspaces/easy-cheese/toronto
> python3 scripts/gen_docs.py && astro build

23:11:06 [astro-mermaid] Setting up Mermaid integration
23:11:06 [astro-mermaid] Existing rehype plugins:
23:11:06 [astro-mermaid] Skipping ELK support
23:11:06 [content] Syncing content
23:11:06 [content] Synced content
23:11:06 [types] Generated 296ms
23:11:06 [build] output: "static"
23:11:06 [build] mode: "static"
23:11:06 [build] directory: /Users/paul/conductor/workspaces/easy-cheese/toronto/dist/
23:11:06 [build] Collecting build info...
23:11:06 [build] ✓ Completed in 399ms.
23:11:06 [build] Building static entrypoints...
23:11:07 [vite] ✓ built in 302ms
23:11:07 [WARN] [vite] [plugin builtin:vite-reporter] 
(!) Some chunks are larger than 500 kB after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rolldownOptions.output.codeSplitting to improve chunking: https://rolldown.rs/reference/OutputOptions.codeSplitting
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
23:11:07 [vite] ✓ built in 280ms
23:11:07 [build] Rearranging server assets...

 generating static routes 
23:11:07   ├─ /404.html (+9ms) 
23:11:07   ├─ /code-of-conduct/index.html (+3ms) 
23:11:07   ├─ /contributing/index.html (+2ms) 
23:11:07   ├─ /index.html (+2ms) 
23:11:07   ├─ /install/index.html (+2ms) 
23:11:07   ├─ /readme/index.html (+1ms) 
23:11:07   ├─ /security/index.html (+1ms) 
23:11:07   ├─ /skills/index.html (+1ms) 
23:11:07   ├─ /skills/affinage/index.html (+2ms) 
23:11:07   ├─ /skills/age/index.html (+3ms) 
23:11:07   ├─ /skills/briesearch/index.html (+3ms) 
23:11:07   ├─ /skills/cheese/index.html (+2ms) 
23:11:07   ├─ /skills/cheez-read/index.html (+1ms) 
23:11:07   ├─ /skills/cheez-search/index.html (+1ms) 
23:11:07   ├─ /skills/cheez-write/index.html (+1ms) 
23:11:07   ├─ /skills/cook/index.html (+1ms) 
23:11:07   ├─ /skills/culture/index.html (+1ms) 
23:11:07   ├─ /skills/cure/index.html (+1ms) 
23:11:07   ├─ /skills/easy-cheese-setup/index.html (+1ms) 
23:11:07   ├─ /skills/hard-cheese/index.html (+1ms) 
23:11:07   ├─ /skills/melt/index.html (+1ms) 
23:11:07   ├─ /skills/mold/index.html (+2ms) 
23:11:07   ├─ /skills/pasteurize/index.html (+1ms) 
23:11:07   ├─ /skills/plate/index.html (+1ms) 
23:11:07   ├─ /skills/press/index.html (+1ms) 
23:11:07   ├─ /skills/ultracook/index.html (+2ms) 
23:11:07   ├─ /skills/wheypoint/index.html (+1ms) 
23:11:07 ✓ Completed in 99ms.

 generating optimized images 
23:11:07   ▶ /_astro/favicon.Baa5x8TM_SMe1d.svg (reused cache entry) (+1ms) (1/1)
23:11:07 ✓ Completed in 1ms.

23:11:07 [build] ✓ Completed in 702ms.
23:11:07 [starlight:pagefind] Building search index with Pagefind...
23:11:07 [starlight:pagefind] Found 27 HTML files.
23:11:07 [starlight:pagefind] Finished building search index in 109ms.
23:11:07 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
23:11:07 [build] 27 page(s) built in 1.23s
23:11:07 [build] Complete!