### PR TITLE
refactor(cure): route detailed guidance into references

### DIFF
--- a/.github/skill-budgets.json
+++ b/.github/skill-budgets.json
@@ -15,7 +15,7 @@
     "cheese": 3017,
     "cook": 3500,
     "culture": 2521,
-    "cure": 5130,
+    "cure": 3463,
     "easy-cheese-setup": 760,
     "hard-cheese": 3085,
     "melt": 2178,

--- a/skills/cure/SKILL.md
+++ b/skills/cure/SKILL.md
@@ -11,18 +11,16 @@ Use this skill after `/age`, failed validation, or user-selected review findings
 
 ## Inputs
 
-Accept any of: a `/age` slug (`/cure <slug>` reads `.cheese/age/<slug>.md`), a pasted findings list, a CI failure summary, or a scoped instruction like "fix the high-severity age findings". `/age` may also hand off with a pre-locked selection by passing the chosen ids in a structured handoff context (see `references/selection.md#handoff-from-age` for the canonical format); when that context is present, skip rendering the selection list and go straight to apply.
+Accept any of: a `/age` slug (`/cure <slug>` reads `.cheese/age/<slug>.md`), a pasted findings list, a CI failure summary, or a scoped instruction like "fix the high-severity age findings". When `/age` or `/affinage` hands off a pre-locked selection (canonical format: `references/selection.md#handoff-from-age`), adopt it and go straight to apply. Called bare, apply the recommended composite (`all-medium, cheap`) per `references/selection.md`, which also defines the gate conditions.
 
-Age reports older than this severity-rubric revision lack the `severity`, `location`, `fix-cost-now`, and `fix-cost-later` sub-fields on each finding. Tolerate the older shape: when a finding has no `severity` field, infer it from the section header (`## High-stake findings` → `high`, `## Medium-stake findings` → `medium`); when `fix-cost-now` is absent, the `cheap` selection verb resolves to the empty set per `references/selection.md`. Never reject a report for missing sub-fields; record any inference in the cure report under `### Notes`. Reports predating the per-finding `confidence:` label simply lack it; treat missing confidence as unspecified — no inference, no rejection.
-
-When `/age` or `/affinage` hands off a pre-locked selection, adopt it. When called bare without a pre-locked selection, apply the recommended composite (`all-medium, cheap`) per `references/selection.md`, which also defines the gate conditions.
+Age reports may predate the severity-rubric revision and lack per-finding sub-fields or `confidence`. Read `references/selection.md` § Older report shape before selecting from such a report — it defines the inference and toleration rules; never reject a report for missing sub-fields.
 
 Optional flags:
 
 - `--safe` — re-introduce the selection and terminal publication handoff gates.
 - `--open-pr` — after a clean cure, allow terminal `/plate` publication when no PR exists.
-- `--auto` — autonomous mode (propagated from `/cook --auto`). Bypasses the user-selection step. Must be paired with `--stake <floor>` to set the inclusion threshold; `/cook --auto` always passes `--stake medium+`. See `references/selection.md` for the auto-selection rules and `## Auto mode` below for the pass-cap and revert behaviour.
-- `--stake <floor>` — used only with `--auto`. Severity floor: `blocker`, `high`, `medium+`, or `all`. Floor definitions and the `medium+` cheap-lows rule: `references/selection.md` § Auto-mode selection. Without `--auto` this flag is ignored.
+- `--auto` — autonomous mode (propagated from `/cook --auto`). Skips user selection; requires `--stake <floor>`, and `/cook --auto` always passes `medium+`. Auto-selection rules: `references/selection.md`; pass-cap and revert behaviour: `## Auto mode` below.
+- `--stake <floor>` — with `--auto` only, ignored otherwise. Severity floor: `blocker`, `high`, `medium+`, or `all`; definitions and the `medium+` cheap-lows rule live in `references/selection.md` § Auto-mode selection.
 - `--hard` — propagate the metacognitive-gate flag to terminal `/plate`; see `## --hard mode`.
 
 Portability reference: [`../cheese/references/harness-portability.md`](../cheese/references/harness-portability.md). It covers helper resolution, sub-agent dispatch, GitHub operations, and handoff transitions; prefer the bundled or repo-local helper first, and treat `${CLAUDE_SKILL_DIR}` as optional host-provided fallback.
