### PR TITLE
refactor(ci): split the skill validator's exit surface and correct its prose

### DIFF
--- a/.github/scripts/test_validate_skills.py
+++ b/.github/scripts/test_validate_skills.py
@@ -61,6 +61,12 @@ class ValidateSkillsTest(unittest.TestCase):
             rc = validate_skills.main()
         return rc, out.getvalue(), err.getvalue()
 
+    def _run_argv(self, argv: list[str]) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = validate_skills.main(argv)
+        return rc, out.getvalue(), err.getvalue()
+
     def test_valid_skill_passes(self) -> None:
         self._write_skill("foo")
         rc, out, _ = self._run()
@@ -436,6 +442,91 @@ class ValidateSkillsTest(unittest.TestCase):
         self.assertIn("non-description frontmatter", err)
         self.assertIn("metadata", err)
         self.assertIn(f"{validate_skills.FRONTMATTER_EXTRA_MAX}-token cap", err)
+
+    # --- body-size goal report ---
+    def test_body_size_goal_report_shows_over_goal_row(self) -> None:
+        excess = 100
+        self._write(
+            "skills/foo/SKILL.md",
+            self._skill_text("foo", validate_skills.GOAL_TOKENS + excess),
+        )
+        rc, out, _ = self._run()
+        self.assertEqual(rc, 0)
+        self.assertIn("Body-size goal", out)
+        self.assertIn(f"skills/foo/SKILL.md: +{excess} over goal", out)
+
+    # --- shipped/repo-local split ---
+    def test_frontmatter_reporting_shipped_local_split_counts(self) -> None:
+        self._write_skill("foo")
+        self._write_skill("bar", parent=".agents/skills")
+        rc, out, _ = self._run()
+        self.assertEqual(rc, 0)
+        self.assertIn("(1 shipped + 1 repo-local under .agents/skills/)", out)
+
+    # --- --checks family selection ---
+
+    def test_checks_frontmatter_skips_size_violation(self) -> None:
+        over = validate_skills.TARGET_TOKENS + 1
+        self._write("skills/foo/SKILL.md", self._skill_text("foo", over))
+        rc, _, _ = self._run_argv(["--checks", "frontmatter"])
+        self.assertEqual(rc, 0)
+
+    def test_no_checks_flag_still_catches_size_violation(self) -> None:
+        over = validate_skills.TARGET_TOKENS + 1
+        self._write("skills/foo/SKILL.md", self._skill_text("foo", over))
+        rc, _, err = self._run_argv([])
+        self.assertEqual(rc, 1)
+        self.assertIn("exceeds budget", err)
+
+    def test_checks_frontmatter_still_catches_frontmatter_violation(self) -> None:
+        filler = "y" * (validate_skills.FRONTMATTER_EXTRA_MAX * 4 + 40)
+        self._write(
+            "skills/foo/SKILL.md",
+            f"---\nname: foo\ndescription: t\nmetadata:\n  x: {filler}\n---\n",
+        )
+        rc, _, err = self._run_argv(["--checks", "frontmatter"])
+        self.assertEqual(rc, 1)
+        self.assertIn("non-description frontmatter", err)
+
+    def test_checks_structure_ignores_size_violation(self) -> None:
+        over = validate_skills.TARGET_TOKENS + 1
+        self._write("skills/foo/SKILL.md", self._skill_text("foo", over))
+        rc, _, _ = self._run_argv(["--checks", "structure"])
+        self.assertEqual(rc, 0)
+
+    def test_checks_size_ignores_structure_violation(self) -> None:
+        self._write_skill("a")
+        self._write("skills/a/references/orphan.md", "nobody links here\n")
+        rc, _, _ = self._run_argv(["--checks", "size"])
+        self.assertEqual(rc, 0)
+
+    def test_narrowed_run_omits_report_blocks(self) -> None:
+        self._write_skill("foo")
+        rc, out, _ = self._run_argv(["--checks", "frontmatter"])
+        self.assertEqual(rc, 0)
+        self.assertIn("OK: validated 1 SKILL.md file(s)", out)
+        self.assertNotIn("Frontmatter tokens", out)
+        self.assertNotIn("Body-size goal", out)
+
+    def test_full_run_still_emits_report_blocks(self) -> None:
+        self._write_skill("foo")
+        rc, out, _ = self._run_argv([])
+        self.assertEqual(rc, 0)
+        self.assertIn("Frontmatter tokens", out)
+        self.assertIn("Body-size goal", out)
+
+    def test_checks_bogus_family_is_argparse_error(self) -> None:
+        self._write_skill("foo")
+        with redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit) as cm:
+                validate_skills.main(["--checks", "bogus"])
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_write_budgets_flag_via_argv(self) -> None:
+        self._write("skills/foo/SKILL.md", self._skill_text("foo", 6000))
+        rc, out, _ = self._run_argv(["--write-budgets"])
+        self.assertEqual(rc, 0)
+        self.assertIn("OK: wrote", out)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/validate_skills.py
+++ b/.github/scripts/validate_skills.py
@@ -2,6 +2,7 @@
 """Validate every SKILL.md in the repository. Exit 0 on success, 1 on any failure."""
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import sys
@@ -56,23 +57,30 @@ GOAL_TOKENS = 1800
 # Gated cap on everything in frontmatter that is NOT `description` --
 # description is separately bounded by DESCRIPTION_MAX_LEN (1024 chars =~
 # 256 tokens), so capping the remainder at 96 provably bounds total
