### PR TITLE
feat(age): add GitHub publication modes

### DIFF
--- a/skills/age/SKILL.md
+++ b/skills/age/SKILL.md
@@ -16,8 +16,8 @@ Do not use it to apply fixes directly. Hand fix work to `/cure`, which owns appl
 Accept:
 
 ```text
-/age [<ref-or-range>] [--scope <path>] [--comprehensive] [--full] [--safe] [--open-pr] [--auto] [--html]
-/age <slug> [--full] [--safe] [--open-pr] [--auto] [--html]
+/age [<ref-or-range>] [--scope <path>] [--comprehensive] [--full] [--safe] [--open-pr] [--auto] [--html] [--post-report | --post-inline]
+/age <slug> [--full] [--safe] [--open-pr] [--auto] [--html] [--post-report | --post-inline]
 ```
 
 `--full` un-collapses the `## Low` section when 10 or more low-severity findings exist (the default report collapses them to a one-line summary). Suppressed lows feed the cure-selection table only when `--full` is passed.
@@ -40,6 +40,8 @@ python3 src/age/age-html-report.py \
 
 Print the returned temp-file path beside the markdown path. `html-report` groups the findings by severity into age's own badge template and wraps them in the shared document shell (`shared/scripts/html_report.render_document`); the output is stdlib-only, offline, and deterministic — no CDN, no JavaScript. Do not inline or hand-roll the document chrome. Pass `--out-dir <dir>` to write somewhere other than the OS temp dir.
 If the host only ships the bundle, `python3 ${CLAUDE_SKILL_DIR}/scripts/age.pyz html-report --report .cheese/age/<slug>.md --slug <slug>` is the fallback.
+
+`--post-report` publishes the reader-facing Age report as one top-level PR conversation comment. `--post-inline` publishes one inline thread per anchorable finding and puts unanchorable findings in a compact top-level summary comment. `--post-report` and `--post-inline` are mutually exclusive. Both require an existing PR and are explicit exceptions to Age's local-only default; see [`references/publication.md`](references/publication.md).
 
 Portability reference: [`../cheese/references/harness-portability.md`](../cheese/references/harness-portability.md). It covers helper resolution, sub-agent dispatch, GitHub operations, and handoff transitions; prefer the bundled or repo-local helper first, and treat `${CLAUDE_SKILL_DIR}` as optional host-provided fallback.
 The handoff blocks below are the portable contract; slash commands are host renderings, not the control model.
@@ -105,7 +107,8 @@ Per-dimension base-severity tables, location-sensitivity, fix-cost-now / fix-cos
      --durable-flags "<none | one line per flag>" \
      --body-file "$report_file"` is the fallback.
    Then print the path.
-6. Hand off (see `## Handoff` below).
+6. If `--post-report` or `--post-inline` is set, publish the completed report via `## GitHub publication`.
+7. Hand off (see `## Handoff` below).
 
 ## Preferred tools and fallbacks
 
@@ -247,6 +250,20 @@ Age report:  .cheese/age/<slug>.md
 HTML report: <path printed by html-report>
 ```
 
+## GitHub publication
+
+The canonical `.cheese/age/<slug>.md` artifact is always written before any GitHub write. Publication is opt-in and operates on the current invocation only.
+
+When a publication flag is set:
+
+1. Resolve the existing PR, repository, base SHA, and head SHA before review. Review the PR's exact committed `base...head` diff; exclude working-tree and index changes. `--open-pr` does not satisfy this requirement because no PR exists yet at review time.
+2. Refuse publication for a halted report, a report produced from any other diff, or a PR whose base or head differs from the reviewed SHAs.
+3. Follow [`references/publication.md`](references/publication.md) for report-comment or inline-thread rendering, anchoring, idempotency markers, and partial-failure behavior.
+4. Prefer a host GitHub primitive; use `gh` as the fallback per [`../cheese/references/harness-portability.md`](../cheese/references/harness-portability.md). Never use a browser session for publication.
+5. Print the PR URL and created/updated comment counts, then continue to `## Handoff`. If publication fails, leave the local report intact, report the partial counts, and stop before `/cure`.
+
+The parent Age invocation owns publication. Dimension workers and the review-context sub-agent remain read-only and never post comments.
+
 ## Handoff
 
 **Pipeline:** culture → mold → cook → press → **[age]** → cure → plate
