### PR TITLE
fix(culture): user owns session-end; forks raised conversationally (#299)

### DIFF
--- a/skills/culture/SKILL.md
+++ b/skills/culture/SKILL.md
@@ -18,7 +18,7 @@ Do not use the user-facing mode when the user wants a written spec (`/mold`), im
 
 ## Invariant
 
-`/culture` writes no production code and does not commit changes, open PRs, or mutate project state. In **user-facing mode** it ends every session by writing a durable handoff, delegated to `/wheypoint` (see `## Handoff slug`); that wheypoint is written at session end only, never during the dialogue. In **internal mode** it writes nothing at all. If a user-facing conversation reveals that something should be built, route to `/mold` or `/cook` after the wheypoint is written. In internal mode, just return the decision and let the calling skill act.
+`/culture` writes no production code and does not commit changes, open PRs, or mutate project state. In **user-facing mode** it ends every session by writing a durable handoff, delegated to `/wheypoint` (see `## Handoff slug`); that wheypoint is written at session end only, never during the dialogue. The user declares the session over — the agent never declares convergence on the user's behalf; it may ask whether the thread feels settled, and otherwise carries it forward. In **internal mode** it writes nothing at all. If a user-facing conversation reveals that something should be built, route to `/mold` or `/cook` after the wheypoint is written. In internal mode, just return the decision and let the calling skill act.
 
 ## Flow
 
@@ -28,9 +28,9 @@ Both modes share this reasoning loop; the per-step difference is internal-return
 2. Identify assumptions, constraints, and decision criteria.
 3. Explore trade-offs and likely blast radius. When the trade-off hinges on "what does this touch", run a read-only shape check on the candidate seam — a `cheez-search` callers query plus dependency/blast-radius context from the selected semantic backend — and label each option `[low | medium | high blast radius]`. Procedure mirrors `../mold/references/shape-check.md`; culture stops at the verdict and never drafts signatures. Steelman the rejected option before settling on a recommendation.
 4. Gather evidence to the depth the question needs. Start with a light wiki probe — is this already decided or already known? — per the detect-and-degrade contract in [`../cheese/references/optional-plugins.md`](../cheese/references/optional-plugins.md): at most one `ground` call in internal mode, scaled up as useful in user-facing mode; when hallouminate is absent, skip, note the absence once, and cap confidence at `speculating` when design rationale is central. In internal mode keep the rest light — a quick shape check, no deep research — so the calling skill stays fast. In user-facing mode investigate as deeply as useful: dispatch the read-only `explorer` agent for code grounding and take back its digest, rather than dumping raw reads into the dialogue (where the `explorer` agent isn't available, e.g. a harness that installs only easy-cheese, ground directly via `/cheez-search` / `/cheez-read`).
-5. Decide the next move. In internal mode, return a single recommendation and stop. In user-facing mode you need not force convergence: render a compact summary and confidence-tagged open questions (`certain | speculating | don't know`), then either recommend a downstream skill or defer and carry the thread forward. End the session by writing the wheypoint (`## Handoff slug`), whose `next:` records where the modeling landed.
+5. Decide the next move. In internal mode, return a single recommendation and stop. In user-facing mode you need not force convergence: render a compact summary and confidence-tagged open questions (`certain | speculating | don't know`), then either recommend a downstream skill or defer and carry the thread forward. Once the user calls the thread over, end the session by writing the wheypoint (`## Handoff slug`), whose `next:` records where the modeling landed.
 
-Asking the user is the point: every consequential fork is theirs to decide, surfaced as a choice rather than settled for them. The depth you offer — full signatures, named edge cases, file:line evidence — informs each question; it never substitutes for asking it.
+Asking the user is the point: every consequential fork is theirs to decide, surfaced as a choice rather than settled for them. The depth you offer — full signatures, named edge cases, file:line evidence — informs each question; it never substitutes for asking it. In user-facing mode, raise forks conversationally in the dialogue; reserve structured question tools for the end-of-session handoff gate. Never bundle multiple consequential forks into one prompt.
 
 ## Preferred tools and fallbacks
 
@@ -54,7 +54,7 @@ See Flow step 5.
 
 **Every** user-facing session ends by writing a durable wheypoint, so the modeling is resumable. Invoke `/wheypoint <focus>` and let it own compaction, secret redaction, the state-mapped suggested-skills section, and the resumable slug. Culture does not maintain its own schema; the slug contract (`status` / `next` / `mode` / `artifact` and the `## Document` body) is defined in `skills/wheypoint/SKILL.md`, which is the single source of truth.
 
-Culture-relevant `next:` values: `culture` or `hold` to resume the modeling in a later session (defer convergence), `mold` (fuzzy idea, route to spec), `cook` (clear ask, route to implementation), or `done` when the thread is genuinely closed. When the next step is blocked on a human decision, set `status: gated:` rather than a `next:` value.
+Culture-relevant `next:` values: `culture` or `hold` to resume the modeling in a later session (defer convergence), `mold` (fuzzy idea, route to spec), `cook` (clear ask, route to implementation), or `done` when the user judges the thread genuinely closed. When the next step is blocked on a human decision, set `status: gated:` rather than a `next:` value.
 
 ## Handoff
 

--- a/tests/python/test_culture_convergence.py
+++ b/tests/python/test_culture_convergence.py
@@ -1,0 +1,118 @@
+"""Regression guard for issue #299 (culture user-facing convergence + fork medium).
+
+Two gaps confirmed on origin/main @ 8e75a68 for `/culture` user-facing mode:
+
+1. **Session-end ownership.** The Invariant, Flow step 5, and Handoff-slug
+   `done` value all described session end as agent-executed with no owner, so a
+   strong model could declare convergence on the user's behalf and end the
+   thread unilaterally. The fix pins the USER as the one who declares the
+   session over, and forbids the agent from declaring convergence for them.
+
+2. **Fork medium.** The fork clauses constrained the *count* of consequential
+   forks ("one at a time") but not the *medium*, so chained single-question
+   structured popups satisfied the text while still railroading the dialogue.
+   The fix requires forks to be raised conversationally in the dialogue and
+   reserves structured question tools for the end-of-session handoff gate, and
+   forbids bundling multiple forks into one prompt.
+
+Each assertion pins the *semantic relationship* within a bounded span (who
+declares, what is reserved for where), not a vacuous co-occurrence of isolated
+substrings anywhere in the file — the exact defect called out on PR #297.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CULTURE_SKILL = REPO_ROOT / "skills" / "culture" / "SKILL.md"
+
+
+def _body_below_frontmatter(path: Path) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if lines and lines[0].strip() == "---":
+        for i in range(1, len(lines)):
+            if lines[i].strip() == "---":
+                return "\n".join(lines[i + 1 :])
+    return "\n".join(lines)
+
+
+# --- Clause 1: session-end ownership -----------------------------------------
+# The user is the subject who declares the session/thread over.
+USER_DECLARES_END = re.compile(
+    r"user\b[^.\n]{0,40}\bdeclares?\b[^.\n]{0,40}\b(?:session|thread)\b[^.\n]{0,20}\bover\b",
+    re.I,
+)
+# The agent is explicitly barred from declaring convergence for the user.
+AGENT_NEVER_CONVERGES = re.compile(
+    r"agent\b[^.\n]{0,40}\bnever\b[^.\n]{0,40}\bdeclares?\b[^.\n]{0,40}\bconvergence\b",
+    re.I,
+)
+# Flow step 5 must gate the wheypoint write on the user calling the thread over.
+END_GATED_ON_USER = re.compile(
+    r"user\b[^.\n]{0,40}\b(?:calls?|declares?)\b[^.\n]{0,40}\b(?:thread|session)\b[^.\n]{0,20}\bover\b[^.\n]{0,80}\bwheypoint\b",
+    re.I,
+)
+
+
+# --- Clause 2: fork medium ---------------------------------------------------
+# Forks are raised conversationally in the dialogue.
+FORKS_CONVERSATIONAL = re.compile(
+    r"\bforks?\b[^.\n]{0,40}\bconversational(?:ly)?\b[^.\n]{0,40}\bdialogue\b",
+    re.I,
+)
+# Structured question tools are reserved for the handoff gate — not the dialogue.
+STRUCTURED_RESERVED_FOR_HANDOFF = re.compile(
+    r"reserve\b[^.\n]{0,40}\bstructured\b[^.\n]{0,80}\bhandoff\b",
+    re.I,
+)
+# Multiple consequential forks must never be bundled into one prompt — this is
+# what closes the chained single-question-popup gap that count-only wording left
+# open.
+NO_BUNDLED_FORKS = re.compile(
+    r"never\b[^.\n]{0,30}\bbundle\b[^.\n]{0,40}\b(?:multiple|consequential)\b[^.\n]{0,20}\bforks?\b",
+    re.I,
+)
+
+
+def test_culture_skill_exists() -> None:
+    assert CULTURE_SKILL.exists(), f"culture SKILL.md moved or renamed: {CULTURE_SKILL}"
+
+
+def test_user_owns_session_end() -> None:
+    body = _body_below_frontmatter(CULTURE_SKILL)
+    missing = []
+    if not USER_DECLARES_END.search(body):
+        missing.append("the user declares the session/thread over")
+    if not AGENT_NEVER_CONVERGES.search(body):
+        missing.append("the agent never declares convergence on the user's behalf")
+    assert not missing, (
+        "#299 session-end ownership clause absent — user-facing mode must name the "
+        "USER as the one who ends the session, not the agent:\n  - "
+        + "\n  - ".join(missing)
+    )
+
+
+def test_flow_step_five_gates_end_on_user() -> None:
+    body = _body_below_frontmatter(CULTURE_SKILL)
+    assert END_GATED_ON_USER.search(body), (
+        "#299 wiring absent — the wheypoint write (session end) must be gated on the "
+        "user calling the thread over, not executed unilaterally by the agent."
+    )
+
+
+def test_forks_raised_conversationally_not_bundled() -> None:
+    body = _body_below_frontmatter(CULTURE_SKILL)
+    missing = []
+    if not FORKS_CONVERSATIONAL.search(body):
+        missing.append("forks are raised conversationally in the dialogue")
+    if not STRUCTURED_RESERVED_FOR_HANDOFF.search(body):
+        missing.append("structured question tools are reserved for the handoff gate")
+    if not NO_BUNDLED_FORKS.search(body):
+        missing.append("multiple consequential forks are never bundled into one prompt")
+    assert not missing, (
+        "#299 fork-medium clause absent — count-only wording lets chained "
+        "single-question popups railroad the dialogue; the medium must be pinned:\n  - "
+        + "\n  - ".join(missing)
+    )


### PR DESCRIPTION
Fixes #299.

Two clauses in `skills/culture/SKILL.md`, per the issue's suggested wording:

1. **Session-end ownership** (Invariant): "The user declares the session over — the agent never declares convergence on the user's behalf; it may ask whether the thread feels settled, and otherwise carries it forward." Flow step 5 and the handoff-slug `done` value are wired to it minimally.
2. **Fork medium**: "In user-facing mode, raise forks conversationally in the dialogue; reserve structured question tools for the end-of-session handoff gate. Never bundle multiple consequential forks into one prompt."

Tests: new `tests/python/test_culture_convergence.py` (4 relationship-pinning tests, red-first proven against pre-fix text — reversal of the ownership direction breaks the match, not vacuous co-occurrence). Full `tests/python` suite: 657 passed, 1 skipped. markdownlint clean.

Deliberately out of scope: the ask-user-question.md transport pointer for culture — that belongs to the #287/#294 design pass in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