-# frontmatter at ~320 tokens/skill from one constant, without a long
-# description competing with metadata/hooks for budget. Flat cap, not a
+# frontmatter at ~352 tokens/skill (256 + 96) from one constant, without a
+# long description competing with metadata/hooks for budget. Flat cap, not a
 # ratchet: no grandfathering, no allowlist.
 FRONTMATTER_EXTRA_MAX = 96
 
-# A reference file must not markdown-link to another path containing
-# "references/" — Anthropic's one-level-deep rule; a partial `head -100` read
-# silently misses the tail of a nested reference.
-NESTED_LINK_RE = re.compile(r"\]\(([^)]+)\)")
+# Any markdown link target, e.g. "](target)". The nested-hop decision --
+# which linked references/ targets count as a hidden second hop -- is made
+# in nested_reference_target, not by this regex.
+MARKDOWN_LINK_RE = re.compile(r"\]\(([^)]+)\)")
 
-# A path mention of the form "references/<basename>", markdown link or plain
-# backtick-quoted path, counts as "linked" for the orphan check.
+# Any textual occurrence of "references/<basename>" -- markdown link,
+# backtick-quoted path, or bare prose -- counts as "linked" for the orphan
+# and nested-reachability checks. Deliberately broad (ADR
+# skill-size-ratchet-003): a prose mention is treated as reachable too,
+# trading false negatives for zero false-positive orphan flags on files
+# that are legitimately referenced only in prose.
 REFERENCE_MENTION_RE = re.compile(r"references/([A-Za-z0-9_.\-]+)")
 
 
+CHECK_FAMILIES = ("frontmatter", "size", "structure")
+
+
 def _under_agents_skills(path: Path) -> bool:
-    """True for any path rooted at .agents/skills/ (any depth) — the narrow
+    """True for any path rooted at .agents/skills/ (any depth) -- the narrow
     allowance that lets repo-local skills opt into discovery despite the
     dot-prefix skip below; validate_path_shape still rejects the wrong depth.
     """
@@ -97,8 +105,7 @@ def validate_path_shape(path: Path) -> str | None:
     )
 
 
-def validate_frontmatter(path: Path) -> list[str]:
-    text = path.read_text(encoding="utf-8")
+def validate_frontmatter(path: Path, text: str) -> list[str]:
     match = FRONTMATTER_RE.match(text)
     if not match:
         return [f"{path}: missing or malformed YAML frontmatter (expected leading --- ... ---)"]
@@ -159,31 +166,38 @@ def validate_frontmatter(path: Path) -> list[str]:
 
 
 def estimate_tokens(body: str) -> int:
-    """len(body_bytes) // 4 — no tokenizer dependency, deliberately coarse."""
+    """len(body_bytes) // 4 -- no tokenizer dependency, deliberately coarse."""
     return len(body.encode("utf-8")) // 4
 
 
 def skill_body(text: str) -> str:
