### PR TITLE
fix(mold): accept contextual curdle approvals

### DIFF
--- a/.hallouminate/wiki/workflow-invariants.md
+++ b/.hallouminate/wiki/workflow-invariants.md
@@ -33,9 +33,11 @@ slug the next phase reads.
 `/mold` will not extract a spec until **both keys** turn
 (`skills/mold/references/handshake.md:1-3`):
 
-1. **User key** — the user says an explicit extraction verb: `curdle`,
-   `ship it`, `extract`, `that's enough`. A vague "ok let's go" does not
-   count (`handshake.md:5-9`).
+1. **User key** — the user expresses explicit extraction intent: `curdle`,
+   `ship it`, `extract`, or `that's enough`. A clear affirmative such as
+   `ok let's go`, `sounds good`, or `go ahead` also counts when it directly
+   answers an agent's extraction question. Do not infer the key from unrelated
+   or ambiguous approval (`handshake.md:5-10`).
 2. **Agent key** — the agent prints a 10-item coherence self-check
    (problem grounded, ≥2 options weighed including Do Nothing, interface
    sketches with pseudocode signatures, Validate Cycles judged, Grill run

--- a/skills/mold/references/handshake.md
+++ b/skills/mold/references/handshake.md
@@ -4,9 +4,9 @@ Curdle (artifact extraction) requires **both** keys. Neither is optional.
 
 ## User key
 
-The user must say one of: `curdle`, `ship it`, `extract`, `that's enough`. **Never inferred.**
+The user must express explicit extraction intent: `curdle`, `ship it`, `extract`, or `that's enough`. A clear affirmative such as `ok let's go`, `sounds good`, or `go ahead` also turns the key when it directly answers an agent's extraction question.
 
-A vague "ok let's go" or "sounds good" is not the user key. Ask explicitly.
+Do not infer the key from unrelated or ambiguous approval; ask explicitly when the context does not establish that the user is approving Curdle.
 
 ## Agent key — coherence self-check
 

--- a/tests/python/test_mold_followup_routing.py
+++ b/tests/python/test_mold_followup_routing.py
@@ -44,6 +44,24 @@ def test_scoped_documents_exist() -> None:
     assert not missing, f"Mold follow-up routing files moved or renamed: {missing}"
 
 
+def test_user_key_allows_contextual_affirmations_without_inference() -> None:
+    section = _section(HANDSHAKE, "User key")
+    for phrase in (
+        "explicit extraction intent",
+        "curdle",
+        "ship it",
+        "extract",
+        "that's enough",
+        "directly answers an agent's extraction question",
+        "ok let's go",
+        "sounds good",
+        "go ahead",
+    ):
+        assert phrase.casefold() in section.casefold()
+    assert "Never inferred" not in section
+    assert "unrelated or ambiguous approval" in section
+
+
 def test_candidate_collection_is_non_committing_dialogue_state() -> None:
     _assert_phrases(
         MOLD,


### PR DESCRIPTION
## Summary
- Accept clear affirmative responses when they directly answer an agent's extraction question.
- Keep unrelated or ambiguous approval from unlocking Curdle.
- Align the workflow invariant and add a contract test.

## Test plan
- just check