@@ -40,8 +38,8 @@ The handoff blocks below are the portable contract; slash commands are host rend
    If the host only ships the bundle, `python3 ${CLAUDE_SKILL_DIR}/scripts/common.pyz findings_cli parse-selection ...` is the fallback.
 3. **Apply** — fix one logical group at a time: re-confirm the anchor through a fresh bounded read, then apply a stale-safe write from a compatible backend family.
 4. **Validate** — run the narrowest tests that prove each fix, then any relevant project-wide gates (lint, typecheck, build). When the handoff carries a recorded `baseline:` block, classify gate failures against it per [`../cook/references/quality-gates.md`](../cook/references/quality-gates.md): identical failures do not block a clean cure or trigger a halt; only new or changed failures are cure's to fix.
-5. **Taste-test (behavioural fixes only)** — if this cure applied a *behavioural* fix (touched production logic or public surface), run the fresh-context taste-test before the handoff slug: dispatch the read-only `reviewer` phase-agent (named, no call-site model — its def pins `model: opus`) over the cure diff with the same lenses cook uses, or fall back to the inline self-check when no such reviewer sub-agent is available. *Mechanical* fixes — formatting, comment, import, no-logic rename — skip this and keep the current flow. Pipe any `revise` into a bounded corrective pass; a Locked-decision `halt` stops for a human. (A coder-nested cure cannot fan out; it defers the authoritative pass to the orchestrator.)
-6. **Domain-model correction (diff-touched terms only)** — after the cook's fixes land, correct the project domain model (ubiquitous language) for terms **touched by the cook's diff** (bounded — diff-touched terms only, never a free rewrite). Resolve the store with `domain_model_target()` (`shared/scripts/paths.py`, read-probe cascade wiki → docs → XDG; an existing model always wins). For a diff-touched entry whose definition or `_Code_:` referent no longer matches the code, update it and write a one-line change note per edit (entry format: `**Term** — definition.` / `_Avoid_: syn1, syn2` / `_Code_: file:line (or NEW ENTITY)`). **HARD rule — flag, don't reverse:** if a correction would REVERSE a mold-decided canonical term (replace the term mold made authoritative, or contradict its definition), do not rewrite — flag it to the user (the term, mold's decision, the conflict) and leave the entry unchanged. mold DECIDES canonical terms at curdle; cure only APPLIES BOUNDED corrections and never overrules the authoritative writer.
+5. **Taste-test (behavioural fixes only)** — for a *behavioural* fix (production logic or public surface), run the fresh-context taste-test before the handoff slug: dispatch the read-only `reviewer` phase-agent (model pinned to opus) over the cure diff with cook's lenses, or fall back to the inline self-check if unavailable. *Mechanical* fixes (formatting, comment, import, no-logic rename) skip this. Pipe a `revise` into a bounded corrective pass; a Locked-decision `halt` stops for a human. (A coder-nested cure defers the authoritative pass to the orchestrator.)
+6. **Domain-model correction (diff-touched terms only)** — after the cook's fixes land, correct diff-touched domain-model terms (never a free rewrite). Read `references/domain-model-correction.md` before this step — it defines the store resolution, the entry format, and the hard rule against reversing a mold-locked canonical term.
 7. **Re-review hand-off** — recommend `/age --scope <touched-path>` so review runs through the proper skill rather than reimplementing it inline. `/cure` does not re-grade its own work. If the user picks re-age, the resulting report can feed a fresh `/cure` invocation.
 8. **Ship report** — what changed, checks run, deferred items, residual risks. Write the handoff slug at the top of `.cheese/cure/<slug>.md` (see `## Handoff slug` below) so the chain (and `/cook`'s fan pathway) can read the outcome without re-parsing the full report.
 9. **Plate / hand off** — on a clean cure, dispatch `/plate` per `## Handoff`.
@@ -126,67 +124,37 @@ When the run was chained from `/affinage` (`handoff_context.source_skill: /affin
 
 **Default (no `--safe`) — plate the work:**
 
-- Detect an open PR with `gh pr view`. If one exists, dispatch `/plate` to run its final writing gate, validation, named-file commit, topology-aware update, and publication. Rule 11 authorizes the update. Propagate `--hard`; `/plate` gives `/hard-cheese` the final artifact state before publishing.
-- If no open PR exists: with `--open-pr`, dispatch `/plate [--hard]`; explicit topology choices and obviously cohesive work proceed without asking, while stack-sized or ambiguous work asks before commit or branch-layout mutation. Without `--open-pr`, leave the remote untouched and finish with `no open PR — pass --open-pr or run /plate`.
-- After `/plate`'s publication lands, run the **§ Post-PR learnings write-back** below.
-- If the cure was not clean, do not dispatch `/plate`; mention the blocker and stop.
+- With an open PR (`gh pr view`), dispatch `/plate [--hard]` for its final writing gate, commit, topology-aware update, and publication (Rule 11 authorizes the update).
+- With no open PR: `--open-pr` dispatches `/plate [--hard]` — explicit topology choices and obviously cohesive work proceed without asking, while stack-sized or ambiguous work asks before commit or branch-layout mutation. Without `--open-pr`, leave the remote untouched and finish with `no open PR — pass --open-pr or run /plate`.
+- After publication lands, run **§ Post-PR learnings write-back** below.
+- If the cure was not clean, skip `/plate`; mention the blocker and stop.
 
 **`--safe` — ask via the shared handoff gate** in [`../cheese/references/handoff-gate.md`](../cheese/references/handoff-gate.md). Default options:
 
 - **Re-review the touched code** *(recommended when fixes escaped the finding hunk)* — `/age --scope <touched-path>`.
 - **Plate it — commit and open or update the PR** — `/plate [--hard]`.
-- **Checkpoint & stop** — `/wheypoint`.
-- **Stop** — dispatch none.
+- **Checkpoint & stop** (`/wheypoint`) or **Stop** (dispatch none).
 
 Pre-select **Plate it** only when all selected findings applied cleanly and gates passed. Never dispatch before selection; run the selected command immediately.
 
 ### Post-PR learnings write-back
 
-After any path that **publishes to a PR** — the default `/plate` dispatch, an `--open-pr` new PR, the `--safe` **Plate it** selection, or the auto-mode terminal publication — record the session's *implementation-time* learnings to the wiki. This is the second wiki write moment; curdle owns the design-time write, this owns what only surfaces while building: constraints discovered in `/cook`, `/age` findings that changed the design, and any domain terms the diff introduced or redefined.
-
-- **Candidates — upstream `durable_flags` + new-since-curdle ADRs.** Read `durable_flags:` from the upstream `/cook` and `/age` handoff slugs (`.cheese/cook/<slug>.md`, `.cheese/age/<slug>.md`); every non-`none` line is a write-back candidate alongside the new ADRs + domain-model deltas. Upstream phases record flags only — cure/plate/affinage remain the only wiki writers.
-- **Writer — `/wiki-ingest`, detect-and-degrade.** When the hallouminate plugin is available, dispatch `/wiki-ingest` with the candidate list above; its dedup/route/merge/contradiction handling ensures only rationale *new since curdle* lands (say "new since curdle" in the dispatch so it does not re-add design-time ADRs). When hallouminate is absent, write `docs/adr/<slug>-NNN.md` + the domain-model file fallback and emit a **loud one-line note** that the write-back went to files, not the wiki — never a silent degrade. Detection and the degrade contract: [`../cheese/references/optional-plugins.md`](../cheese/references/optional-plugins.md).
-- **Every publication path.** Fires from the frame that dispatched terminal `/plate` — manual `cook→cure` and `--auto` alike — after publication lands.
-- **Publication-owner exception.** When cure does not own terminal `/plate` — the `/cook` fan-pathway no-publish cases below, or the `/affinage` chain where affinage owns terminal `/plate` — cure does **not** write back; the skill that owns the `/plate` dispatch owns the write-back at its publish boundary.
-- **Nothing to record** — all upstream `durable_flags` are `none` (or absent), no new ADR-worthy decision, and no domain-model delta — skip with a one-line "no post-PR learnings" note. Do not manufacture an entry.
-
-`[TBD]` The write-back trigger lives at this cure boundary today; `/plate` (the dedicated commit/PR skill) now exists, so the deferred follow-up is to move the trigger onto `/plate` so publication and learnings-capture are wired at one seam (see the `post-pr-wiki-writeback` wiki page). Upstream `durable_flags` feed whichever skill owns this single publish-boundary write, so if the trigger moves to `/plate`, flag consumption moves with it.
+After any path that **publishes to a PR** — the default `/plate` dispatch, an `--open-pr` new PR, the `--safe` **Plate it** selection, or the auto-mode terminal publication — read `references/post-pr-writeback.md` before writing back. It defines the write-back candidates (upstream `durable_flags` + new-since-curdle ADRs), the `/wiki-ingest` writer with its file-fallback degrade, the publication-owner exception, and the "nothing to record" case.
 
 ## --hard mode
 
-`/cure --hard` propagates `--hard` to `/plate` at the share-for-review boundary. `/plate` first completes and verifies every durable write, then gives `/hard-cheese` that final artifact inventory and proceeds only on pass. Re-review, checkpoint, and stop choices do not fire the gate. The mechanism lives in `skills/hard-cheese/SKILL.md`; composition details live in `../hard-cheese/references/composition.md`.
+`/cure --hard` propagates `--hard` to `/plate`, which completes and verifies every durable write, then gives `/hard-cheese` the final artifact inventory and proceeds only on pass. Re-review, checkpoint, and stop choices skip the gate. Mechanism: `skills/hard-cheese/SKILL.md`; composition: `../hard-cheese/references/composition.md`.
 
 ## Auto mode
 
-When invoked with `--auto --stake <floor>`:
+When invoked with `--auto --stake <floor>`, skip the selection list and the handoff gate, auto-select every finding meeting the severity floor (`references/selection.md` § Auto-mode selection), apply and validate each one — reverting and deferring on breakage — then invoke `/age --scope <touched-paths> --auto` (forwarding `--open-pr` when in scope) so the chain re-reviews; `/age --auto` owns the two-pass cap. On a terminal `next: done`, dispatch `/plate` once and run the **§ Post-PR learnings write-back** above.
 
-- Skip the selection-list rendering and the handoff gate.
-- Auto-select every finding that meets the severity floor. Floor definitions: `references/selection.md` § Auto-mode selection.
-- Apply findings one at a time. After each fix, run the narrowest test that proves it. If the fix breaks a previously-passing test or any project-wide gate, revert that single finding's edit and record it under `### Deferred` in the cure report with the test name and the failure summary. Continue with the remaining findings.
-- After all selected findings are processed, skip the handoff gate and invoke `/age --scope <touched-paths> --auto` (forward `--open-pr` when it is in scope) so the chain can re-review.
-- `/age --auto` enforces the two-pass cap. Cure does not need to track passes itself — it just keeps applying when invoked.
-- **Terminal publication.** When the age child returns `next: done`, dispatch `/plate` once. It updates an existing PR automatically or, with `--open-pr`, applies the explicit-choice and review-shape policy before committing a new PR layout. After the publication lands, run the **§ Post-PR learnings write-back** in `## Handoff`.
-- **Orchestrated sub-agent exception.** A phase-only cure dispatched by `/cook`'s fan pathway never invokes `/plate`; the orchestrator owns commit and publication.
-- **`/affinage` chain exception.** When `handoff_context.source_skill` is `/affinage`, suppress this terminal `/plate` — affinage posts its GitHub replies (final writes) and then owns terminal `/plate`.
-
-**`--auto --hard` puncture clause.** When age returns `next: done`, dispatch `/plate --hard` rather than firing `/hard-cheese` directly. `/plate`'s final writing gate makes the completed artifact inventory visible to the metacognitive check. A failed hard gate halts publication; a non-TTY environment reports that `--hard` needs an interactive TTY.
-
-If no findings meet the floor, write an empty cure report with `### Applied: (none — no findings meet <floor>)` and skip straight to the auto handoff with a one-line "auto chain clean" note.
-
-### Within cook's own fan pathway (single-curd chain or a wave curd)
-
-When `/cook`'s fan pathway (its retired-`/ultracook` mechanics, now self-hosted — see `skills/cook/SKILL.md` `## Fan pathway`) spawns cure as a phase-only sub-agent and owns the chain itself, honour the no-chain / no-push override:
-
-- **Single-curd chain** — the spawn prompt says "for THIS PHASE ONLY" and "do not chain forward to the next phase." Apply the auto-selected findings, write `.cheese/cure/<slug>.md` (handoff slug at the top, `next: age`), and stop. Do not invoke `/age --scope <touched-paths> --auto`. The orchestrator reads the cure slug and spawns the next age itself.
-- **Wave curd worker** — apply findings, write the cure slug, and stop. Do not invoke `/plate` or touch the remote; the fan pathway owns final commit and publication.
-
-In both cases terminal `/plate` dispatch is suppressed — the orchestrator owns it.
+Read `references/auto-mode.md` before running this mode — it defines the empty-floor case, the `--auto --hard` puncture clause, and the cook fan-pathway sub-agent exceptions (single-curd chain and wave-curd worker) that suppress terminal `/plate`.
 
 ## Rules
 
-- Default to the recommended composite (`all-medium, cheap`), or the selection `/age` / `/affinage` locked in. `--safe` re-introduces the selection gate. A finding resting on a false premise, or a sprawling/structural fix, still pauses for a decision regardless of mode.
-- Keep fixes scoped to selected (or auto-selected) findings.
-- Do not re-halt or re-flag gate failures identical to the handoff's recorded `baseline:` block; only new or changed failures are cure's to fix — see [`../cook/references/quality-gates.md`](../cook/references/quality-gates.md).
+- Default to the recommended composite (or `/age`/`/affinage`'s locked selection); `--safe` re-introduces the gate. A false-premise or sprawling/structural finding still pauses for a decision regardless of mode.
+- Keep fixes scoped to selected (or auto-selected) findings. Baseline-identical gate failures are never cure's to fix (Flow step 4).
 - Do not hide failed or skipped checks. In auto mode, reverted findings go under `### Deferred`, never silently dropped.
 - Publication contract — existing PR authorization, `--open-pr`, `--safe`, and never publishing an unclean cure: see `## Handoff`.
 - If a selected finding rests on a false premise (the `/age` claim is wrong, or the diff already addresses it), stop and surface the premise before applying. Disagreeing with the report is allowed; silently working around it is not.
@@ -195,8 +163,8 @@ In both cases terminal `/plate` dispatch is suppressed — the orchestrator owns
 
 ## Discipline
 
-Iron Law, Red Flags, and the fix-application Rationalization table live in
-[`references/cure-discipline.md`](references/cure-discipline.md).
+Read `references/cure-discipline.md` before applying any fix — it holds the
+Iron Law, Red Flags, and the fix-application Rationalization table.
 
 ## Agent resolution
 

--- a/skills/cure/references/auto-mode.md
+++ b/skills/cure/references/auto-mode.md
@@ -1,0 +1,31 @@
+# Auto mode detail (cure)
+
+Read this before running `/cure --auto --stake <floor>` for the fan-pathway exceptions, the puncture clause, and the empty-floor case.
+
+## Per-finding flow
+
+- Skip the selection-list rendering and the handoff gate.
+- Auto-select every finding that meets the severity floor. Floor definitions: `selection.md` § Auto-mode selection.
+- Apply findings one at a time. After each fix, run the narrowest test that proves it. If the fix breaks a previously-passing test or any project-wide gate, revert that single finding's edit and record it under `### Deferred` in the cure report with the test name and the failure summary. Continue with the remaining findings.
+- After all selected findings are processed, skip the handoff gate and invoke `/age --scope <touched-paths> --auto` (forward `--open-pr` when it is in scope) so the chain can re-review.
+- `/age --auto` enforces the two-pass cap. Cure does not need to track passes itself — it just keeps applying when invoked.
+
+## Terminal publication
+
+When the age child returns `next: done`, dispatch `/plate` once. It updates an existing PR automatically or, with `--open-pr`, applies the explicit-choice and review-shape policy before committing a new PR layout. After the publication lands, run the **§ Post-PR learnings write-back** (`post-pr-writeback.md`).
+
+- **Orchestrated sub-agent exception.** A phase-only cure dispatched by `/cook`'s fan pathway never invokes `/plate`; the orchestrator owns commit and publication.
+- **`/affinage` chain exception.** When `handoff_context.source_skill` is `/affinage`, suppress this terminal `/plate` — affinage posts its GitHub replies (final writes) and then owns terminal `/plate`.
+
+**`--auto --hard` puncture clause.** When age returns `next: done`, dispatch `/plate --hard` rather than firing `/hard-cheese` directly. `/plate`'s final writing gate makes the completed artifact inventory visible to the metacognitive check. A failed hard gate halts publication; a non-TTY environment reports that `--hard` needs an interactive TTY.
+
+If no findings meet the floor, write an empty cure report with `### Applied: (none — no findings meet <floor>)` and skip straight to the auto handoff with a one-line "auto chain clean" note.
+
+## Within cook's own fan pathway (single-curd chain or a wave curd)
+
+When `/cook`'s fan pathway (its retired-`/ultracook` mechanics, now self-hosted — see `skills/cook/SKILL.md` `## Fan pathway`) spawns cure as a phase-only sub-agent and owns the chain itself, honour the no-chain / no-push override:
+
+- **Single-curd chain** — the spawn prompt says "for THIS PHASE ONLY" and "do not chain forward to the next phase." Apply the auto-selected findings, write `.cheese/cure/<slug>.md` (handoff slug at the top, `next: age`), and stop. Do not invoke `/age --scope <touched-paths> --auto`. The orchestrator reads the cure slug and spawns the next age itself.
+- **Wave curd worker** — apply findings, write the cure slug, and stop. Do not invoke `/plate` or touch the remote; the fan pathway owns final commit and publication.
+
+In both cases terminal `/plate` dispatch is suppressed — the orchestrator owns it.

--- a/skills/cure/references/domain-model-correction.md
+++ b/skills/cure/references/domain-model-correction.md
@@ -1,0 +1,17 @@
+# Domain-model correction (cure)
+
+Read this before Flow step 6 (domain-model correction).
+
+After the cook's fixes land, correct the project domain model (ubiquitous language) for terms **touched by the cook's diff** (bounded — diff-touched terms only, never a free rewrite).
+
+Resolve the store with `domain_model_target()` (`shared/scripts/paths.py`, read-probe cascade wiki → docs → XDG; an existing model always wins).
+
+For a diff-touched entry whose definition or `_Code_:` referent no longer matches the code, update it and write a one-line change note per edit. Entry format:
+
+```
+**Term** — definition.
+_Avoid_: syn1, syn2
+_Code_: file:line (or NEW ENTITY)
+```
+
+**HARD rule — flag, don't reverse:** if a correction would REVERSE a mold-decided canonical term (replace the term mold made authoritative, or contradict its definition), do not rewrite — flag it to the user (the term, mold's decision, the conflict) and leave the entry unchanged. mold DECIDES canonical terms at curdle; cure only APPLIES BOUNDED corrections and never overrules the authoritative writer.

--- a/skills/cure/references/post-pr-writeback.md
+++ b/skills/cure/references/post-pr-writeback.md
@@ -1,0 +1,13 @@
+# Post-PR learnings write-back (cure)
+
+Read this before any path that publishes to a PR (the default `/plate` dispatch, an `--open-pr` new PR, the `--safe` **Plate it** selection, or the auto-mode terminal publication).
+
+After any path that **publishes to a PR**, record the session's *implementation-time* learnings to the wiki. This is the second wiki write moment; curdle owns the design-time write, this owns what only surfaces while building: constraints discovered in `/cook`, `/age` findings that changed the design, and any domain terms the diff introduced or redefined.
+
+- **Candidates — upstream `durable_flags` + new-since-curdle ADRs.** Read `durable_flags:` from the upstream `/cook` and `/age` handoff slugs (`.cheese/cook/<slug>.md`, `.cheese/age/<slug>.md`); every non-`none` line is a write-back candidate alongside the new ADRs + domain-model deltas. Upstream phases record flags only — cure/plate/affinage remain the only wiki writers.
+- **Writer — `/wiki-ingest`, detect-and-degrade.** When the hallouminate plugin is available, dispatch `/wiki-ingest` with the candidate list above; its dedup/route/merge/contradiction handling ensures only rationale *new since curdle* lands (say "new since curdle" in the dispatch so it does not re-add design-time ADRs). When hallouminate is absent, write `docs/adr/<slug>-NNN.md` + the domain-model file fallback and emit a **loud one-line note** that the write-back went to files, not the wiki — never a silent degrade. Detection and the degrade contract: [`../../cheese/references/optional-plugins.md`](../../cheese/references/optional-plugins.md).
+- **Every publication path.** Fires from the frame that dispatched terminal `/plate` — manual `cook→cure` and `--auto` alike — after publication lands.
+- **Publication-owner exception.** When cure does not own terminal `/plate` — the `/cook` fan-pathway no-publish cases, or the `/affinage` chain where affinage owns terminal `/plate` — cure does **not** write back; the skill that owns the `/plate` dispatch owns the write-back at its publish boundary.
+- **Nothing to record** — all upstream `durable_flags` are `none` (or absent), no new ADR-worthy decision, and no domain-model delta — skip with a one-line "no post-PR learnings" note. Do not manufacture an entry.
+
+`[TBD]` The write-back trigger lives at this cure boundary today; `/plate` (the dedicated commit/PR skill) now exists, so the deferred follow-up is to move the trigger onto `/plate` so publication and learnings-capture are wired at one seam (see the `post-pr-wiki-writeback` wiki page). Upstream `durable_flags` feed whichever skill owns this single publish-boundary write, so if the trigger moves to `/plate`, flag consumption moves with it.

--- a/skills/cure/references/selection.md
+++ b/skills/cure/references/selection.md
@@ -98,3 +98,7 @@ When `/cure` is invoked with `--auto --stake <floor>`:
 - **After all selected findings are processed:** invoke `/age --scope <touched-paths> --auto` directly (no handoff gate). The pass-cap is enforced inside `/age --auto`, not here — cure keeps applying when called.
 
 `--auto` is not a verb the user should type interactively. It exists to make the `/cook --auto` chain coherent. If a user types `/cure --auto` directly without `--stake`, error out with a one-line message pointing them at standard interactive `/cure <slug>` — `--stake` is the contract for auto mode, and without it `/cure --auto` has no inclusion threshold. Do not prompt for a floor; do not silently fall back to interactive selection.
+
+## Older report shape
+
+Age reports older than the severity-rubric revision lack the `severity`, `location`, `fix-cost-now`, and `fix-cost-later` sub-fields on each finding. Tolerate the older shape: when a finding has no `severity` field, infer it from the section header (`## High-stake findings` → `high`, `## Medium-stake findings` → `medium`); when `fix-cost-now` is absent, the `cheap` selection verb resolves to the empty set (see `## Recognized selection verbs` above). Never reject a report for missing sub-fields; record any inference in the cure report under `### Notes`. Reports predating the per-finding `confidence:` label simply lack it; treat missing confidence as unspecified — no inference, no rejection.

--- a/tests/python/test_plate_contract.py
+++ b/tests/python/test_plate_contract.py
@@ -141,7 +141,11 @@ def test_ultracook_preflights_parallel_publication_before_commits() -> None:
 
 
 def test_cure_open_pr_dispatch_obeys_plate_policy() -> None:
-    cure = read("skills/cure/SKILL.md")
+    cure_dir = ROOT / "skills" / "cure"
+    cure = read("skills/cure/SKILL.md") + "".join(
+        (cure_dir / "references" / f"{name}.md").read_text()
+        for name in ("auto-mode", "selection", "post-pr-writeback")
+    )
     assert "explicit topology choices and obviously cohesive work proceed without asking" in cure
     assert "stack-sized or ambiguous work asks before commit or branch-layout mutation" in cure
 

--- a/tests/python/test_transport_audit.py
+++ b/tests/python/test_transport_audit.py
@@ -133,6 +133,12 @@ EXEMPT_SITES: list[tuple[str, str, str]] = [
         "not this pass",
     ),
     (
+        "skills/cure/references/auto-mode.md",
+        "the handoff gate",
+        "internal auto-mode mechanism note; cure/SKILL.md's own ask site "
+        "already routes through handoff-gate.md",
+    ),
+    (
         "skills/cure/references/selection.md",
         "invoke `/age --scope <touched-paths> --auto` directly (no handoff gate)",
         "internal auto-mode mechanism note; cure/SKILL.md's own ask site "


### PR DESCRIPTION
## Purpose

Trim `/cure`'s always-on `SKILL.md` body by routing detailed operational guidance into explicitly linked `references/*.md` files.

## Artifacts

- Skill body, routed references, and the `cure` budget ratchet are complete.
- Direct documentation-contract tests move with the extracted content.

## Verification

- `just check` — passed.

## Stack relationship

This layer is based on #364. Merge the stack bottom-to-top from #360 through #367.

## Risk

No runtime implementation behavior changes; reviewers should verify each extraction retains an explicit read-when pointer from `SKILL.md`.


Supersedes #365 (auto-closed when its base branch `paulnsorensen/skill-trim-cook` merged and was deleted; GitHub refused to reopen).