@@ -320,6 +337,7 @@ On `none` / `Stop` (only reachable via the gate), exit cleanly with the report p
 When invoked with `--auto`:
 
 - Skip the handoff gate.
+- Publish only the current report when an explicit publication flag is present; never propagate publication into the cure loop.
 - If two cure passes have already completed (cap reached), stop and surface the final report — do not invoke `/cure` again even if findings remain.
 - Otherwise, if any finding meets the **medium+ floor** (the composite floor defined at **Compute the recommended set** under `## Handoff`) — invoke `/cure <slug> --auto --stake medium+` (forward `--open-pr` when it is in scope) and increment the cure-pass count when it returns.
 - If no finding meets the **medium+ floor**, stop the chain with a one-line "auto chain clean" note and the report path.
@@ -328,6 +346,7 @@ When invoked with `--auto`:
 
 `/ultracook` spawns age as a fresh-context sub-agent and owns the chain itself. Honour the no-chain override:
 
+- Reject `--post-report` and `--post-inline` in this sub-agent context; ultracook does not delegate external publication.
 - Write `.cheese/age/<slug>.md` (with the handoff slug at the top) and stop. Do not invoke `/cure <slug> --auto --stake medium+` from inside the sub-agent.
 - Set `next:` from what you observe on this run, not from any guess about chain position. `next: cure` when at least one finding meets the **medium+ floor**; `next: done` when none do.
 - The two-cure-pass cap is enforced by ultracook's fixed chain length. The terminal age is publishable only with `next: done`; `next: cure` or a missing `next` halts without publishing. Parallel curds and post-merge review dispatch age as a top-level fresh-context reviewer, never as nested inline self-review.
@@ -336,6 +355,8 @@ When invoked with `--auto`:
 
 - Review is not a verdict; explain where to look and why.
 - Do not edit production files; `/cure` owns application.
+- The default remains local-only. GitHub writes require exactly one explicit publication flag and authorize comments only.
+- Do not propagate either publication flag to `/cure`, `/plate`, or nested `/age --auto` invocations.
 - Do not raise a finding for a gate failure identical to the diff's recorded `baseline:` block; flag only new or changed failures per [`../cook/references/quality-gates.md`](../cook/references/quality-gates.md).
 - Default to acting: auto-select the recommended set and dispatch `/cure` without a gate. Ask first only on a genuine reason (a sprawling/structural fix in the set, or conflicting findings) or under `--safe`. An empty recommended set is a clean stop, not a question.
 - Do not invent evidence. Cite files, diffs, commands, or unavailable-source notes.
@@ -348,6 +369,7 @@ When invoked with `--auto`:
 
 - `references/dimensions.md` — per-dimension rubrics and recommendation shapes.
 - `references/voice.md` — shared output discipline, reasoning posture, and confidence vocabulary.
+- `references/publication.md` — explicit full-report and inline GitHub publication contracts.
 - `references/deslop-rust.md` / `references/deslop-typescript.md` / `references/deslop-python.md` / `references/deslop-shell.md` / `references/deslop-go.md` — per-language `deslop` pattern catalogs with lint-rule mappings and citations.
 - `references/sub-agent-gate.md` — shared sub-agent kernel: digest contract, harness-agnostic selection, what the parent never delegates.
 

