### PR TITLE
test(skills): align routed documentation contracts

### DIFF
--- a/tests/python/test_transport_audit.py
+++ b/tests/python/test_transport_audit.py
@@ -115,15 +115,15 @@ EXEMPT_SITES: list[tuple[str, str, str]] = [
         "not this pass",
     ),
     (
+        "skills/cheese/references/optional-plugins.md",
+        "Do not ask the user to install the MCP during the run.",
+        "negative instruction, not a question-asking site",
+    ),
+    (
         "skills/affinage/references/handoff-templates.md",
         "Read this when rendering either handoff gate",
         "internal mechanism note for the gates affinage/SKILL.md already "
         "routes through handoff-gate.md; not a transport site itself",
-    ),
-    (
-        "skills/cheese/references/optional-plugins.md",
-        "Do not ask the user to install the MCP during the run.",
-        "negative instruction, not a question-asking site",
     ),
     (
         "skills/cheese/references/escalation.md",


### PR DESCRIPTION
## Purpose

Preserve the exact documentation-contract wording and audit ordering from PR #359 after its mechanical split.

## Verification

- `just check` — passed.

## Stack relationship

Final test-contract layer, based on #366.
