### PR TITLE
refactor(affinage): route detailed guidance into references

### DIFF
--- a/.github/skill-budgets.json
+++ b/.github/skill-budgets.json
@@ -9,7 +9,7 @@
     "skills/ultracook/references/wiring-prompt.md"
   ],
   "skills": {
-    "affinage": 7953,
+    "affinage": 3496,
     "age": 8736,
     "briesearch": 2064,
     "cheese": 5543,

--- a/skills/affinage/SKILL.md
+++ b/skills/affinage/SKILL.md
@@ -7,7 +7,7 @@ metadata: {dispatches-agents: true}
 
 # /affinage
 
-Use this skill when the user wants to act on external claims about a PR — review comments from humans or bots, plus failing CI checks and merge conflicts — and wants those claims graded through the same lens `/age` uses for fresh review, then handed to `/cure` for application.
+Act on external claims about a PR — review comments from humans or bots, plus failing CI checks and merge conflicts — grading them through the same lens `/age` uses for fresh review, then handing them to `/cure` for application.
 
 `/affinage` always refines the claims that already exist on the PR (comments, CI failures, conflicts). Whether it *also* generates fresh `/age` findings depends on how it was reached:
 
@@ -26,89 +26,51 @@ See `## Fresh-window review` for the detection rule and `## Merge-conflict resol
 
 Flags:
 
-- `--auto --stake <floor>` — autonomous mode. `<floor>` is `blocker`, `high`, `medium+`, or `all` (same semantics as `/cure`). Skips the selection gate, dispatches `/cure --auto --stake <floor>`, posts all replies without prompting.
-- `--safe` — also gate the cure-selection and merge-conflict-resolution steps (which otherwise run autonomously by default). Reply posting is **gated by default regardless of this flag** — only `--auto` posts without prompting. Use `--safe` when you also want to choose before anything is fixed or a conflict is resolved.
-- `--open-pr` — allow affinage's terminal `/plate` to open a *new* PR when none exists (otherwise plate only updates the already-open one).
-- `--plate` — one-shot publish combo, equivalent to `--auto --stake medium+ --open-pr`: autonomously triage, cure the recommended floor (medium-and-above plus cheap contained-fix lows), post every reply, then plate. Because it carries `--auto`, replies post without prompting. An explicit `--stake <floor>` overrides the `medium+` default.
-- `--hard` — propagated metacognitive-gate flag. `/affinage` does not fire the gate; passes `--hard` forward to its terminal `/plate` at publication.
+- `--auto --stake <floor>` — autonomous mode; `<floor>` (`blocker`, `high`, `medium+`, `all`) matches `/cure`'s semantics. Skips selection, dispatches `/cure --auto --stake <floor>`, posts replies without prompting. Mechanics: `references/auto-mode.md`.
+- `--safe` — also gates cure-selection and merge-conflict resolution (autonomous by default). Reply posting is **gated by default regardless** — only `--auto` skips it.
+- `--open-pr` — let terminal `/plate` open a *new* PR when none exists (else it only updates the open one).
+- `--plate` — one-shot publish combo = `--auto --stake medium+ --open-pr`: triage, cure the recommended floor, post every reply, then plate. An explicit `--stake <floor>` overrides `medium+`.
+- `--hard` — propagated metacognitive-gate flag; forwarded to terminal `/plate`, not fired here.
 - `--full` — un-collapses `## Low` when ≥10 low-severity findings exist (mirrors `/age --full`).
-- `--include-outdated` — include outdated review threads. Default skips them.
-- `--no-age` — skip the standalone fresh `/age` pass. No effect when chained (the pass is already skipped). Use when you only want to triage existing comments, CI failures, and conflicts.
+- `--include-outdated` — include outdated review threads (default: skip).
+- `--no-age` — skip the standalone fresh `/age` pass; no effect when chained.
 
 Portability reference: [`../cheese/references/harness-portability.md`](../cheese/references/harness-portability.md). It covers helper resolution, sub-agent dispatch, GitHub operations, and handoff transitions; prefer the bundled or repo-local helper first, and treat `${CLAUDE_SKILL_DIR}` as optional host-provided fallback.
 The handoff blocks below are the portable contract; slash commands are host renderings, not the control model.
 
 ## Flow
 
-1. **Resolve PR.** From `<pr-ref>` or `gh pr view --json number` on the current branch. Resolve `<owner>/<repo>` from the git remote.
-2. **Fetch PR status.** Call `python3 skills/affinage/scripts/affinage.pyz pr-status <pr>`. The script returns JSON with build status, per-check failure summaries (last ~10 lines of failed logs + parsed failed-test names), and merge state. Map the exit code:
-   - **Exit 0** — proceed with grading.
-   - **Exit 3** (`logs-expired`) — the build is failing but every failing check's log was unfetchable (typically expired GitHub Actions logs past the retention window), so there is nothing to ground a CI finding on. Write `status: halt: pr-status-logs-expired` and stop with the hint: *"CI is failing but the logs have expired — rerun the failed jobs (`gh run rerun <run-id> --failed`, where `<run-id>` is the `/actions/runs/<id>/` segment of the failing check's `url`, or read it from `gh pr checks`) and re-invoke `/affinage`."*
-   - **Any other non-zero** (1 PR/gh API error, 2 missing gh binary) — write `status: halt: pr-status-unavailable` and stop.
-   - **Merge conflicts.** If `merge.mergeable` is `CONFLICTING` or `merge.state` is `DIRTY`, the PR has unresolved conflicts. Resolve them before grading — see `## Merge-conflict resolution`.
-3. **Fresh-window review.** If this is a standalone run and `--no-age` was not passed: compute the PR diff's `review_surface` score via the `review-surface` CLI (source: `src/fanout/review_surface_cli.py`, wrapping `src/fanout/review_surface.py::score()`) over the diff's git numstat rows. Run it through the `.pyz` bundle — the direct script imports `cli`/`git_utils` from `shared/scripts/`, which are only co-staged flat inside the bundle, so running it directly fails with `ModuleNotFoundError: No module named 'cli'`: `python3 skills/affinage/scripts/affinage.pyz review-surface --repo . <base>...HEAD` — the range must be the PR's full diff against its base branch (after `gh pr checkout <pr>`, `origin/<base>...HEAD`), never the CLI's bare `HEAD` default, which scores only the uncommitted delta. Grep the diff's **added lines outside `skills/**` and `.hallouminate/**`** for `age_route.OVERRIDE_FLAGS` risk flags — a missed token means no promoted lens, not a missing security lens — and call `age_route.route(score=<float>, risk_flags=[...], entry="affinage", comments=<unresolved-thread-count>, ci_class=<"failing"|"red"|"flaky"|None from pr-status>)` — the same router `/age` itself calls, but sized with affinage's comment count and CI failure class so a heavily-commented or red-CI PR gets the bigger fan-out even on a small diff. If the host only ships the bundle, `echo '{"score": <float>, "risk_flags": [...], "entry": "affinage", "comments": <n>, "ci_class": <"failing"|"red"|"flaky"|null>}' | python3 skills/affinage/scripts/affinage.pyz age-route` is the fallback for the router call (JSON on stdin, route JSON on stdout). Pass the returned `n`/`lenses`/`effort` into the `/age` dispatch (so `/age` uses affinage's sizing rather than recomputing from `entry="age"` defaults) and treat each finding as an additional input. See `## Fresh-window review`.
-4. **Fetch comments.**
-   - Inline threads: `gh api repos/<owner>/<repo>/pulls/<pr>/comments`. This REST endpoint returns individual review comments without thread-level resolution state, so the skill cannot filter on `isResolved` from this surface; it skips comments whose `position` is `null` (the diff has moved past the anchored line) unless `--include-outdated`.
-   - Review bodies: `gh api repos/<owner>/<repo>/pulls/<pr>/reviews`. Filter to non-empty bodies. Dedupe against inline comments via `pull_request_review_id`.
-5. **Skip already-replied threads.** A thread whose most recent comment is from the resolved GitHub handle (see §Rules) has already been responded to; skip it. The same resolved handle is rendered in the reply footer as `agent on behalf of <handle>`.
-6. **Grade through the age lens.** For each input (comment, CI/build failure, OR fresh `/age` finding):
-   - Classify dimension from the **code + claim** (or check type + failure summary, for CI items). See `../age/references/dimensions.md` for the dimension rubric.
-   - **Build failures count, not just test failures.** A failing check is a finding whether the failure is a compile error, a lint/type-check failure, or a failing test — grade the `build.status: failing` checks from `affinage.pyz pr-status` and route them to `/cure` exactly like test failures. Tag CI-sourced items `[from-check:<job>]`.
-   - **Fresh `/age` findings** (standalone runs) arrive already dimension-classified and severity-scored; fold them into the buckets below tagged `[from-age:<dimension>]`. Dedupe against comment-sourced items echoing the same defect — keep the comment-sourced one (it carries a reviewer to reply to).
-   - Compute severity from base + location + compounding modifiers (same rubric as `/age`).
-   - **Ignore reviewer-asserted urgency for severity computation.** Surface `CHANGES_REQUESTED` as metadata (`reviewer-asserted:` line) but do not let it modify computed severity.
-   - Bucket into:
-     - Standard severity sections (`## Blocker / ## High / ## Medium / ## Low`) when the claim is grounded in the diff and its fix is **contained** (`fix-cost-now: contained` — roughly a few lines or a localized refactor). Every such item still maps to a dimension and carries a `[<dimension>:<severity>]` tag — a style or quality nit maps to `deslop` (e.g. `[deslop:low]`). The new rule is to route these grounded, contained-fix nits to `/cure` (usually as `Low`) instead of `## Reviewer-rejected`, keeping the `[from-comment:<id>]` tag so `/cure`'s reply still reaches the reviewer; a valid cheap nit is cheaper to fix than to argue, so do not push back on it.
-     - `## Needs-investigation` when the claim is plausible but requires evidence outside the diff (e.g., downstream caller in another repo).
-     - `## Reviewer-rejected` only when the claim is **wrong or ungrounded** (the code is already correct, the reviewer misread it, or there is no real improvement) OR is valid but **a lot of follow-up work** (`fix-cost-now: moderate`/`sprawling` or `fix-cost-later: structural` — a refactor or scope expansion beyond this PR). Reject the wrong ones; defer the expensive ones.
-7. **Write report** to `.cheese/affinage/pr-<n>.md` with the four-line handoff slug at the top, then the age-format body plus the two extra sections. See `## Output` below.
+Exact CLI invocations, exit-code hints, and grading rationale for steps 2, 3, 6, and 9 below: `references/flow-details.md`.
+
+1. **Resolve PR.** From `<pr-ref>` or `gh pr view --json number`; resolve `<owner>/<repo>` from the git remote.
+2. **Fetch PR status.** `affinage.pyz pr-status <pr>`. Exit 3 halts `status: halt: pr-status-logs-expired`; any other non-zero halts `status: halt: pr-status-unavailable`. Conflicting/dirty merge state routes to `## Merge-conflict resolution` before grading. Exit-code detail: `references/flow-details.md`.
+3. **Fresh-window review.** Standalone and `--no-age` not passed: score the PR diff, route it through `age_route.route(...)` sized with affinage's comment count and CI failure class, run `/age` with the returned `n`/`lenses`/`effort`, and fold each finding tagged `[from-age:<dimension>]`. See `## Fresh-window review`.
+4. **Fetch comments.** Inline threads: `gh api repos/<owner>/<repo>/pulls/<pr>/comments` (REST; no thread-resolution state, so skip `position: null` comments unless `--include-outdated`). Review bodies: `gh api repos/<owner>/<repo>/pulls/<pr>/reviews`, filtered to non-empty bodies, deduped against inline comments via `pull_request_review_id`.
+5. **Skip already-replied threads.** A thread last-commented by the resolved GitHub handle (§Rules) is already answered — skip it; the footer renders as `agent on behalf of <handle>`.
+6. **Grade through the age lens.** Classify each input (comment, CI failure, or fresh `/age` finding) by dimension — code/claim, or check type/failure for CI — per `../age/references/dimensions.md`, and by severity (base + location + compounding, same rubric as `/age`); ignore reviewer-asserted urgency (`CHANGES_REQUESTED` is metadata, never a severity bump). Bucket into severity sections (contained fixes), `## Needs-investigation` (needs out-of-diff evidence), or `## Reviewer-rejected` (wrong/ungrounded, or a lot of follow-up work). Full bucketing criteria: `references/flow-details.md`.
+7. **Write report** to `.cheese/affinage/pr-<n>.md`: four-line handoff slug, then the age-format body plus two extra sections. See `## Output`.
 8. **Act or ask** — per §Handoff.
-9. **Draft non-cure replies, then gate before posting** (runs whenever grading produced these items, with or without `/cure`). **Never post blind** — posting requires the reply-approval gate (§Handoff) by default, or `--auto`. Draft each reply, then post approved ones via `python3 skills/affinage/scripts/affinage.pyz post-reply`:
-   - **Reviewer-rejected items** → the pre-drafted push-back text from the affinage report.
-   - **Needs-investigation items** → do NOT post a bare acknowledgement. The reply must (a) name the specific evidence that would settle the claim — the regression test, throwaway prototype, or out-of-diff file to read — and (b) state that a follow-up will report the result. Before posting, **offer to run that investigation now**: a regression test via `/pasteurize`, or explore the out-of-diff evidence via `/briesearch`. If run, post a reply carrying the actual outcome; if the user declines, post the explicit `"Needs <named test/exploration> to confirm — will follow up with the result."` note — never a blind "investigating".
-   - **CI-sourced findings** (`from-check:<job>` tag) and **fresh-review findings** (`from-age:<dimension>` tag) → no reply (no reviewer to notify).
-
-10. **Post-cure reply posting** (only when `/cure` ran). The chained `/cure` applies its fixes and runs its `/age --scope` loop but returns **without plating** (it owns no publication in the `/affinage` chain). When `/cure` returns, read `.cheese/cure/pr-<n>.md`'s `### Applied` / `### Deferred` sections and post per-finding replies via `python3 skills/affinage/scripts/affinage.pyz post-reply`:
-    - **Applied** (with `from-comment:<id>` tag) → `"Fixed — <applied summary>."`
-    - **Deferred** (with `from-comment:<id>` tag) → `"Attempted fix reverted — <reason>."`
-
-11. **Plate** — the final writes above (steps 9–10) must land before publication. Once every approved reply is posted, and only when the cure applied ≥1 fix (there is something to publish), dispatch terminal `/plate [--open-pr] [--hard] [--safe]` to commit and publish cure's fixes to the PR. `/affinage` owns this dispatch; publication lands after all replies. After publication lands, run the **§ Post-PR learnings write-back** (`../cure/SKILL.md` § Handoff) — affinage owns terminal `/plate`, so it owns the write-back the chained `/cure` suppressed. Skip plate and write-back when no fix was applied — there is nothing to publish.
+9. **Draft non-cure replies, then gate before posting** (whenever grading produced these items, with or without `/cure`). Never post blind — requires the reply-approval gate (§Handoff), or `--auto`. Draft per `references/flow-details.md`; post approved ones via `affinage.pyz post-reply`. CI-sourced (`from-check:<job>`) and fresh-review (`from-age:<dimension>`) findings get no reply.
+10. **Post-cure reply posting** (only when `/cure` ran). Once `/cure` returns, read `.cheese/cure/pr-<n>.md`'s `### Applied`/`### Deferred` and post per-finding replies via `affinage.pyz post-reply`: **Applied** (`from-comment:<id>`) → `"Fixed — <applied summary>."`; **Deferred** (`from-comment:<id>`) → `"Attempted fix reverted — <reason>."`
+11. **Plate** — once every approved reply is posted (steps 9–10) and the cure applied ≥1 fix, dispatch terminal `/plate [--open-pr] [--hard] [--safe]`; publication lands after every reply. After it lands, run the **§ Post-PR learnings write-back** (`../cure/SKILL.md` § Handoff) — affinage owns the write-back the chained `/cure` suppressed. Skip plate and write-back when no fix was applied.
 
 ## Fresh-window review
 
-Detection: standalone = no upstream `handoff_context`; chained = a `handoff_context` with `source_skill: /cook` or `/cure`. Behaviour:
+Standalone runs (see intro) compute the `entry="affinage"` router call (Flow step 3) and run `/age <pr-ref>` over the PR diff, passing the router's `n`/`lenses`/`effort` so `/age` doesn't recompute a smaller `entry="age"` sizing from the diff alone. Fold each returned finding into the report's severity sections tagged `[from-age:<dimension>]` — they flow to `/cure` like any other finding but get no GitHub reply (no reviewer to notify, same as `[from-check:…]` items).
 
-- **Standalone** (and `--no-age` not passed): compute the `entry="affinage"` router call (Flow step 3) and run `/age <pr-ref>` over the PR diff, passing the router's `n`/`lenses`/`effort` so `/age` doesn't recompute a smaller `entry="age"` sizing from the diff alone. Fold each returned finding into the affinage report's severity sections tagged `[from-age:<dimension>]`. They flow to `/cure` with every other selected finding and get **no** GitHub reply — there is no reviewer to notify, same as `[from-check:…]` items.
-- **Chained**, or `--no-age`: skip the pass. Re-running `/age` on an already-reviewed diff double-grades.
-
-Run the fresh `/age` before grading external claims so a comment that merely echoes an `/age` finding can be deduped. To keep the parent context lean, run the pass under the same sub-agent gate as grading (`## Sub-agent context gate`).
+Run the fresh pass before grading external claims so an echoing comment can be deduped, under the same sub-agent gate as grading (`## Sub-agent context gate`) to keep the parent context lean.
 
 ## Merge-conflict resolution
 
-When `affinage.pyz pr-status` reports `merge.mergeable: CONFLICTING` or `merge.state: DIRTY`, the PR cannot merge until conflicts are resolved. `/affinage` does not resolve conflicts by hand — it routes to `/melt`, which runs the structural cascade (mergiraf → rerere → kdiff3).
-
-1. Materialise the conflicts locally: `gh pr checkout <pr>`, then `git merge origin/<base>`. (`gh pr checkout` neither opens nor updates the PR, so it does not breach the no-`/gh` rule.)
-2. Hand off to `/melt`. It first checks for squash-merge residue and stops with remedies if found — surface those verbatim and do not auto-apply.
-3. After `/melt` resolves cleanly, the resolution commit is owned by `/melt` / `/cure`. `/plate` owns the verified commit and existing-PR update transaction.
-
-- **Default and `--auto` mode**: run the checkout + `/melt` automatically before dispatching `/cure`, then re-run `affinage.pyz pr-status` to confirm `mergeable` cleared. If `/melt` cannot resolve (manual kdiff3 needed, or squash residue), write `status: halt: merge-conflicts-need-human` and stop.
-- **`--safe` mode**: gate the checkout + `/melt` behind the handoff prompt — offer "Resolve merge conflicts" alongside the cure-selection options.
+When `pr-status` reports unresolved conflicts, `/affinage` routes to `/melt` (mergiraf → rerere → kdiff3) rather than resolving by hand. Default/`--auto` run checkout + `/melt` automatically before `/cure`; `--safe` gates it behind the handoff prompt. If `/melt` cannot resolve, write `status: halt: merge-conflicts-need-human` and stop. Full steps: `references/merge-conflict.md`.
 
 ## Sub-agent context gate
 
-`/affinage` keeps dialogue, selection, approval state, and reply posting in the parent context. When the parent context would balloon, resolve a fresh read-only `reviewer` through the shared agent resolver. A compatible reviewer is preferred; a general worker qualifies only with prompt-only no-write enforcement and `degraded: true`:
-
-- Total input count (comments + CI failures) exceeds 10.
-- Diff exceeds ~25 KB.
-- Threads span more than 5 files.
-
-The sub-agent returns a digest: graded findings table with dimension, severity, confidence, grounded-evidence cite, and pre-drafted push-back text for any `Reviewer-rejected` items. The parent owns the report write, selection gate, `/cure` dispatch, and reply posting.
-
-Digest size, parent-vs-sub-agent split, and harness-agnostic sub-agent selection live in `../age/references/sub-agent-gate.md`.
+`/affinage` keeps dialogue, selection, approval state, and reply posting in the parent context. When the parent context would balloon — inputs exceed 10, diff exceeds ~25 KB, or threads span more than 5 files — resolve a fresh read-only `reviewer` through the shared agent resolver (a general worker qualifies only with `degraded: true`). The sub-agent returns a digest of graded findings (dimension, severity, confidence, evidence cite, pre-drafted push-back for `Reviewer-rejected` items); the parent owns the report write, selection gate, `/cure` dispatch, and reply posting. Digest size and selection detail: `../age/references/sub-agent-gate.md`.
 
 ## Preferred tools and fallbacks
 
-Call source-code search and read backends directly according to the shared [`code-intelligence-routing.md`](../cheese/references/code-intelligence-routing.md) contract. Beyond source-code routing there are affinage-specific tools:
+Call source-code search/read backends per [`code-intelligence-routing.md`](../cheese/references/code-intelligence-routing.md). Affinage-specific tools:
 
 | Need | Prefer | Fallback |
 | --- | --- | --- |
@@ -119,168 +81,53 @@ Call source-code search and read backends directly according to the shared [`cod
 
 ## Output
 
-Write to `.cheese/affinage/pr-<n>.md` with the four-line handoff slug at the top, then the age-style body with two extra sections:
+Write to `.cheese/affinage/pr-<n>.md`: the four-line handoff slug, then the age-style body plus two extra sections (`## PR status` and the same severity / `## Needs-investigation` / `## Reviewer-rejected` shape `/age` uses). Full annotated template: `references/report-template.md`.
 
 ```markdown
 status: ok | halt: <one-line reason>
 next: cure | done
 artifact: <path-to-prior-cure-or-press-report-if-any>
 <one-line orientation: what the PR does and what was graded>
-
-# Affinage Report — PR #<n>
-
-## Orientation
-<one or two factual sentences about the PR and what was graded>
-
-## PR status
-- Build: passing | failing (N jobs)
-- Merge: clean | conflicts (resolved via /melt | needs human)
-- Comments: K unresolved (M skipped as outdated)
-- Fresh review: ran /age (N findings) | skipped (chained) | skipped (--no-age)
-
-## Blocker
-- **[from-comment:<id>] [security:blocker]** alice on `src/auth.ts:42` — token parsed without validation.
-  - location: contract · fix-cost-now: contained · fix-cost-later: structural · confidence: certain
-  - reviewer-asserted: changes-requested
-  - recommendation: validate `authorization` header; reject with 401 on missing.
-- **[from-check:test-suite] [correctness:blocker]** CI job `test-suite` — 3 tests failing in `tests/auth.test.ts`.
-  - location: contract · fix-cost-now: contained · fix-cost-later: structural · confidence: certain
-  - recommendation: re-run after fixing the missing null check.
-- **[from-check:build] [correctness:blocker]** CI job `build` — `tsc` fails: `src/auth.ts:42: 'token' is possibly undefined`.
-  - location: contract · fix-cost-now: contained · fix-cost-later: structural · confidence: certain
-  - recommendation: narrow `token` before use; build is red until this compiles.
-- **[from-age:efficiency] [efficiency:high]** fresh review — `src/api/users.ts:88` re-fetches the user inside the loop body.
-  - location: hot path · fix-cost-now: contained · fix-cost-later: contained · confidence: speculating
-  - recommendation: hoist the fetch above the loop.
-
-## High
-... (same shape)
-
-## Medium
-... (same shape)
-
-## Low
-- **[from-comment:<id>] [deslop:low]** copilot on `src/utils/format.ts:18` — rename `data` to `lineItems` for clarity.
-  - location: class · fix-cost-now: contained · fix-cost-later: contained · confidence: certain
-  - recommendation: rename `data` → `lineItems`. Valid cheap nit — fixed via `/cure`, not pushed back.
-... (same shape; collapsible per --full rules)
-
-## Needs-investigation
-- **[from-comment:<id>]** bob on `src/api/users.ts:108` — "might break analytics pipeline."
-  - reason: claim plausible but pipeline lives in a different repo; diff cannot confirm.
-  - suggested action: human reads `analytics-svc/consumers/users.ts`.
-
-## Reviewer-rejected
-- **[from-comment:<id>]** copilot on `src/auth.ts:30` — "missing `await`; this promise is unhandled."
-  - reason: wrong — `parseToken` is synchronous (returns `string`, not a `Promise`, see `src/auth.ts:12`); there is nothing to await.
-  - draft reply: "`parseToken` is synchronous here (returns `string`, `src/auth.ts:12`), so there's no promise to await. Leaving as-is."
-- **[from-comment:<id>]** dana on `src/api/users.ts:60` — "extract this into a generic repository layer."
-  - reason: valid but large — fix-cost-now: sprawling (6 files across 2 slices); scope expansion beyond this PR.
-  - draft reply: "Agreed this would be cleaner, but it's a cross-slice refactor beyond this PR's scope — filing a follow-up rather than growing this change."
-
-## Confidence
-<certain | speculating | don't know> — <one-line justification>
-
-## Next step
-Auto-fixing the recommended set via `/cure`; drafted replies are held for the reply-approval gate before posting (`--auto` posts directly). Replies post before terminal `/plate` publishes cure's fixes. On a reason to ask / `--safe`, the cure-selection prompt renders inline — pick findings to cure or `none` to stop.
 ```
 
-Empty severity sections are omitted entirely. `## Needs-investigation` and `## Reviewer-rejected` are omitted when no items land there.
-
-Per-finding `confidence:` uses the voice-kernel scale (`../age/references/voice.md` § Reasoning posture): `certain` — the defect is verified by direct evidence (diff/code read, command output); `speculating` — inferred from indirect signal. A `don't know` grading never ships as a severity row — route it to `## Needs-investigation`.
-
-`status: ok` when grading completed; `status: halt: <reason>` when `gh` or `pr-status.py` failed in a way that blocks honest grading. `next:` is set per §Handoff — `cure` when ≥1 finding meets the `medium+` floor; `done` otherwise.
+Empty severity sections are omitted; so are `## Needs-investigation`/`## Reviewer-rejected` when empty. `status: ok` when grading completed; `halt: <reason>` when `gh`/`pr-status` failed. `next:` per `## Handoff` § Slug `next:` values.
 
 ## Handoff
 
 **Pipeline:** culture → mold → cook → press → age → cure → plate · `/affinage` is parallel to `/age` and feeds `/cure`.
 
-After the report lands, affinage acts by default and asks only on a genuine reason (a sprawling/structural fix in the recommended set, conflicting findings) or under `--safe` (Flow step 8). What it acts on depends on whether any severity-section finding exists.
+Default: affinage acts without asking, and asks only for a genuine reason (a sprawling/structural fix in the recommended set, conflicting findings) or under `--safe` (Flow step 8).
 
-**When at least one severity-section finding exists (any severity, including `Low`)** — compute the recommended composite (`all-medium, cheap`). With no reason to ask and no `--safe`: announce the one-line selection, dispatch `/cure` (below), then render the **reply-approval gate** before posting the non-cure replies (Flow step 9) and the cure-dependent replies (step 10) — never post blind. `--auto` posts without the gate (§Auto mode). On a reason to ask or `--safe`: render the cure-selection table inline (per `../cure/references/selection.md`) and ask via `../cheese/references/handoff-gate.md`, pre-selecting the recommended composite and flagging heavy rows. Lead with the recommended composite, then present the four severity-floor options below it, in the same most-inclusive-to-least order, so the gate is predictable across every run:
+- **Severity-section findings exist (any severity, including `Low`)** — compute the recommended composite (`all-medium, cheap`). No reason to ask and no `--safe`: announce the selection, dispatch `/cure` with the locked `handoff_context` (shape: `references/handoff-templates.md` § Cure dispatch context), then render the **reply-approval gate** before posting (Flow steps 9–10) — never post blind. A reason to ask, or `--safe`: render the **cure-selection gate** per `../cheese/references/handoff-gate.md` instead, pre-selecting the composite and flagging heavy rows. `--auto` skips both gates (`## Auto mode`).
+- **No severity-section findings, but `Reviewer-rejected`/`Needs-investigation` items exist** — nothing for `/cure` to act on; render the reply-approval gate and post nothing until chosen. Only `--auto` skips it.
 
-- The five severity-floor options (recommended `all-medium, cheap`, then `all`, `all-medium`, `all-high`, `all-blocker`) are exactly age's — see [`../age/SKILL.md`](../age/SKILL.md) § Selection gate for their labels and semantics.
+After the selection, post approved replies (Flow step 9–10), then — only when the cure applied ≥1 fix — dispatch terminal `/plate [--open-pr] [--hard] [--safe]` (Flow step 11); publication lands after every reply. Exit `status: ok / next: done` when there is nothing to act on.
 
-Then offer the non-floor options last:
-
-- **Pick findings to fix** — free-text reply using `/age`/`/cure` verbs (`1,3,5`, `all-blocker`, `all-medium`, `all-high`, `cheap`, `all`, `none`, `skip N`).
-- **Resolve merge conflicts** *(offered only when the PR has conflicts)* — checkout + `/melt` per `## Merge-conflict resolution`, then re-render this gate.
-- **Stop — leave the report for later** — equivalent to `none`.
-
-The "present all four severity options on every run, empty-set-resolves-to-`none`" rule is age's — see [`../age/SKILL.md`](../age/SKILL.md) § Selection gate.
-
-**When no severity-section finding exists but `Reviewer-rejected` or `Needs-investigation` has items** — `/cure` has nothing to act on, so skip it. Posting is gated by default; render the **reply-approval gate** (below) and post nothing until the user chooses. Only `--auto` posts without this gate.
-
-**Reply-approval gate** — the single gate both Handoff branches use before any `post-reply` call:
-
-- **Post pushbacks only** *(recommended)* — post `Reviewer-rejected` drafts; hold `Needs-investigation` items for investigation.
-- **Investigate now, then post** — for each `Needs-investigation` item, run the follow-up investigation (`/pasteurize` for a regression test, `/briesearch` to explore the out-of-diff evidence), then post a reply carrying the actual result.
-- **Post all** — post every drafted push-back and the explicit `Needs-investigation` follow-up notes (naming the needed evidence) without running the investigation first.
-- **Skip posting** — leave the report for later; post nothing.
-- **Per-finding** — free-text pick of which drafts to post or investigate.
-
-After the selection, post the approved replies via Flow step 9. Then — only when the cure applied ≥1 fix — dispatch terminal `/plate` (Flow step 11) so publication follows the replies; when no cure ran or no fix applied, there is nothing to plate. Exit with `status: ok / next: done` — see `## Auto mode` § "no findings meet the floor" for the auto path.
-
-**Slug `next:` values.** Write `next: cure` when at least one finding meets the `medium+` floor (medium-or-above, or a cheap contained-fix low). Write `next: done` when no severity-section finding exists or all meeting items are empty-selection after floor resolution.
-
-On a non-empty cure selection (auto-selected by default or chosen at the gate), immediately dispatch `/cure <slug> [--safe] [--open-pr] [--hard]` with locked context:
-
-```yaml
-handoff_context:
-  source_skill: /affinage
-  source_report: .cheese/affinage/pr-<n>.md
-  selection: "<verb or explicit ids>"
-  resolved_ids: [<expanded ids>]
-```
-
-`/cure` re-confirms cited ids and goes straight to apply. Because the handoff carries `source_skill: /affinage`, `/cure` applies its fixes and runs its `/age --scope` loop but **suppresses its own terminal `/plate`** and returns — affinage owns publication. Propagate `--safe`, `--open-pr`, and `--hard` to `/cure` when in scope. On return, `/affinage` posts every reply (Flow steps 9–10) — its terminal final writes — and only then dispatches terminal `/plate [--open-pr] [--hard] [--safe]` (Flow step 11), so publication lands after every reply. Skip the plate dispatch when the cure applied no fix.
+**Slug `next:` values.** `cure` when ≥1 finding meets the `medium+` floor; `done` when no severity-section finding exists or all meeting items resolve to an empty selection.
 
 ## Auto mode
 
-When invoked with `--auto --stake <floor>` (or `--plate`, which enters this mode with `--stake medium+ --open-pr`):
-
-- Skip the selection gate.
-- If the PR has merge conflicts, resolve them via `/melt` first (see `## Merge-conflict resolution`). If `/melt` cannot resolve, halt with `status: halt: merge-conflicts-need-human` before any `/cure` dispatch.
-- If standalone (and `--no-age` not passed), run the fresh `/age` pass so `[from-age:…]` findings join the floor-based auto-selection.
-- Auto-select every finding (comment-sourced, CI-sourced, OR fresh-`/age`-sourced) that meets the floor — severity at or above the floor, plus cheap contained-fix lows when the floor is `medium+` (same floor semantics as `/cure`).
-- Dispatch `/cure --auto --stake <floor>`.
-- After `/cure --auto` and its downstream `/age --scope --auto` chain settle, post replies for the originally graded items only. Do NOT re-grade for findings discovered by `/age --scope`.
-- Reviewer-rejected items: post the pre-drafted push-back.
-- Needs-investigation items: post the explicit follow-up note naming the evidence that would settle the claim (`"Needs <named test/prototype> to confirm — will follow up with the result."`). Auto mode does not pause to run the spike; it posts the honest follow-up note, never a blind acknowledgement.
-- After the cure chain settles and **all** replies are posted (previous two bullets), `/affinage` dispatches terminal `/plate --open-pr [--hard]` to publish cure's fixes — the final writes precede publication. `/cure` suppresses its own terminal `/plate` for the `/affinage` chain (keyed on `source_skill: /affinage`). Skip the dispatch when no fix was applied.
-
-The whole cure chain (cure → `/age --scope --auto` → up to the two-cure-pass cap) must run in the parent affinage context so the post-cure reply step still has the original graded findings (slug, ids, `from-comment:<id>` tags, drafted push-back text) in memory. Spawning the cure chain in a sub-agent breaks reply posting — do not.
-
-If no findings meet the floor, skip the `/cure` dispatch, post replies for `Reviewer-rejected` + `Needs-investigation` items only, and exit with `status: ok / next: done`.
+Skips the selection gate. Resolves merge conflicts via `/melt` first (halt `status: halt: merge-conflicts-need-human` if unresolved). If standalone, runs the fresh `/age` pass. Auto-selects every finding meeting `<floor>` (`--plate` enters this mode at `--stake medium+ --open-pr`) and dispatches `/cure --auto --stake <floor>`; once its chain settles, posts replies for the originally graded items only, then dispatches terminal `/plate --open-pr [--hard]` once every reply posts (skipped if no fix applied). If no findings meet the floor: skip `/cure`, post rejection/investigation replies only, exit `status: ok / next: done`. Full mechanics: `references/auto-mode.md`.
 
 ## --hard mode
 
-`/affinage` passes `--hard` to its own terminal `/plate` (dispatched after replies), which fires `/hard-cheese` after verifying the final artifact state. `/cure` does not dispatch plate in the `/affinage` chain, so the gate fires once — at affinage's publication boundary.
+`/affinage` passes `--hard` to its terminal `/plate`, which fires `/hard-cheese` after verifying the final artifact state. `/cure` never dispatches plate in this chain, so the gate fires once — at affinage's publication boundary.
 
 ## Rules
 
-- Grading is code-grounded, not reviewer-asserted. `CHANGES_REQUESTED` is metadata, not a severity bump.
-- Prefer fixing over pushing back. A valid, grounded nit whose fix is contained (`fix-cost-now: contained` — a few lines or a localized refactor) goes to `/cure` as a `Low` finding tagged `[from-comment:<id>]`; do not draft a push-back for it. Reserve `## Reviewer-rejected` for claims that are wrong/ungrounded or whose fix is a lot of work (`moderate`/`sprawling`/`structural`). See `../age/references/voice.md`.
-- Never auto-apply fixes from `/affinage` itself. Code fixes go through `/cure`; merge conflicts go through `/melt`.
-- Never post a GitHub reply without approval. Reply posting is gated by default (§Handoff reply-approval gate); only `--auto` posts autonomously. A `Needs-investigation` reply must name the follow-up test or exploration and offer to run it (`/pasteurize` or `/briesearch`) before posting — never a blind acknowledgement.
-- Fresh `/age` runs only on standalone invocations (no upstream `handoff_context`) and only when `--no-age` is absent. Chained runs never re-review the diff.
-- Merge conflicts are resolved through `/melt`, not by hand. `gh pr checkout` to materialise conflicts is allowed — it neither opens nor updates the PR. After resolution, affinage's terminal `/plate` owns the verified commit and push.
-- `/affinage` owns terminal publication. The chained `/cure` suppresses its own `/plate` (keyed on `source_skill: /affinage`); after a clean cure, `/affinage` posts every reply and *then* dispatches `/plate` to update the existing PR — or, with `--open-pr`, apply the explicit-choice and review-shape policy before publishing a new PR. Replies always precede plate: no final write lands after publication.
+- Grading is code-grounded, not reviewer-asserted — see Flow step 6.
+- Prefer fixing over pushing back. A grounded nit with a contained fix goes to `/cure` as `Low`; reserve `## Reviewer-rejected` for claims that are wrong, ungrounded, or a lot of work (Flow step 6, `../age/references/voice.md`).
+- Never auto-apply fixes itself — code fixes go through `/cure`, merge conflicts through `/melt` (`## Merge-conflict resolution`).
+- Never post a reply without approval — see the reply-approval gate (`## Handoff`, `references/handoff-templates.md`).
 - Every posted reply ends with the literal `agent on behalf of <handle>` attribution via `skills/affinage/scripts/affinage.pyz post-reply`, where `<handle>` is resolved from `RESPOND_GH_HANDLE` → `gh api user --jq .login` → `git config user.name`. Never call `gh api` directly to post.
-- Idempotent re-runs: skip threads where the latest comment is from the resolved handle. The REST `/comments` endpoint does not expose thread resolution, so honest idempotency relies on the latest-comment-from-self heuristic; switch to GraphQL `reviewThreads` if cross-session resolution-state visibility becomes required.
-- CI-sourced findings get no reply (no reviewer to notify).
+- Idempotent re-runs rely on the latest-comment-from-self heuristic (Flow step 5) — the REST `/comments` endpoint exposes no thread resolution state; use GraphQL `reviewThreads` if cross-session resolution state is ever needed.
 - Apply the shared voice kernel (`../age/references/voice.md`): name confidence as `certain | speculating | don't know`; agree when no findings warrant grading.
 
 ## References
 
-- `skills/age/SKILL.md` — review pipeline, dimensions, sub-agent gate, report shape.
-- `../age/references/dimensions.md` — per-dimension rubrics and severity computation.
-- `skills/cure/SKILL.md` — apply pipeline, `--auto --stake` floors, handoff context shape.
-- `../cure/references/selection.md` — selection verbs and composition.
-- `skills/melt/SKILL.md` — merge-conflict resolution cascade (mergiraf → rerere → kdiff3).
-- `../cheese/references/handoff-gate.md` — gate primitives.
-- `python3 skills/affinage/scripts/affinage.pyz post-reply` — reply posting with `agent on behalf of <handle>` attribution.
-- `python3 skills/affinage/scripts/affinage.pyz pr-status` — PR status fetcher.
+Affinage-local, each also routed inline above: `references/flow-details.md`, `references/merge-conflict.md`, `references/report-template.md`, `references/handoff-templates.md`, `references/auto-mode.md`. `references/sub-agent-gate.md` is `../age/references/sub-agent-gate.md` (shared, not affinage-local).
+
+Scripts: `skills/affinage/scripts/affinage.pyz post-reply` (reply posting), `pr-status` (PR status fetcher).
 
 ## Agent resolution
 

--- a/skills/affinage/references/auto-mode.md
+++ b/skills/affinage/references/auto-mode.md
@@ -1,0 +1,17 @@
+# Auto mode — full mechanics
+
+Read this when running (or dispatching) `/affinage --auto --stake <floor>` (or `--plate`, which enters this mode with `--stake medium+ --open-pr`). The body's `## Auto mode` states the decision spine; this is the full step detail.
+
+- Skip the selection gate.
+- If the PR has merge conflicts, resolve them via `/melt` first (see `merge-conflict.md`). If `/melt` cannot resolve, halt with `status: halt: merge-conflicts-need-human` before any `/cure` dispatch.
+- If standalone (and `--no-age` not passed), run the fresh `/age` pass so `[from-age:…]` findings join the floor-based auto-selection.
+- Auto-select every finding (comment-sourced, CI-sourced, OR fresh-`/age`-sourced) that meets the floor — severity at or above the floor, plus cheap contained-fix lows when the floor is `medium+` (same floor semantics as `/cure`).
+- Dispatch `/cure --auto --stake <floor>`.
+- After `/cure --auto` and its downstream `/age --scope --auto` chain settle, post replies for the originally graded items only. Do NOT re-grade for findings discovered by `/age --scope`.
+- Reviewer-rejected items: post the pre-drafted push-back.
+- Needs-investigation items: post the explicit follow-up note naming the evidence that would settle the claim (`"Needs <named test/prototype> to confirm — will follow up with the result."`). Auto mode does not pause to run the spike; it posts the honest follow-up note, never a blind acknowledgement.
+- After the cure chain settles and **all** replies are posted (previous two bullets), `/affinage` dispatches terminal `/plate --open-pr [--hard]` to publish cure's fixes — the final writes precede publication. `/cure` suppresses its own terminal `/plate` for the `/affinage` chain (keyed on `source_skill: /affinage`). Skip the dispatch when no fix was applied.
+
+The whole cure chain (cure → `/age --scope --auto` → up to the two-cure-pass cap) must run in the parent affinage context so the post-cure reply step still has the original graded findings (slug, ids, `from-comment:<id>` tags, drafted push-back text) in memory. Spawning the cure chain in a sub-agent breaks reply posting — do not.
+
+If no findings meet the floor, skip the `/cure` dispatch, post replies for `Reviewer-rejected` + `Needs-investigation` items only, and exit with `status: ok / next: done`.

--- a/skills/affinage/references/flow-details.md
+++ b/skills/affinage/references/flow-details.md
@@ -1,0 +1,31 @@
+# Flow — full command and rationale detail
+
+Read this when executing `## Flow` steps 2, 3, 6, or 9 — the exact CLI invocations, exit-code hints, and bucketing rationale the body's numbered list summarizes.
+
+## Step 2 — Fetch PR status
+
+Call `python3 skills/affinage/scripts/affinage.pyz pr-status <pr>`. The script returns JSON with build status, per-check failure summaries (last ~10 lines of failed logs + parsed failed-test names), and merge state.
+
+- **Exit 3** (`logs-expired`) — the build is failing but every failing check's log was unfetchable (typically expired GitHub Actions logs past the retention window), so there is nothing to ground a CI finding on. Write `status: halt: pr-status-logs-expired` and stop with the hint: *"CI is failing but the logs have expired — rerun the failed jobs (`gh run rerun <run-id> --failed`, where `<run-id>` is the `/actions/runs/<id>/` segment of the failing check's `url`, or read it from `gh pr checks`) and re-invoke `/affinage`."*
+- **Any other non-zero** (1 PR/gh API error, 2 missing gh binary) — write `status: halt: pr-status-unavailable` and stop.
+
+## Step 3 — Fresh-window review
+
+Compute the PR diff's `review_surface` score via the `review-surface` CLI (source: `src/fanout/review_surface_cli.py`, wrapping `src/fanout/review_surface.py::score()`) over the diff's git numstat rows. Run it through the `.pyz` bundle — the direct script imports `cli`/`git_utils` from `shared/scripts/`, which are only co-staged flat inside the bundle, so running it directly fails with `ModuleNotFoundError: No module named 'cli'`: `python3 skills/affinage/scripts/affinage.pyz review-surface --repo . <base>...HEAD` — the range must be the PR's full diff against its base branch (after `gh pr checkout <pr>`, `origin/<base>...HEAD`), never the CLI's bare `HEAD` default, which scores only the uncommitted delta. Grep the diff's **added lines outside `skills/**` and `.hallouminate/**`** for `age_route.OVERRIDE_FLAGS` risk flags — a missed token means no promoted lens, not a missing security lens — and call `age_route.route(score=<float>, risk_flags=[...], entry="affinage", comments=<unresolved-thread-count>, ci_class=<"failing"|"red"|"flaky"|None from pr-status>)` — the same router `/age` itself calls, but sized with affinage's comment count and CI failure class so a heavily-commented or red-CI PR gets the bigger fan-out even on a small diff. If the host only ships the bundle, `echo '{"score": <float>, "risk_flags": [...], "entry": "affinage", "comments": <n>, "ci_class": <"failing"|"red"|"flaky"|null>}' | python3 skills/affinage/scripts/affinage.pyz age-route` is the fallback for the router call (JSON on stdin, route JSON on stdout). Pass the returned `n`/`lenses`/`effort` into the `/age` dispatch (so `/age` uses affinage's sizing rather than recomputing from `entry="age"` defaults) and treat each finding as an additional input.
+
+## Step 6 — Grading rationale
+
+- **Build failures count, not just test failures.** A failing check is a finding whether the failure is a compile error, a lint/type-check failure, or a failing test — grade the `build.status: failing` checks from `affinage.pyz pr-status` and route them to `/cure` exactly like test failures. Tag CI-sourced items `[from-check:<job>]`.
+- **Fresh `/age` findings** (standalone runs) arrive already dimension-classified and severity-scored; fold them into the buckets tagged `[from-age:<dimension>]`. Dedupe against comment-sourced items echoing the same defect — keep the comment-sourced one (it carries a reviewer to reply to).
+- **Ignore reviewer-asserted urgency for severity computation.** Surface `CHANGES_REQUESTED` as metadata (`reviewer-asserted:` line) but do not let it modify computed severity.
+- Bucket into:
+  - Standard severity sections (`## Blocker / ## High / ## Medium / ## Low`) when the claim is grounded in the diff and its fix is **contained** (`fix-cost-now: contained` — roughly a few lines or a localized refactor). Every such item still maps to a dimension and carries a `[<dimension>:<severity>]` tag — a style or quality nit maps to `deslop` (e.g. `[deslop:low]`). The rule is to route these grounded, contained-fix nits to `/cure` (usually as `Low`) instead of `## Reviewer-rejected`, keeping the `[from-comment:<id>]` tag so `/cure`'s reply still reaches the reviewer; a valid cheap nit is cheaper to fix than to argue, so do not push back on it.
+  - `## Needs-investigation` when the claim is plausible but requires evidence outside the diff (e.g., downstream caller in another repo).
+  - `## Reviewer-rejected` only when the claim is **wrong or ungrounded** (the code is already correct, the reviewer misread it, or there is no real improvement) OR is valid but **a lot of follow-up work** (`fix-cost-now: moderate`/`sprawling` or `fix-cost-later: structural` — a refactor or scope expansion beyond this PR). Reject the wrong ones; defer the expensive ones.
+
+## Step 9 — Reply drafting rules
+
+Post each approved reply with `python3 skills/affinage/scripts/affinage.pyz post-reply` — never a direct `gh api` call, which would bypass the `agent on behalf of <handle>` attribution.
+- **Reviewer-rejected items** → the pre-drafted push-back text from the affinage report.
+- **Needs-investigation items** → do NOT post a bare acknowledgement. The reply must (a) name the specific evidence that would settle the claim — the regression test, throwaway prototype, or out-of-diff file to read — and (b) state that a follow-up will report the result. Before posting, **offer to run that investigation now**: a regression test via `/pasteurize`, or explore the out-of-diff evidence via `/briesearch`. If run, post a reply carrying the actual outcome; if the user declines, post the explicit `"Needs <named test/exploration> to confirm — will follow up with the result."` note — never a blind "investigating".
+- **CI-sourced findings** (`from-check:<job>` tag) and **fresh-review findings** (`from-age:<dimension>` tag) → no reply (no reviewer to notify).

--- a/skills/affinage/references/handoff-templates.md
+++ b/skills/affinage/references/handoff-templates.md
@@ -1,0 +1,41 @@
+# Handoff gate templates
+
+Read this when rendering either handoff gate `SKILL.md` § Handoff describes — the exact option wording for the cure-selection gate and the reply-approval gate.
+
+## Cure-selection gate
+
+Lead with the recommended composite, then present the four severity-floor options below it, in the same most-inclusive-to-least order, so the gate is predictable across every run:
+
+- The five severity-floor options (recommended `all-medium, cheap`, then `all`, `all-medium`, `all-high`, `all-blocker`) are exactly age's — see [`../../age/SKILL.md`](../../age/SKILL.md) § Selection gate for their labels and semantics.
+
+Then offer the non-floor options last:
+
+- **Pick findings to fix** — free-text reply using `/age`/`/cure` verbs (`1,3,5`, `all-blocker`, `all-medium`, `all-high`, `cheap`, `all`, `none`, `skip N`).
+- **Resolve merge conflicts** *(offered only when the PR has conflicts)* — checkout + `/melt` per `merge-conflict.md`, then re-render this gate.
+- **Stop — leave the report for later** — equivalent to `none`.
+
+The "present all four severity options on every run, empty-set-resolves-to-`none`" rule is age's — see [`../../age/SKILL.md`](../../age/SKILL.md) § Selection gate.
+
+## Reply-approval gate
+
+The single gate both Handoff branches use before any `post-reply` call:
+
+- **Post pushbacks only** *(recommended)* — post `Reviewer-rejected` drafts; hold `Needs-investigation` items for investigation.
+- **Investigate now, then post** — for each `Needs-investigation` item, run the follow-up investigation (`/pasteurize` for a regression test, `/briesearch` to explore the out-of-diff evidence), then post a reply carrying the actual result.
+- **Post all** — post every drafted push-back and the explicit `Needs-investigation` follow-up notes (naming the needed evidence) without running the investigation first.
+- **Skip posting** — leave the report for later; post nothing.
+- **Per-finding** — free-text pick of which drafts to post or investigate.
+
+## Cure dispatch context
+
+On a non-empty cure selection (auto-selected by default or chosen at the gate), immediately dispatch `/cure <slug> [--safe] [--open-pr] [--hard]` with locked context:
+
+```yaml
+handoff_context:
+  source_skill: /affinage
+  source_report: .cheese/affinage/pr-<n>.md
+  selection: "<verb or explicit ids>"
+  resolved_ids: [<expanded ids>]
+```
+
+`/cure` re-confirms cited ids and goes straight to apply. Because the handoff carries `source_skill: /affinage`, `/cure` applies its fixes and runs its `/age --scope` loop but **suppresses its own terminal `/plate`** and returns — affinage owns publication. Propagate `--safe`, `--open-pr`, and `--hard` to `/cure` when in scope.

--- a/skills/affinage/references/merge-conflict.md
+++ b/skills/affinage/references/merge-conflict.md
@@ -1,0 +1,10 @@
+# Merge-conflict resolution
+
+When `affinage.pyz pr-status` reports `merge.mergeable: CONFLICTING` or `merge.state: DIRTY`, the PR cannot merge until conflicts are resolved. `/affinage` does not resolve conflicts by hand — it routes to `/melt`, which runs the structural cascade (mergiraf → rerere → kdiff3).
+
+1. Materialise the conflicts locally: `gh pr checkout <pr>`, then `git merge origin/<base>`. (`gh pr checkout` neither opens nor updates the PR, so it does not breach the no-`/gh` rule.)
+2. Hand off to `/melt`. It first checks for squash-merge residue and stops with remedies if found — surface those verbatim and do not auto-apply.
+3. After `/melt` resolves cleanly, the resolution commit is owned by `/melt` / `/cure`. `/plate` owns the verified commit and existing-PR update transaction.
+
+- **Default and `--auto` mode**: run the checkout + `/melt` automatically before dispatching `/cure`, then re-run `affinage.pyz pr-status` to confirm `mergeable` cleared. If `/melt` cannot resolve (manual kdiff3 needed, or squash residue), write `status: halt: merge-conflicts-need-human` and stop.
+- **`--safe` mode**: gate the checkout + `/melt` behind the handoff prompt — offer "Resolve merge conflicts" alongside the cure-selection options.

--- a/skills/affinage/references/report-template.md
+++ b/skills/affinage/references/report-template.md
@@ -1,0 +1,66 @@
+# Affinage report — full annotated template
+
+Read this when writing `.cheese/affinage/pr-<n>.md` — the worked example for every section below the four-line handoff slug (which stays in `SKILL.md` § Output, since downstream skills parse it directly).
+
+```markdown
+# Affinage Report — PR #<n>
+
+## Orientation
+<one or two factual sentences about the PR and what was graded>
+
+## PR status
+- Build: passing | failing (N jobs)
+- Merge: clean | conflicts (resolved via /melt | needs human)
+- Comments: K unresolved (M skipped as outdated)
+- Fresh review: ran /age (N findings) | skipped (chained) | skipped (--no-age)
+
+## Blocker
+- **[from-comment:<id>] [security:blocker]** alice on `src/auth.ts:42` — token parsed without validation.
+  - location: contract · fix-cost-now: contained · fix-cost-later: structural · confidence: certain
+  - reviewer-asserted: changes-requested
+  - recommendation: validate `authorization` header; reject with 401 on missing.
+- **[from-check:test-suite] [correctness:blocker]** CI job `test-suite` — 3 tests failing in `tests/auth.test.ts`.
+  - location: contract · fix-cost-now: contained · fix-cost-later: structural · confidence: certain
+  - recommendation: re-run after fixing the missing null check.
+- **[from-check:build] [correctness:blocker]** CI job `build` — `tsc` fails: `src/auth.ts:42: 'token' is possibly undefined`.
+  - location: contract · fix-cost-now: contained · fix-cost-later: structural · confidence: certain
+  - recommendation: narrow `token` before use; build is red until this compiles.
+- **[from-age:efficiency] [efficiency:high]** fresh review — `src/api/users.ts:88` re-fetches the user inside the loop body.
+  - location: hot path · fix-cost-now: contained · fix-cost-later: contained · confidence: speculating
+  - recommendation: hoist the fetch above the loop.
+
+## High
+... (same shape)
+
+## Medium
+... (same shape)
+
+## Low
+- **[from-comment:<id>] [deslop:low]** copilot on `src/utils/format.ts:18` — rename `data` to `lineItems` for clarity.
+  - location: class · fix-cost-now: contained · fix-cost-later: contained · confidence: certain
+  - recommendation: rename `data` → `lineItems`. Valid cheap nit — fixed via `/cure`, not pushed back.
+... (same shape; collapsible per --full rules)
+
+## Needs-investigation
+- **[from-comment:<id>]** bob on `src/api/users.ts:108` — "might break analytics pipeline."
+  - reason: claim plausible but pipeline lives in a different repo; diff cannot confirm.
+  - suggested action: human reads `analytics-svc/consumers/users.ts`.
+
+## Reviewer-rejected
+- **[from-comment:<id>]** copilot on `src/auth.ts:30` — "missing `await`; this promise is unhandled."
+  - reason: wrong — `parseToken` is synchronous (returns `string`, not a `Promise`, see `src/auth.ts:12`); there is nothing to await.
+  - draft reply: "`parseToken` is synchronous here (returns `string`, `src/auth.ts:12`), so there's no promise to await. Leaving as-is."
+- **[from-comment:<id>]** dana on `src/api/users.ts:60` — "extract this into a generic repository layer."
+  - reason: valid but large — fix-cost-now: sprawling (6 files across 2 slices); scope expansion beyond this PR.
+  - draft reply: "Agreed this would be cleaner, but it's a cross-slice refactor beyond this PR's scope — filing a follow-up rather than growing this change."
+
+## Confidence
+<certain | speculating | don't know> — <one-line justification>
+
+## Next step
+Auto-fixing the recommended set via `/cure`; drafted replies are held for the reply-approval gate before posting (`--auto` posts directly). Replies post before terminal `/plate` publishes cure's fixes. On a reason to ask / `--safe`, the cure-selection prompt renders inline — pick findings to cure or `none` to stop.
+```
+
+Empty severity sections are omitted entirely. `## Needs-investigation` and `## Reviewer-rejected` are omitted when no items land there.
+
+Per-finding `confidence:` uses the voice-kernel scale (`../age/references/voice.md` § Reasoning posture): `certain` — the defect is verified by direct evidence (diff/code read, command output); `speculating` — inferred from indirect signal. A `don't know` grading never ships as a severity row — route it to `## Needs-investigation`.

--- a/tests/python/test_baseline_consumer_docs.py
+++ b/tests/python/test_baseline_consumer_docs.py
@@ -24,11 +24,26 @@ CONSUMERS = (
     "skills/wheypoint/SKILL.md",
 )
 
-SETTLED_STATE_MARKERS = ("re-flag", "re-halt", "re-ask", "raise a finding")
+SETTLED_STATE_MARKERS = ("re-flag", "re-halt", "re-ask", "raise a finding", "trigger a halt")
 
 
 def read(rel_path: str) -> str:
     return (REPO_ROOT / rel_path).read_text()
+
+
+def _corpus(rel_path: str) -> str:
+    """A skill's SKILL.md plus its references/*.md, concatenated.
+
+    Prose that used to live in SKILL.md has been trimmed out into routed
+    references/*.md files; consumer-doc checks must read the whole skill
+    corpus, not just SKILL.md, or they false-negative on content that moved.
+    """
+    skill_path = REPO_ROOT / rel_path
+    parts = [read(rel_path)]
+    refs_dir = skill_path.parent / "references"
+    if refs_dir.is_dir():
+        parts += [p.read_text() for p in sorted(refs_dir.glob("*.md"))]
+    return "\n".join(parts)
 
 
 def test_quality_gates_policy_doc_exists() -> None:
@@ -40,20 +55,40 @@ def test_quality_gates_policy_doc_exists() -> None:
 SCHEMA_CONSUMERS = tuple(c for c in CONSUMERS if c != "skills/cheese/SKILL.md")
 
 
-def _handoff_schema_fence(body: str) -> str:
-    """Return the first ```markdown fenced block (the handoff-slug schema)."""
+def _handoff_schema_fence(rel_path: str) -> str:
+    """Return the ```markdown fence carrying the handoff-slug schema.
+
+    Searches the skill's whole corpus (SKILL.md + references/*.md) for the
+    fence containing `status: ok` -- the schema itself, not just the first
+    ```markdown fence in SKILL.md, which may be an unrelated worked example
+    once the schema has been routed out to a references file.
+    """
+    skill_path = REPO_ROOT / rel_path
+    candidates = [skill_path] + sorted((skill_path.parent / "references").glob("*.md"))
     marker = "```markdown"
-    start = body.index(marker) + len(marker)
-    end = body.index("```", start)
-    return body[start:end]
+    for path in candidates:
+        if not path.is_file():
+            continue
+        body = path.read_text()
+        pos = 0
+        while True:
+            idx = body.find(marker, pos)
+            if idx == -1:
+                break
+            start = idx + len(marker)
+            end = body.index("```", start)
+            fence = body[start:end]
+            if "status: ok" in fence:
+                return fence
+            pos = end + 3
+    raise AssertionError(f"no ```markdown fence containing 'status: ok' found for {rel_path}")
 
 
 @pytest.mark.parametrize("rel_path", SCHEMA_CONSUMERS)
 def test_consumer_handoff_schema_carries_baseline_field(rel_path: str) -> None:
     # cheese/SKILL.md has no handoff-slug schema (router doc, prose-only
     # baseline mention) so it is excluded from SCHEMA_CONSUMERS above.
-    body = read(rel_path)
-    schema_fence = _handoff_schema_fence(body)
+    schema_fence = _handoff_schema_fence(rel_path)
     assert any(
         line.strip().startswith("baseline: none |") for line in schema_fence.splitlines()
     ), f"{rel_path} handoff-slug schema fence must carry a `baseline: none |` sentinel line"
@@ -61,7 +96,7 @@ def test_consumer_handoff_schema_carries_baseline_field(rel_path: str) -> None:
 
 @pytest.mark.parametrize("rel_path", CONSUMERS)
 def test_consumer_states_settled_state_rule(rel_path: str) -> None:
-    body = read(rel_path)
+    body = _corpus(rel_path)
     assert any(marker in body for marker in SETTLED_STATE_MARKERS), (
         f"{rel_path} must state the no-re-flag/no-re-halt settled-state rule"
     )

--- a/tests/python/test_docs_emphasis_guard.py
+++ b/tests/python/test_docs_emphasis_guard.py
@@ -140,7 +140,12 @@ def test_harness_portability_reference_is_linked_from_workflow_docs():
     }
 
     for path, snippets in portable_examples.items():
+        # A skill's portable invocations may live in the SKILL.md body or in any
+        # of its routed references/ files -- the body is token-budgeted, so
+        # worked command examples legitimately sit one hop out.
         text = path.read_text(encoding="utf-8")
+        for ref in sorted((path.parent / "references").glob("*.md")):
+            text += ref.read_text(encoding="utf-8")
         for snippet in snippets:
             assert snippet in text, path
 

--- a/tests/python/test_fanout_sizing_docs.py
+++ b/tests/python/test_fanout_sizing_docs.py
@@ -28,6 +28,7 @@ DECOMPOSER_DOC = ROOT / "skills" / "cheese" / "references" / "decomposer.md"
 PACKET_DOC = ROOT / "skills" / "age" / "references" / "packet.md"
 MODE_PY = ROOT / "src" / "fanout" / "mode.py"
 CURD_BLOCK_PY = ROOT / "src" / "fanout" / "curd_block.py"
+AFFINAGE_FLOW_DETAILS_DOC = ROOT / "skills" / "affinage" / "references" / "flow-details.md"
 
 WIKI_AGE_ROUTER = ROOT / ".hallouminate" / "wiki" / "architecture" / "age-fanout-router.md"
 WIKI_ADR_001 = ROOT / ".hallouminate" / "wiki" / "adr" / "deterministic-fanout-sizing-001.md"
@@ -123,9 +124,9 @@ class TestAgeLadder:
 
 class TestAffinageRouteCall:
     def test_affinage_route_call_passes_score_kwarg(self) -> None:
-        text = read(AFFINAGE_SKILL)
+        text = read(AFFINAGE_FLOW_DETAILS_DOC)
         assert re.search(r"route\(\s*score\s*=", text), (
-            "affinage/SKILL.md's route call does not pass score="
+            "affinage/references/flow-details.md's route call does not pass score="
         )
 
 

--- a/tests/python/test_transport_audit.py
+++ b/tests/python/test_transport_audit.py
@@ -113,6 +113,12 @@ EXEMPT_SITES: list[tuple[str, str, str]] = [
         "not this pass",
     ),
     (
+        "skills/affinage/references/handoff-templates.md",
+        "Read this when rendering either handoff gate",
+        "internal mechanism note for the gates affinage/SKILL.md already "
+        "routes through handoff-gate.md; not a transport site itself",
+    ),
+    (
         "skills/cheese/references/optional-plugins.md",
         "Do not ask the user to install the MCP during the run.",
         "negative instruction, not a question-asking site",

--- a/tests/python/test_ultracook_skills.py
+++ b/tests/python/test_ultracook_skills.py
@@ -27,6 +27,21 @@ def _skill(name: str) -> str:
     return _read(SKILLS_DIR / name / "SKILL.md")
 
 
+def _skill_corpus(name: str) -> str:
+    """SKILL.md body plus every skills/<name>/references/*.md file, concatenated.
+
+    Sub-protocol prose that moved out of SKILL.md during the token-budget
+    trim still lives in the routed reference files; tests asserting on that
+    prose must search the corpus, not just the trimmed body.
+    """
+    body = _skill(name)
+    refs_dir = SKILLS_DIR / name / "references"
+    if refs_dir.is_dir():
+        for ref_path in sorted(refs_dir.glob("*.md")):
+            body += "\n" + _read(ref_path)
+    return body
+
+
 HANDOFF_SCHEMA_FIELDS = ("status:", "next:", "artifact:")
 
 
@@ -103,7 +118,7 @@ class TestUltracookPhaseChain:
     format to reappear."""
 
     def test_lists_seven_phases_in_order(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         # Single-coder auto chain: press -> age -> cure -> scoped re-verify
         # age, capped at two cure passes, terminal next: done.
         auto_idx = body.find("## Auto mode")
@@ -130,7 +145,7 @@ class TestUltracookPhaseChain:
         assert "press → age → cure → age" in fan_section
 
     def test_propagates_auto_through_every_phase(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         for invocation in (
             "/press <slug> --auto",
             "/age <slug> --auto",
@@ -176,7 +191,7 @@ class TestUltracookHandoffSchema:
         assert "next:" in body and "done" in body
 
     def test_paths_are_under_dot_cheese_phase_slug(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         # Each phase's handoff lives at a predictable path; the orchestrator
         # has to know where to read after spawning.
         for phase in ("cook", "press", "age", "cure"):
@@ -190,7 +205,7 @@ class TestUltracookExistingHandoffsGuard:
     /cook's Fan pathway, under its own `### Existing handoffs guard`."""
 
     def test_refuses_to_wipe_existing_handoffs(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         # If handoffs already exist for the slug, cook stops and points
         # the user at /cheese --continue or a manual rm. No flag-driven wipe.
         assert "/cheese --continue" in body
@@ -276,7 +291,7 @@ def _mold_high_blast_handoff_menu() -> str:
     assertions target this branch's own text, not unrelated prose elsewhere
     in the skill that happens to mention "fresh" and "context" separately.
     """
-    body = _skill("mold")
+    body = _skill_corpus("mold")
     start = body.index("**Non-decomposable, high-blast-radius specs")
     end = body.index("**Non-decomposable, low- or medium-blast-radius specs", start)
     return body[start:end]
@@ -295,7 +310,7 @@ class TestMoldHighBlastHandoff:
         )
 
     def test_offers_continue_flow(self) -> None:
-        body = _skill("mold")
+        body = _skill_corpus("mold")
         assert "/cheese --continue" in body, (
             "mold's handoff must offer the /cheese --continue compaction path"
         )
@@ -313,7 +328,7 @@ def _mold_low_medium_handoff_menu() -> str:
     so assertions target the menu options themselves, not the surrounding
     prose (which also references /cook --auto).
     """
-    body = _skill("mold")
+    body = _skill_corpus("mold")
     start = body.index("**Non-decomposable, low- or medium-blast-radius specs")
     end = body.index("The internal `mode` signal", start)
     return body[start:end]
@@ -373,7 +388,7 @@ class TestCheeseContinueFlag:
         assert ".cheese/" in body and "<slug>" in body
 
     def test_parallel_mode_dispatches_multiple_tasks(self) -> None:
-        body = _skill("cheese")
+        body = _skill_corpus("cheese")
         body_lower = body.lower()
         assert "mode: parallel" in body, (
             "cheese --continue must document the parallel continuation mode"
@@ -389,7 +404,7 @@ class TestCheeseContinueFlag:
         )
 
     def test_parallel_write_tasks_require_checkout_isolation(self) -> None:
-        body = _skill("cheese")
+        body = _skill_corpus("cheese")
         body_lower = body.lower()
         assert "worktree_strategy" in body, (
             "parallel continuation must define how write tasks get separate checkouts"
@@ -621,7 +636,7 @@ def test_phase_handoff_documents_artifact_field(skill_name: str) -> None:
     this one locks down `artifact:` so a future edit cannot silently shrink
     the schema and break the orchestrator's halt-and-surface contract.
     """
-    body = _skill(skill_name)
+    body = _skill_corpus(skill_name)
     assert "artifact:" in body, (
         f"{skill_name} handoff schema must document the `artifact:` field"
     )
@@ -634,7 +649,7 @@ class TestUltracookReadsSlugFile:
     """
 
     def test_rule_present_in_skill_md(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         # Acceptable phrasings: "read the file", "read each phase's
         # handoff slug", or any explicit instruction not to infer from
         # stdout. Match on the substantive prohibition.
@@ -720,7 +735,7 @@ class TestCheeseContinueScansNotes:
     that resumption path."""
 
     def test_notes_slug_in_scan(self) -> None:
-        body = _skill("cheese")
+        body = _skill_corpus("cheese")
         # The scan-paths phrase must include `notes` alongside the four
         # implementation phases. Either an explicit list or a brace
         # expansion is acceptable.
@@ -750,7 +765,7 @@ class TestUltracookNoChainDirective:
     fresh-context-per-phase property is silently broken."""
 
     def test_prompt_template_disables_chaining(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         body_lower = body.lower()
         # The override must be visible in the Agent() prompt template.
         # Acceptable phrasings: "do not chain forward", "this phase only",
@@ -776,7 +791,7 @@ def test_phase_documents_ultracook_no_chain_override(phase: str) -> None:
     """Every phase ultracook spawns must explicitly document that, when
     invoked from ultracook with the no-chain directive, it writes its
     handoff slug and stops instead of chaining forward."""
-    body = _skill(phase)
+    body = _skill_corpus(phase)
     assert "/ultracook" in body, (
         f"{phase} must mention /ultracook so the no-chain override is documented"
     )
@@ -804,7 +819,7 @@ class TestUltracookChainTerminatesInAge:
         # capped at two cure passes — same terminal-in-age guarantee, a
         # different literal shape. Assert on cook's actual chain instead of
         # forcing the old table format to reappear.
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         assert "next: done" in body
         assert "/age <slug> --auto" in body, "cook's chain must include the initial full age"
         assert "/age --scope <touched-paths> --auto" in body, (
@@ -823,7 +838,7 @@ class TestUltracookCapEnforcedByChainLength:
     so a future edit cannot silently revert to the broken hybrid contract."""
 
     def test_ultracook_says_chain_length_enforces_cap(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         body_lower = body.lower()
         # Mechanism-B signal: somewhere in cook's body, the cap must be
         # attributed to chain length / table length, not to age.
@@ -832,7 +847,7 @@ class TestUltracookCapEnforcedByChainLength:
         ), "cook must declare that chain length (not age) enforces the cap"
 
     def test_ultracook_says_age_next_is_informational(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         body_lower = body.lower()
         # Under mechanism B, age's `next:` is descriptive: it reports what
         # age observed, but doesn't drive cap enforcement. The contract
@@ -864,7 +879,7 @@ class TestMoldHighBlastIsHighOnly:
     in-session `/cook --auto` chain."""
 
     def test_high_branch_says_high_only(self) -> None:
-        body = _skill("mold")
+        body = _skill_corpus("mold")
         body_lower = body.lower()
         # The high-blast-radius branch heading or surrounding prose must
         # carry the "high only" qualifier so the scope is unambiguous.
@@ -874,7 +889,7 @@ class TestMoldHighBlastIsHighOnly:
         )
 
     def test_medium_keeps_standard_handoff(self) -> None:
-        body = _skill("mold")
+        body = _skill_corpus("mold")
         # The low-branch heading must include `medium` so it's visible
         # that medium-verdict specs route through standard /cook handoff.
         # Either "low or medium" or "low and medium" is acceptable.
@@ -929,7 +944,7 @@ class TestCheeseGatedRouting:
     presumed `decide`)."""
 
     def test_gated_branch_present(self) -> None:
-        body = _skill("cheese")
+        body = _skill_corpus("cheese")
         body_lower = body.lower()
         assert "gated:" in body, (
             "cheese --continue must document a gated: routing branch"
@@ -940,7 +955,7 @@ class TestCheeseGatedRouting:
         )
 
     def test_gated_does_not_auto_dispatch(self) -> None:
-        body = _skill("cheese")
+        body = _skill_corpus("cheese")
         body_lower = body.lower()
         # The clause must forbid auto-dispatch and the presumptive popup.
         assert (
@@ -973,7 +988,7 @@ class TestCheeseReadonlyAutoDispatch:
     when `status: ok` — frictionless research kickoff, not gated."""
 
     def test_readonly_kickoff_branch_present(self) -> None:
-        body = _skill("cheese")
+        body = _skill_corpus("cheese")
         body_lower = body.lower()
         for value in ("briesearch", "culture"):
             assert value in body, (
@@ -1024,7 +1039,7 @@ class TestCheeseHoldAndMissingNext:
         ), "next: hold must surface orientation and stop without dispatching"
 
     def test_missing_next_flagged_not_guessed(self) -> None:
-        body = _skill("cheese")
+        body = _skill_corpus("cheese")
         body_lower = body.lower()
         assert "malformed handoff: next: required" in body, (
             "cheese --continue must flag a missing next: with the exact message"
@@ -1085,7 +1100,7 @@ class TestCheeseNextListRouting:
         assert "order:" in body, "list branch must parse the order: key"
 
     def test_order_required_else_stop(self) -> None:
-        body = _skill("cheese")
+        body = _skill_corpus("cheese")
         body_lower = body.lower()
         # order: missing -> stop and ask for a corrected handoff.
         assert "order:" in body and "required" in body_lower, (
@@ -1093,7 +1108,7 @@ class TestCheeseNextListRouting:
         )
 
     def test_parallel_and_sequential_dispatch(self) -> None:
-        body = _skill("cheese")
+        body = _skill_corpus("cheese")
         body_lower = body.lower()
         assert "order: parallel" in body and "order: sequential" in body, (
             "list branch must handle both order: parallel and order: sequential"
@@ -1104,7 +1119,7 @@ class TestCheeseNextListRouting:
         )
 
     def test_rejects_write_skills_in_inline_list(self) -> None:
-        body = _skill("cheese")
+        body = _skill_corpus("cheese")
         body_lower = body.lower()
         # A write/pipeline skill in the inline list must be rejected and
         # routed to the heavy tasks: block (which carries write isolation).
@@ -1165,7 +1180,7 @@ class TestNextContractV2BackwardCompatible:
     + tasks: slug must both still route exactly as before."""
 
     def test_status_ok_pipeline_phase_still_routes(self) -> None:
-        body = _skill("cheese")
+        body = _skill_corpus("cheese")
         # The original status: ok + pipeline-phase branch must survive,
         # listing the canonical pipeline phases.
         assert "status:" in body and "is `ok`" in body, (
@@ -1177,7 +1192,7 @@ class TestNextContractV2BackwardCompatible:
             )
 
     def test_mode_parallel_tasks_still_documented(self) -> None:
-        body = _skill("cheese")
+        body = _skill_corpus("cheese")
         # The heavyweight write-isolation path must be untouched.
         assert "mode: parallel" in body and "tasks:" in body, (
             "the heavyweight mode: parallel + tasks: path must remain documented"
@@ -1193,14 +1208,14 @@ class TestUltracookDeterministicPhaseLoop:
     orchestrator never judges phase transitions by eye."""
 
     def test_read_handoff_slug_referenced(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         assert "read_handoff_slug" in body, (
             "cook must reference read_handoff_slug in the phase loop so "
             "slug parsing is deterministic, not eyeballed"
         )
 
     def test_phase_decision_referenced(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         assert "phase_decision" in body, (
             "cook must reference phase_decision in the phase loop so "
             "the next-action verdict is deterministic"
@@ -1222,14 +1237,14 @@ class TestUltracookModeGate:
     PARALLEL_THRESHOLD (2) picks linear vs parallel."""
 
     def test_mode_selection_section_present(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         assert "Mode selection" in body, (
             "cook must document a mode-selection gate"
         )
         assert "decomposer" in body.lower(), "the decomposer is the mode gate"
 
     def test_mode_selector_and_threshold_referenced(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         assert "PARALLEL_THRESHOLD" in body, (
             "cook must name the canonical PARALLEL_THRESHOLD constant"
         )
@@ -1239,7 +1254,7 @@ class TestUltracookModeGate:
         )
 
     def test_two_or_more_curds_is_parallel(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         body_lower = body.lower()
         assert "2 or more" in body_lower or "2+" in body, (
             "cook must state 2+ curds routes to parallel mode"
@@ -1249,7 +1264,7 @@ class TestUltracookModeGate:
         )
 
     def test_fast_path_skips_decomposer_for_single_low_or_medium_blast_curd(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         body_lower = body.lower()
         assert "fast-path" in body_lower, (
             "cook must document a deterministic fast-path before the decompose step"
@@ -1279,14 +1294,14 @@ class TestUltracookParallelTopology:
         assert "## Fan pathway" in body
 
     def test_per_curd_pipeline_documented(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         # Per-curd pipeline uses the parallel-curd phase table.
         assert "parallel-curd" in body, (
             "the fan pathway must run each curd on the parallel-curd phase table"
         )
 
     def test_post_merge_final_age_documented(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         body_lower = body.lower()
         assert "parallel-postmerge" in body, (
             "the fan pathway must use the parallel-postmerge table"
@@ -1300,7 +1315,7 @@ class TestUltracookWorktreeLifecycle:
     worktree + branch down afterward — no leaks (acceptance #5)."""
 
     def test_harvest_no_fetch(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         body_lower = body.lower()
         assert "worktree harvest" in body_lower, "the fan pathway must harvest curd branches"
         assert "no `git fetch`" in body or "no git fetch" in body_lower or (
@@ -1308,7 +1323,7 @@ class TestUltracookWorktreeLifecycle:
         ), "harvest must state it needs no git fetch (shared object store)"
 
     def test_teardown_leaves_no_leak(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         body_lower = body.lower()
         assert "worktree teardown" in body_lower, "the fan pathway must tear worktrees down"
         assert "leak" in body_lower, (
@@ -1325,7 +1340,7 @@ class TestUltracookMilknadoSeam:
     parity is stated (acceptance #4)."""
 
     def test_three_probe_roles_documented(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         body_lower = body.lower()
         assert "engine" in body_lower and "tracker" in body_lower, (
             "the milknado seam must name the engine and tracker roles"
@@ -1335,14 +1350,14 @@ class TestUltracookMilknadoSeam:
         )
 
     def test_native_path_runs_without_milknado(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         body_lower = body.lower()
         assert "native fan-out" in body_lower, (
             "the fan pathway must document the native fan-out path when milknado is absent"
         )
 
     def test_parity_difference_stated(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         body_lower = body.lower()
         # The intentional parity difference must be explicit.
         assert "self-verify" in body_lower, (
@@ -1367,7 +1382,7 @@ class TestUltracookAgentResolution:
         assert "agent_resolution" in body
 
     def test_typed_phase_roles_documented(self) -> None:
-        body = _skill("cook").lower()
+        body = _skill_corpus("cook").lower()
         assert "planner/general" in body
         assert "coder(cook)" in body
         assert "reviewer(age)" in body
@@ -1384,7 +1399,7 @@ class TestUltracookRecoveryPaths:
     aggregate-gate failure path (issue #194, acceptance #7)."""
 
     def test_worker_exhaustion_recovery(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         body_lower = body.lower()
         assert "#194" in body or "194" in body, (
             "cook must cite issue #194 for the recovery paths"
@@ -1394,7 +1409,7 @@ class TestUltracookRecoveryPaths:
         )
 
     def test_aggregate_gate_failure_distinguishes_conflict_from_drift(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         body_lower = body.lower()
         assert "aggregate" in body_lower, (
             "the fan pathway must document the aggregate-gate failure path"
@@ -1411,7 +1426,7 @@ class TestUltracookOutputContract:
     """Behavioural output stays stable while resolution provenance exposes topology."""
 
     def test_output_contract_accounts_for_resolution_provenance(self) -> None:
-        body = _skill("cook").lower()
+        body = _skill_corpus("cook").lower()
         assert "behavioral output" in body
         assert "resolution provenance" in body
         assert "topology" in body
@@ -1429,7 +1444,7 @@ class TestUltracookResume:
         )
 
     def test_topology_advances_manifest_at_phase_boundaries(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         # Every schema phase past the decomposer scaffold must be emitted by a
         # manifest_update set-phase call threaded into the topology prose.
         for phase in (
@@ -1452,7 +1467,7 @@ class TestUltracookResume:
         )
 
     def test_resume_section_present(self) -> None:
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         assert "## --resume <slug>" in body, "a dedicated --resume section must exist"
         assert "git cat-file -e" in body, (
             "resume must verify recorded commit SHAs still exist (rebase guard)"
@@ -1469,13 +1484,20 @@ class TestUltracookResume:
         import json
         import re
 
-        body = _skill("cook")
+        body = _skill_corpus("cook")
         schema_path = SKILLS_DIR / "ultracook" / "references" / "manifest-schema.json"
         schema_enum = json.loads(_read(schema_path))["properties"]["phase"]["enum"]
 
-        # cook's heading is `### --resume <slug>` (one level deeper than
-        # retired ultracook's top-level `## --resume <slug>`).
-        resume_section = body.split("\n### --resume <slug>", 1)[1]
+        # cook's heading is `### --resume <slug>` inline in SKILL.md, or
+        # `## --resume <slug>` in the routed fan-pathway.md reference file
+        # (one level shallower once it's a standalone file's own heading).
+        for heading in ("\n### --resume <slug>", "\n## --resume <slug>"):
+            parts = body.split(heading, 1)
+            if len(parts) == 2:
+                resume_section = parts[1]
+                break
+        else:
+            raise AssertionError("cook corpus must carry a `--resume <slug>` heading")
         # Accept either ASCII `->` (cook's convention) or the original
         # unicode `→` — the arrow glyph isn't the guarantee under test.
         arrow_span = re.search(


### PR DESCRIPTION
## Purpose

Trim `/affinage`'s always-on `SKILL.md` body by routing detailed operational guidance into explicitly linked `references/*.md` files.

## Artifacts

- Skill body, routed references, and the `affinage` budget ratchet are complete.
- Direct documentation-contract tests move with the extracted content.

## Verification

- `just check` — passed.

## Stack relationship

This layer is based on #360. Merge the stack bottom-to-top from #360 through #367.

## Risk

No runtime implementation behavior changes; reviewers should verify each extraction retains an explicit read-when pointer from `SKILL.md`.