--- a/skills/age/references/publication.md
+++ b/skills/age/references/publication.md
@@ -1,0 +1,154 @@
+# GitHub publication
+
+Use this reference only when `/age` receives `--post-report` or `--post-inline`.
+The default remains local-only: without either flag, write the canonical Age
+artifact and perform no GitHub write.
+
+## Shared contract
+
+Apply these rules to both modes:
+
+1. Write the canonical local report first. Publish only a completed
+   `status: ok` report.
+2. Require an existing pull request. Resolve it from the explicit PR input or
+   the current branch. `--open-pr` does not create a publication target early
+   enough for Age.
+3. Before dispatching reviewers, resolve the PR's base and head SHAs and review
+   that exact committed `base...head` diff. Exclude index and working-tree
+   changes even when local `HEAD` equals the PR head. Refuse publication when
+   the completed report came from any other input.
+4. Pin publication to both reviewed SHAs. Re-read the PR immediately before
+   the first write and stop if its base or head changed.
+5. Fetch existing PR conversation comments and inline review threads before
+   posting. Use the markers below to update prior Age output instead of
+   duplicating it.
+6. Use the host GitHub primitive when available, with `gh` as fallback. Halt
+   when neither exists.
+7. Submit review comments with the `COMMENT` event. Comment-only publication
+   must never `APPROVE` or `REQUEST_CHANGES`.
+8. Publish only findings visible in the canonical report. Suppressed lows stay
+   unpublished until the user reruns with `--full`.
+9. Do not publish from dimension workers or review-context sub-agents.
+10. Do not propagate either publication flag to `/cure`, `/plate`, or nested
+   `/age --auto` invocations.
+
+Leave the local report intact on any publication failure. Report how many
+comments were created or updated, then stop before the Handoff.
+
+## Full-report mode
+
+`--post-report` publishes one top-level PR conversation comment.
+
+Render the reader-facing report from its `# Age Report` heading onward. Omit
+the machine handoff header (`status`, `next`, `artifact`, `durable_flags`,
+`baseline`, and orientation preamble). Prepend this stable marker:
+
+```html
+<!-- easy-cheese:age:report slug=<slug> -->
+```
+
+Search existing PR conversation comments for the exact marker. When found,
+update the existing comment. Otherwise, create one new comment. Never split a
+normal Age report across comments; if the provider rejects its size, fail loud
+and leave the local artifact as the complete source.
+
+Do not create inline threads in this mode.
+
+## Inline mode
+
+`--post-inline` publishes one inline thread per anchorable finding plus one
+top-level summary comment.
+
+### Finding keys and markers
+
+Derive a deterministic finding key from the finding's dimension, repository
+path, and normalized claim. Do not include line numbers, severity,
+recommendation, or other mutable rendering fields. Use a short SHA-256 digest
+or an equivalent stable hash. Append this marker to every inline body:
+
+```html
+<!-- easy-cheese:age:finding slug=<slug> key=<finding-key> -->
+```
+
+Before posting, search all current and outdated review threads for the marker:
+
+- Partition the canonical findings into anchorable and unanchorable sets before
+  matching threads.
+- Match an anchorable finding by exact key first. If its prose was rephrased
+  and no exact key exists, semantically reconcile same-slug Age comments using
+  dimension, path, referenced symbol, and problem category. Reuse and replace
+  the old marker only when exactly one prior finding is an unambiguous match;
+  otherwise create a new thread and retire unmatched prior threads normally.
+- When a current thread contains the matched marker and its anchor still
+  supports the finding, update the existing inline comment and unresolve the
+  thread if a prior run retired it.
+- When the matched current thread's anchor no longer supports the finding,
+  resolve it and create a replacement at the current anchor.
+- When only an outdated thread contains it and the finding remains, create a
+  replacement at the current anchor and resolve the outdated thread. Prefer the
+  current non-outdated thread on later runs.
+- When no thread contains it, create a new inline comment.
+
+Group all new inline comments into one PR review with the `COMMENT` event.
+Updates to existing threads may happen individually before that review is
+submitted.
+
+After matching the anchorable findings, retire every current, same-slug Age
+thread whose marker is unmatched or whose finding is now unanchorable: append
+`Resolved by the Age review of <head-sha>.` while preserving its marker, then
+resolve the thread. Never delete the historical comment. Include an
+unanchorable finding only in the top-level summary, not in a still-current
+inline thread. If the provider cannot resolve or unresolve a marked thread,
+report partial counts and treat publication as failed rather than leaving the
+summary in conflict with open Age threads. Do not touch unmarked threads or
+markers for another slug.
+
+### Anchoring
+
+Anchor a finding only when its reported range overlaps the PR diff:
+
+- added or context line: `RIGHT`;
+- deleted line: `LEFT`;
+- multi-line finding: use the narrowest changed range that supports the claim.
+
+Do not guess a nearby changed line. Treat findings on unchanged code, the PR
+body, external files, generated context, or a range GitHub rejects as
+unanchorable findings.
+
+Render each inline body as:
+
+```markdown
+**[<dimension>:<severity>]** <claim>
+
+<location / fix-cost / confidence line>
+
+Recommendation: <action>
+
+<!-- easy-cheese:age:finding slug=<slug> key=<finding-key> -->
+```
+
+### Summary and unanchorable findings
+
+Publish one top-level summary comment containing severity counts and every
+unanchorable finding in the report's normal finding format. For a clean review,
+publish the summary with zero counts and no inline threads. Prepend:
+
+```html
+<!-- easy-cheese:age:inline-summary slug=<slug> -->
+```
+
+Search PR conversation comments for the exact marker and update the existing
+comment. Otherwise, create it. Keep this summary compact; the canonical local
+artifact remains the complete report.
+
+## Transport
+
+State the semantic operation first: fetch PR comments and threads, update a
+matching marked comment, create a top-level comment, or submit a comment-only
+review with file comments.
+
+Prefer the host GitHub primitive. With `gh`, use the corresponding GitHub REST
+or GraphQL endpoint and pass bodies as data fields or files, never shell-
+interpolated JSON. Follow
+[`../../cheese/references/harness-portability.md`](../../cheese/references/harness-portability.md)
+for capability detection and fallback.