-    """Everything after the closing frontmatter '---'. Only description length
-    (DESCRIPTION_MAX_LEN) is capped separately; the rest of the frontmatter is not.
+    """Everything after the closing frontmatter '---', used for body-size
+    budgeting. Frontmatter itself is validated separately in
+    validate_frontmatter: description length via DESCRIPTION_MAX_LEN, the
+    rest via FRONTMATTER_EXTRA_MAX -- it is capped too, just not here.
     """
     match = FRONTMATTER_RE.match(text)
     return text[match.end():] if match else text
 
 
 def frontmatter_text(text: str) -> str:
-    r"""The raw '---\n...\n---' frontmatter block, reporting-only surface for
-    whole-frontmatter token estimates (never gated — frontmatter is excluded
-    from the size budget; this is a context-cost report only).
+    r"""The raw '---\n...\n---' frontmatter block. Used only by main()'s
+    reporting block for a whole-frontmatter token estimate -- never gated at
+    that call site. The identical block IS gated elsewhere, in
+    validate_frontmatter, via FRONTMATTER_EXTRA_MAX.
     """
     match = FRONTMATTER_RE.match(text)
     return match.group(0) if match else ""
 
 
+def body_tokens(text: str) -> int:
+    """Estimated token count of a SKILL.md body (everything after frontmatter)."""
+    return estimate_tokens(skill_body(text))
+
+
 def load_budgets() -> dict:
     if not BUDGET_FILE.exists():
         return {
-            "target": TARGET_TOKENS,
             "skills": {},
             "nested_references_allowlist": [],
             "orphaned_references_allowlist": [],
@@ -191,8 +205,7 @@ def load_budgets() -> dict:
     return json.loads(BUDGET_FILE.read_text(encoding="utf-8"))
 
 
-def validate_size(path: Path, budgets: dict) -> list[str]:
-    tokens = estimate_tokens(skill_body(path.read_text(encoding="utf-8")))
+def validate_size(path: Path, tokens: int, budgets: dict) -> list[str]:
     recorded = budgets.get("skills", {}).get(path.parent.name)
     grandfathered = recorded is not None and recorded > TARGET_TOKENS
     cap = recorded if grandfathered else TARGET_TOKENS
@@ -215,71 +228,90 @@ def validate_size(path: Path, budgets: dict) -> list[str]:
     ]
 
 
-def validate(path: Path, budgets: dict) -> list[str]:
-    shape_error = validate_path_shape(path)
-    if shape_error:
-        return [shape_error]
-    errors = validate_frontmatter(path)
-    errors.extend(validate_size(path, budgets))
+def validate(path: Path, text: str, budgets: dict, checks: frozenset[str]) -> list[str]:
+    errors: list[str] = []
+    if "frontmatter" in checks:
+        shape_error = validate_path_shape(path)
+        if shape_error:
+            errors.append(shape_error)
+        else:
+            errors.extend(validate_frontmatter(path, text))
+    if "size" in checks:
+        errors.extend(validate_size(path, body_tokens(text), budgets))
     return errors
 
 
+def skill_md_files() -> list[Path]:
+    """All skills/*/SKILL.md and .agents/skills/*/SKILL.md paths, sorted."""
+    return sorted(Path("skills").glob("*/SKILL.md")) + sorted(
+        Path(".agents/skills").glob("*/SKILL.md")
+    )
+
+
 def reference_files() -> list[Path]:
-    return sorted(p for p in Path("skills").glob("*/references/**/*") if p.is_file())
+    roots = (Path("skills"), Path(".agents/skills"))
+    return sorted(
+        p for root in roots for p in root.glob("*/references/**/*") if p.is_file()
+    )
 
 
-def has_nested_reference_link(path: Path, linked: set[str]) -> bool:
-    """True when this reference file links a references/ target whose basename
-    is NOT itself reachable (linked by basename) from any skills/*/SKILL.md.
-    A lateral link to a target that IS reachable is not a hidden second hop —
-    `linked` is the same reachability set the orphan check below uses, so both
-    structure checks share one definition of "reachable".
+def nested_reference_target(path: Path, linked: set[str]) -> str | None:
+    """The basename of the first references/ target linked from this file
+    whose basename is NOT itself reachable (linked by basename) from any
+    SKILL.md -- a hidden second hop, since reading this file alone would
+    miss it. None when no such link exists. A lateral link to a target that
+    IS reachable is not a hidden second hop -- `linked` is the same
+    reachability set the orphan check below uses, so both structure checks
+    share one definition of "reachable".
     """
     text = path.read_text(encoding="utf-8", errors="ignore")
-    for link in NESTED_LINK_RE.findall(text):
+    for link in MARKDOWN_LINK_RE.findall(text):
         target = link.split("#", 1)[0].split(" ", 1)[0].strip()
         if target.startswith("http"):
             continue
         if "references/" in target:
             basename = target.rsplit("/", 1)[-1]
             if basename not in linked:
-                return True
-    return False
+                return basename
+    return None
 
 
-def linked_reference_basenames() -> set[str]:
+def linked_reference_basenames(skill_texts: dict[Path, str]) -> set[str]:
+    """Basenames mentioned via REFERENCE_MENTION_RE in every canonically
+    located SKILL.md (skills/ or .agents/skills/) among skill_texts.
+    """
     basenames: set[str] = set()
-    for sf in sorted(Path("skills").glob("*/SKILL.md")):
-        text = sf.read_text(encoding="utf-8", errors="ignore")
-        basenames.update(REFERENCE_MENTION_RE.findall(text))
+    for path, text in skill_texts.items():
+        if validate_path_shape(path) is None:
+            basenames.update(REFERENCE_MENTION_RE.findall(text))
     return basenames
 
 
-def validate_structure(budgets: dict) -> list[str]:
+def validate_structure(budgets: dict, skill_texts: dict[Path, str]) -> list[str]:
     errors: list[str] = []
     nested_allow = set(budgets.get("nested_references_allowlist", []))
     orphan_allow = set(budgets.get("orphaned_references_allowlist", []))
     ref_files = reference_files()
-    linked = linked_reference_basenames()
+    linked = linked_reference_basenames(skill_texts)
 
     for rf in ref_files:
         rel = rf.as_posix()
-        if has_nested_reference_link(rf, linked) and rel not in nested_allow:
+        offending = nested_reference_target(rf, linked)
+        if offending is not None and rel not in nested_allow:
             errors.append(
-                f"{rel}: markdown-links to a path containing 'references/' — keep references "
-                f"one level deep from SKILL.md (a partial head -100 read silently misses the "
-                f"tail); move or inline the target, or add this path to "
+                f"{rel}: markdown-links to '{offending}', a references/ target not "
+                f"itself linked (by basename) from any SKILL.md -- a hidden second "
+                f"hop that reading {rf.name} alone would miss; keep references one "
+                f"level deep from SKILL.md. Link '{offending}' directly from a "
+                f"SKILL.md, or move/inline it into {rf.name}, or add this path to "
                 f"nested_references_allowlist in {BUDGET_FILE} if pre-existing"
             )
-
-    for rf in ref_files:
-        rel = rf.as_posix()
         if rf.name not in linked and rel not in orphan_allow:
             errors.append(
-                f"{rel}: not linked (by basename) from any SKILL.md in skills/ — orphaned "
-                f"reference file; link it from the owning or a consuming SKILL.md, delete it "
-                f"if unused, or add it to orphaned_references_allowlist in {BUDGET_FILE} if "
-                f"pre-existing"
+                f"{rel}: not linked (by basename) from any SKILL.md in skills/ or "
+                f".agents/skills/ -- orphaned reference file; link it from the "
+                f"owning or a consuming SKILL.md, delete it if unused, or add it to "
+                f"orphaned_references_allowlist in {BUDGET_FILE} if pre-existing"
             )
 
     return errors
@@ -287,21 +319,22 @@ def validate_structure(budgets: dict) -> list[str]:
 
 def compute_budgets() -> dict:
     prior = load_budgets().get("skills", {})
+    skill_texts = {sf: sf.read_text(encoding="utf-8") for sf in skill_md_files()}
+
     skills = {}
-    sources = sorted(Path("skills").glob("*/SKILL.md")) + sorted(
-        Path(".agents/skills").glob("*/SKILL.md")
-    )
-    for sf in sources:
+    for sf, text in skill_texts.items():
         name = sf.parent.name
-        measured = estimate_tokens(skill_body(sf.read_text(encoding="utf-8")))
+        measured = body_tokens(text)
         prior_recorded = prior.get(name)
         skills[name] = min(measured, prior_recorded) if prior_recorded is not None else measured
+
     ref_files = reference_files()
-    linked = linked_reference_basenames()
-    nested = sorted(rf.as_posix() for rf in ref_files if has_nested_reference_link(rf, linked))
+    linked = linked_reference_basenames(skill_texts)
+    nested = sorted(
+        rf.as_posix() for rf in ref_files if nested_reference_target(rf, linked) is not None
+    )
     orphaned = sorted(rf.as_posix() for rf in ref_files if rf.name not in linked)
     return {
-        "target": TARGET_TOKENS,
         "skills": skills,
         "nested_references_allowlist": nested,
         "orphaned_references_allowlist": orphaned,
@@ -314,15 +347,36 @@ def write_budgets() -> None:
     BUDGET_FILE.write_text(json.dumps(budgets, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def main() -> int:
+def _parse_checks(value: str) -> frozenset[str]:
+    requested = frozenset(v.strip() for v in value.split(","))
+    unknown = requested - set(CHECK_FAMILIES)
+    if unknown:
+        raise argparse.ArgumentTypeError(
+            f"unknown check family/families: {sorted(unknown)}; choose from {CHECK_FAMILIES}"
+        )
+    return requested
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--write-budgets", action="store_true")
+    parser.add_argument("--checks", type=_parse_checks, default=frozenset(CHECK_FAMILIES))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
     if not Path("skills").is_dir():
         print("ERROR: skills/ directory not found", file=sys.stderr)
         return 1
 
-    if len(sys.argv) > 1 and sys.argv[1] == "--write-budgets":
+    args = build_parser().parse_args(argv if argv is not None else [])
+
+    if args.write_budgets:
         write_budgets()
         print(f"OK: wrote {BUDGET_FILE}")
         return 0
+
+    checks = args.checks
 
     skill_files = sorted(
         p for p in Path().rglob("SKILL.md")
@@ -332,11 +386,14 @@ def main() -> int:
         print("ERROR: no SKILL.md files found in repository", file=sys.stderr)
         return 1
 
+    skill_texts = {sf: sf.read_text(encoding="utf-8") for sf in skill_files}
+
     budgets = load_budgets()
     all_errors: list[str] = []
     for sf in skill_files:
-        all_errors.extend(validate(sf, budgets))
-    all_errors.extend(validate_structure(budgets))
+        all_errors.extend(validate(sf, skill_texts[sf], budgets, checks))
+    if "structure" in checks:
+        all_errors.extend(validate_structure(budgets, skill_texts))
 
     if all_errors:
         for e in all_errors:
@@ -347,15 +404,19 @@ def main() -> int:
         )
         return 1
 
+    print(f"OK: validated {len(skill_files)} SKILL.md file(s)")
+
+    if checks != frozenset(CHECK_FAMILIES):
+        return 0
+
     frontmatter_rows = sorted(
-        (sf.as_posix(), estimate_tokens(frontmatter_text(sf.read_text(encoding="utf-8"))))
+        (sf.as_posix(), estimate_tokens(frontmatter_text(skill_texts[sf])))
         for sf in skill_files
     )
     aggregate = sum(tokens for _, tokens in frontmatter_rows)
     shipped_count = sum(1 for sf in skill_files if sf.parts[0] == "skills")
     local_count = len(skill_files) - shipped_count
 
-    print(f"OK: validated {len(skill_files)} SKILL.md file(s)")
     print(
         f"Frontmatter tokens (reporting only, not gated): aggregate {aggregate} "
         f"across {len(skill_files)} skill(s) ({shipped_count} shipped + {local_count} "
@@ -365,10 +426,7 @@ def main() -> int:
         print(f"  {rel}: {tokens}")
 
     goal_rows = sorted(
-        (
-            sf.as_posix(),
-            estimate_tokens(skill_body(sf.read_text(encoding="utf-8"))) - GOAL_TOKENS,
-        )
+        (sf.as_posix(), body_tokens(skill_texts[sf]) - GOAL_TOKENS)
         for sf in skill_files
     )
     meeting_goal = sum(1 for _, excess in goal_rows if excess <= 0)
@@ -377,7 +435,7 @@ def main() -> int:
         f"\nBody-size goal (reporting only, not gated; {GOAL_TOKENS} tokens approximates the "
         f"measured median body size of Anthropic's own shipped skills, not a published "
         f"Anthropic recommendation): {meeting_goal}/{len(skill_files)} skill(s) at or under "
-        f"goal today; aggregate excess {goal_excess_total} tokens — a direction-of-travel "
+        f"goal today; aggregate excess {goal_excess_total} tokens -- a direction-of-travel "
         f"number expected to shrink over time, not a failure count"
     )
     for rel, excess in goal_rows:
@@ -387,4 +445,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv[1:]))

--- a/.github/skill-budgets.json
+++ b/.github/skill-budgets.json
@@ -27,6 +27,5 @@
     "skill-authoring": 1817,
     "ultracook": 410,
     "wheypoint": 4570
-  },
-  "target": 3600
+  }
 }

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,6 +34,24 @@ jobs:
       - name: Validate SKILL.md frontmatter
         run: python3 .github/scripts/validate_skills.py
 
+  validate-frontmatter:
+    name: validate frontmatter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install PyYAML
+        run: pip install --no-cache-dir pyyaml==6.0.2
+
+      - name: Validate SKILL.md frontmatter
+        run: python3 .github/scripts/validate_skills.py --checks frontmatter
+
   test:
     name: test melt + shared + fan-out scripts
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #356. Two things: make frontmatter violations independently merge-blockable, and fix the prose that drifted from the code during that PR's iteration.

## Why the split

`validate_skills.py` was one script with one exit code, so adding `validate skills` to the branch ruleset's required checks would have made the **size ratchet** merge-blocking at the same time. That is not wanted yet — the size budget should stay visible-but-advisory while skills get trimmed toward the 1800 goal.

So `--checks` selects among three families — `frontmatter`, `size`, `structure` — defaulting to all three (today's behaviour, byte-for-byte). A new `validate frontmatter` CI job runs the frontmatter family alone and is intended to become a required status check.

The existing `validate skills` job is unchanged and still goes red on a size or structure violation. It is advisory *only* because it stays out of the required-check list, not because anything was softened.

Narrowed runs suppress the frontmatter-aggregate and body-size-goal reporting blocks, so the two jobs do not print ~40 duplicate lines per PR.

## Prose corrections

A review checked six comment/docstring/error sites against the code and found five had drifted, all from #356's own narrowing of the nested-reference rule:

| Site | Was | Now |
|---|---|---|
| Nested-ref CI error | Described the pre-narrowing rule; remedy list omitted the cheapest correct fix | Names the offending basename, leads with "link it from a SKILL.md" |
| `skill_body` docstring | "the rest of the frontmatter is not [capped]" | It is, via `FRONTMATTER_EXTRA_MAX` |
| `frontmatter_text` docstring | "never gated" | Scoped to this call site; the identical block *is* gated in `validate_frontmatter` |
| `FRONTMATTER_EXTRA_MAX` comment | "provably bounds total frontmatter at ~320 tokens" | 352 (`1024 // 4 + 96`) |
| `NESTED_LINK_RE` | Named and commented as a `references/` rule | Renamed `MARKDOWN_LINK_RE`; it is a generic markdown-link pattern, the hop decision lives in `nested_reference_target` |

To name the offending basename, `has_nested_reference_link` became `nested_reference_target() -> str | None`.

## Other changes

- **Read each SKILL.md once**, not four to five times (88 reads across 18 files per run). Body tokens were re-derived from disk in three places; now one `body_tokens` helper.
- **Structure checks now cover `.agents/skills/`.** Discovery and `compute_budgets` already did. Latent bug: a `skills/*/references/` file linked only from an `.agents/skills/*/SKILL.md` would have been reported orphaned and failed CI. Not currently triggered — no `.agents` SKILL.md mentions a reference path today.
- **Dropped `"target"` from `skill-budgets.json`** — written, never read, and would silently desync from `TARGET_TOKENS`.
- **Tests for the body-size goal report.** It had none: deleting the entire 19-line block left all 41 tests green. Suite goes 41 → 52.

## Verification

| Gate | Result |
|---|---|
| `python3 .github/scripts/test_validate_skills.py` | rc 0, 52 tests |
| `python3 .github/scripts/validate_skills.py` | rc 0, output shape unchanged |
| `python3 .github/scripts/validate_skills.py --checks frontmatter` | rc 0, OK line only, no report blocks |
| `--checks bogus` | rc 2 |
| `--write-budgets` | idempotent (md5 stable) |
| `ruff check .` / `markdownlint` / `yamllint` | rc 0 |
| `just check` | rc 0 |

Non-vacuity: neutering the family selection so `--checks frontmatter` runs everything turns 4 of the new tests red; restoring returns 52/52.

## Two review suggestions deliberately not taken

- **"Record budget pins only for skills over the ceiling."** Ten of eighteen pins cannot act as a cap today, true. But lowering `TARGET_TOKENS` later would then leave nothing to grandfather against and redden everything at once.
- **"Delete the empty `nested_references_allowlist`."** It is the escape hatch for a genuine hidden hop. Unused is not the same as dead.

## Follow-on, not in this PR

Adding `validate frontmatter` and `lint markdown, yaml, python` to the `main-protection` ruleset's `required_status_checks`. That is a repo-settings change and must happen **after** this merges — requiring a check whose job does not yet exist on `main` leaves unrelated PRs pending forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)