--- a/tests/python/test_age_publication_modes.py
+++ b/tests/python/test_age_publication_modes.py
@@ -1,0 +1,64 @@
+"""Contract tests for Age's explicit GitHub publication modes.
+
+Age remains local-only by default.  The two opt-in modes must stay mutually
+exclusive, idempotent, comment-only, and lossless for findings that GitHub
+cannot anchor to a changed line.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGE = (REPO_ROOT / "skills" / "age" / "SKILL.md").read_text(encoding="utf-8")
+PUBLICATION_PATH = REPO_ROOT / "skills" / "age" / "references" / "publication.md"
+
+
+def test_age_advertises_both_publication_modes() -> None:
+    assert "--post-report" in AGE
+    assert "--post-inline" in AGE
+    assert "`--post-report` and `--post-inline` are mutually exclusive" in AGE
+
+
+def test_publication_reference_preserves_local_only_default() -> None:
+    assert PUBLICATION_PATH.is_file()
+    publication = PUBLICATION_PATH.read_text(encoding="utf-8")
+
+    assert "The default remains local-only" in publication
+    assert "existing pull request" in publication
+    assert "write the canonical local report first" in publication.lower()
+    assert "exact committed `base...head` diff" in publication
+    assert "Exclude index and working-tree" in publication
+
+
+def test_full_report_mode_is_one_idempotent_conversation_comment() -> None:
+    publication = PUBLICATION_PATH.read_text(encoding="utf-8")
+
+    assert "one top-level PR conversation comment" in publication
+    assert "<!-- easy-cheese:age:report slug=<slug> -->" in publication
+    assert "update the existing comment" in publication
+
+
+def test_inline_mode_is_lossless_and_idempotent() -> None:
+    publication = PUBLICATION_PATH.read_text(encoding="utf-8")
+
+    assert "one inline thread per anchorable finding" in publication
+    assert "<!-- easy-cheese:age:finding slug=<slug> key=<finding-key> -->" in publication
+    assert "unanchorable findings" in publication
+    assert "top-level summary comment" in publication
+    assert "update the existing inline comment" in publication
+    assert "Do not include line numbers, severity," in publication
+    assert "semantically reconcile same-slug Age comments" in publication
+    assert "Partition the canonical findings into anchorable and unanchorable" in publication
+    assert "whose finding is now unanchorable" in publication
+    assert "while preserving its marker" in publication
+    assert "resolve the thread" in publication
+
+
+def test_publication_never_changes_review_state_or_propagates() -> None:
+    publication = PUBLICATION_PATH.read_text(encoding="utf-8")
+
+    assert "COMMENT" in publication
+    assert "never `APPROVE` or `REQUEST_CHANGES`" in publication
+    assert "Do not propagate either publication flag" in publication
+    assert all(target in publication for target in ("`/cure`", "`/plate`", "`/age --auto`"))


### PR DESCRIPTION
## Description

Add two explicit GitHub publication modes to `/age`:

- `--post-report` updates one top-level PR comment with the reader-facing report.
- `--post-inline` publishes anchorable findings as inline comment-only review threads and keeps unanchorable findings in a compact top-level summary.

Age remains local-only by default, and the flags are mutually exclusive. Publication is pinned to the PR's exact committed base/head diff, uses stable markers for reruns, reconciles moved or rephrased findings, and retires stale Age threads without changing the PR review verdict.

## Motivation

Reviewers need both a compact full-report option and a line-level workflow. Making publication explicit preserves Age's safe local default while allowing actionable findings to appear where maintainers review code.

## Testing

- `just check`
- 1,492 Python tests passed; 1 skipped
- 5 JavaScript tests passed
- 116 shell tests passed
- skill/wiki validation, formatting, packaging, and docs build passed
- independent forward test and diff review passed

## Type of change

- Feature
- Documentation
- Tests
