### PR TITLE
docs(checkpoint): preserve full protocol reconstruction

### DIFF
--- a/.cheese/notes/root-cheese-milknado-full-protocol-reconstruction.md
+++ b/.cheese/notes/root-cheese-milknado-full-protocol-reconstruction.md
@@ -1,0 +1,732 @@
+## Handoff slug
+
+~~~text
+status: gated: finalize record fields, package and versioning, persistence, and Wheypoint integrity before spec approval
+next: mold
+mode: single
+artifact: .cheese/notes/root-cheese-milknado-decision-audit.md
+session: codex:019fb751-d863-7d62-a3db-78e8e3dd1453
+git: checkpoint/root-cheese-milknado-orchestration@4690aed
+created: 2026-08-01T08:51:33Z
+parents: [root-cheese-milknado-orchestration, wheypoint-root-cheese-context-loss-audit]
+baseline: none
+<certain> This is the full reconstruction checkpoint for the Root Cheese and Milknado protocol, recovery slice, shared Pydantic contract, and Wheypoint integrity incident; resume by reading this file before any narrower artifact.
+~~~
+
+## Document
+
+## Purpose and recovery guarantee
+
+- <certain> The user requested a deliberately full checkpoint that can recreate the complete design if model context, a mutable handoff, or another artifact loses state again.
+- <certain> This file therefore overrides Wheypoint's normal compression and no-duplication preference.
+- <certain> A cold reader should be able to reconstruct the intended Easy Cheese and Milknado specs from this file plus the linked evidence without reading an old chat transcript.
+- <certain> Historical decisions, supersessions, unresolved forks, source sessions, proposed record shapes, Wheypoint bugs, and the context-loss diagnosis are all carried here.
+- <certain> Model-context compaction is not accepted as durable memory or decision authority.
+- <certain> Prefer a full durable Wheypoint followed by a fresh session over allowing a long design session to depend on automatic model compaction.
+- <certain> When automatic compaction has already occurred, treat the active model summary as incomplete until it is reconciled against the starting handoff, immutable revisions, decision records, and source artifacts.
+
+## Goal
+
+- <certain> Define the complete agentic protocol used by standalone Easy Cheese and Easy Cheese accelerated by Milknado.
+- <certain> Define the smallest safe v1 executor-recovery contract without losing the wider planner, review, WorkRecord, continuation, identity, artifact, schema, and adapter design.
+- <certain> Keep Easy Cheese's semantic contracts independent of harness and executor while giving Milknado explicit import, execution, checkpoint, recovery, and result-production contracts.
+- <certain> Produce two coupled implementation specs, one for Easy Cheese and one for Milknado, plus one shared compatibility and conformance-fixture matrix.
+- <certain> Repair Wheypoint so a later checkpoint cannot silently delete earlier decisions or rely on a model-generated compaction summary.
+
+## State
+
+- <certain> This remains an advanced mold dialogue; neither implementation spec has passed the two-key approval handshake.
+- <certain> No production implementation, Pydantic model package, generated schema, compatibility fixture corpus, or runtime persistence adapter has been written.
+- <certain> External research and repository grounding are complete for the recovery slice and for the earlier operation, identity, schema, and framework questions.
+- <certain> The July 29 full-scope protocol checkpoint was committed as 4690aed.
+- <certain> The July 31 recovery-focused Wheypoint replaced the same working-tree path and omitted material earlier context.
+- <certain> The current recovery-focused note has been reconciled with the source sessions for the bounded recovery slice.
+- <certain> This new file restores the wider July 29 protocol decisions by value and by link, rather than relying on the overwritten mutable note.
+- <certain> The broader protocol remains part of the eventual design even where the first implementation slice deliberately defers it.
+- <certain> The current branch is checkpoint/root-cheese-milknado-orchestration at 4690aed3df94a4098cc2c86c3706a18da85326fd.
+- <certain> The tracked recovery note is modified by the reconciliation; .claude/ is untracked.
+- <certain> This new full note is under the repository's normally ignored .cheese/ tree and is not remotely durable until deliberately tracked and committed in a later authorized publication step.
+
+## Source and lineage map
+
+### Previous Wheypoints and audits
+
+- <certain> [Current recovery-focused Wheypoint](./root-cheese-milknado-orchestration.md) contains the reconciled July 31 recovery decisions and the August 1 Pydantic-package correction.
+- <certain> [Preserved July 29 full-protocol Wheypoint](https://github.com/paulnsorensen/easy-cheese/blob/4690aed3df94a4098cc2c86c3706a18da85326fd/.cheese/notes/root-cheese-milknado-orchestration.md) is the rich predecessor that the July 31 working-tree write replaced.
+- <certain> [Root Cheese and Milknado decision audit](./root-cheese-milknado-decision-audit.md) adversarially classifies earlier decisions as retained, amended, reopened, or rejected.
+- <certain> [Wheypoint context-loss audit](./wheypoint-root-cheese-context-loss-audit.md) records the overwrite, compaction events, skill gaps, and proposed repairs.
+- <certain> The logical parent global-fanout-policy is not present as a local note in this checkout.
+- <certain> [PR #358](https://github.com/paulnsorensen/easy-cheese/pull/358) contains the parent global-fanout-policy and schema-grounded subagent-design material.
+- <certain> [PR #331](https://github.com/paulnsorensen/easy-cheese/pull/331) contains the earlier cross-skill WorkRecord and Handoff contract under examination.
+
+### Source sessions
+
+- <certain> July 29 session codex:019fabc3-59bf-7d72-926f-115b5dce56b6 contains the shared CurdResult ownership decision and the canonical Pydantic and JSON-validation decisions.
+- <certain> July 29 session codex:019fac63-a3d8-7382-a606-6ea52cefec51 contains operation and invocation identity work.
+- <certain> July 29 session codex:019facd7-109a-7092-96f7-fa9480f8dd6f contains WorkRecord, WorkAttempt, recovery, and the preserved full Wheypoint.
+- <certain> July 31 session codex:019fb6b1-d0a3-7500-ba4b-dbba543f9c7e contains the simplified recovery mold and the no-import choice later corrected by the user.
+- <certain> Current reconstruction session codex:019fb751-d863-7d62-a3db-78e8e3dd1453 contains the handoff audit, source-log recovery, Pydantic-package correction, and this full checkpoint.
+
+### Raw rollout paths
+
+- /home/paul/.codex/sessions/2026/07/29/rollout-2026-07-29T02-45-34-019fabc3-59bf-7d72-926f-115b5dce56b6.jsonl
+- /home/paul/.codex/sessions/2026/07/29/rollout-2026-07-29T05-40-39-019fac63-a3d8-7382-a606-6ea52cefec51.jsonl
+- /home/paul/.codex/sessions/2026/07/29/rollout-2026-07-29T07-46-43-019facd7-109a-7092-96f7-fa9480f8dd6f.jsonl
+- /home/paul/.codex/sessions/2026/07/31/rollout-2026-07-31T05-42-14-019fb6b1-d0a3-7500-ba4b-dbba543f9c7e.jsonl
+- /home/paul/.codex/sessions/2026/07/31/rollout-2026-07-31T08-37-02-019fb751-d863-7d62-a3db-78e8e3dd1453.jsonl
+
+## Context-loss incident and model-compaction policy
+
+### What happened
+
+- <certain> The July 29 Wheypoint explicitly contained the shared Easy Cheese Curd and result ownership, Pydantic v2 canonical models, generated JSON Schema 2020-12, bundled pure-Python validators, WorkRecord and WorkAttempt decisions, continuation records, stable identities, and delivery order.
+- <certain> The July 31 resumed session automatically compacted model context at 06:34:01Z and 08:21:15Z.
+- <certain> At 08:26:25Z the user selected local Milknado implementation over a published import package and asked for a Wheypoint.
+- <certain> At 08:28:04Z the writer replaced the same root-cheese-milknado-orchestration.md path with a much narrower recovery note.
+- <certain> That replacement captured the immediate no-import choice but omitted the earlier Pydantic and one-shared-model context that made the choice semantically surprising.
+- <certain> The current reconstruction session itself automatically compacted at 2026-08-01T08:16:48Z before the full handoff audit completed.
+- <certain> The current agent therefore had to recover historical decisions from the committed July 29 note and the raw rollout logs rather than trust active model context alone.
+
+### Why it happened
+
+1. <certain> Wheypoint instructs the writer to reuse an existing slug but does not require reading and reconciling the existing note before replacing the path.
+2. <certain> Wheypoint treats the current conversation as its primary input and has no mandatory recovery path when the conversation has already been compacted.
+3. <certain> The writer pointed at a decision-audit artifact that predated several later July 29 decisions.
+4. <certain> The overwritten note had no immutable predecessor or compaction-receipt link in its own schema.
+5. <certain> The July 31 note used status: ok despite open human design forks, violating the skill's gated-state rule and bypassing the mandatory decision dossier.
+6. <certain> Current tests validate the prose present in Wheypoint's SKILL.md, not the correctness or preservation behavior of a generated handoff.
+7. <certain> /cheese --continue reads one selected note and does not reconcile it against parents, a prior revision, Git provenance, or source sessions.
+8. <don't know> The exact automatic-compaction summaries are encrypted, so their retained and omitted facts cannot be audited.
+9. <speculative> Automatic compaction increased the probability of omission, but overwrite without reconciliation and validation was the deterministic data-loss mechanism.
+
+### User-required compaction rule
+
+- <certain> Avoid automatic model-context compaction for long design and mold sessions.
+- <certain> Before the context window is likely to compact, stop and write a full Wheypoint from durable sources, then continue in a fresh session.
+- <certain> A model compaction summary is a navigation aid only; it is never authoritative evidence for a prior decision.
+- <certain> After a detected compaction, do not make a superseding design decision or write a replacement Wheypoint until the starting handoff and decision ledger have been reconciled.
+- <certain> The eventual Wheypoint contract must make this rule executable rather than advisory.
+
+## Cross-contract shape
+
+<certain> The intended architecture remains four related layers with one authority for each fact.
+
+~~~text
+Domain contracts owned by Easy Cheese
+  PlannerRequest / PlannerResult
+  ReviewRequest / ReviewResult
+  CurdPlan / CurdResult
+
+Execution protocol shared across runtimes
+  OperationInvocation<TRequest>
+  OperationCheckpoint<TResult>
+  OperationOutcome<TResult>
+
+Workflow continuity owned by Easy Cheese
+  WorkRecord / WorkAttempt
+  ContinuationAssessment
+  ContinuationDecision
+  ContinuationRecord
+  CompactionRecord
+  Wheypoint cold-reader projection
+
+Runtime adapters
+  Easy Cheese standalone executor
+  Milknado importer, graph executor, recovery owner, result producer
+~~~
+
+- <certain> These layers reference each other through stable IDs, schema versions, and immutable digests.
+- <certain> They do not duplicate execution status, domain result, continuation choice, or artifact ownership.
+
+## Locked decisions
+
+### Ownership and boundaries
+
+- <certain> Easy Cheese owns CurdPlan, CurdResult, semantic planning, review, operation, WorkRecord, compaction, continuation, schema, identity-rule, and compatibility-fixture contracts.
+- <certain> Milknado owns curd import, graph mapping, graph persistence, physical scheduling, runtime recovery, and actual executor resolution for invocations it admits.
+- <certain> Root Cheese owns topology, policy, and orchestration intent; the admitting runtime owns mutable execution truth.
+- <certain> Standalone Easy Cheese and Milknado-assisted execution are both first-class modes using the same semantic contracts.
+- <certain> Human configuration outranks an agent request, which outranks executor defaults; the resolved execution choice is recorded.
+- <certain> Curd, physical change, batch, wave, graph node, operation, invocation, and agent remain distinct concepts.
+- <certain> There is no universal total-curd, total-wave, or node-count cap.
+- <certain> Root Cheese projects cost including retries, reviews, remediation, checkpoints, and capacity; expensive plans require a human gate.
+
+### Two Milknado ingress paths
+
+- <certain> A raw goal or spec enters semantic planning, physical planning, batching, and graph construction.
+- <certain> An approved CurdPlan bypasses semantic decomposition and cross-curd batching and enters the Milknado adapter directly.
+- <certain> One semantic curd maps to one Milknado goal or task group with aggregate curd-level verification.
+- <certain> Milknado GOAL, task, graph, node, run, and executor-attempt records remain runtime state and foreign provenance, not CurdPlan fields.
+
+### Planning and review
+
+- <certain> Semantic planning and physical execution planning are separate stages.
+- <certain> PlannerRequest carries an explicit intent including at least decompose, remediate, or replan plus typed evidence.
+- <certain> PlannerResult may contain a CurdPlan and must express no-work, blocked, complete, and valid-partial outcomes without conflating them with executor failure.
+- <certain> Standalone Easy Cheese may use agent generation followed by deterministic validation.
+- <certain> Milknado may add deterministic grouping and deduplication, use an agent only for ambiguity, and validate the same semantic result.
+- <certain> Taste-test and /age are review types in one typed review family.
+- <certain> Review batches preserve successful items when another item fails; correlation never relies on array position.
+- <certain> Review findings do not route directly to curds; they enter PlannerRequest with remediation intent.
+- <certain> A clean review produces no_work rather than an empty plan or a review-specific clean_complete shortcut.
+
+### Curd result and continuation ownership
+
+- <certain> Milknado already consumes the Easy Cheese curd shape and must produce the Easy Cheese CurdResult shape rather than invent a second semantic result vocabulary.
+- <certain> CurdResult records acceptance-level outcomes, completed and missed work, semantic evidence, deliverables, follow-up candidates, and foreign runtime provenance.
+- <certain> Acceptance results distinguish at least passed, failed, blocked, and skipped.
+- <certain> OperationOutcome owns execution status, runtime diagnostics, usage, and executor provenance.
+- <certain> Root Cheese evaluates results and shepherds continuation; Milknado reports what happened and does not choose the next Easy Cheese phase.
+
+### Operation and invocation identity
+
+- <certain> The generic execution shape is OperationInvocation<TRequest> to zero or more OperationCheckpoint<TResult> records to one OperationOutcome<TResult>.
+- <certain> Operation is the correct term because the executor may be an agent, deterministic code, or a workflow.
+- <certain> operation_id identifies one immutable semantic request.
+- <certain> invocation_id identifies one admitted execution of that operation.
+- <certain> Transport replay and Milknado-internal transient retries remain inside the current invocation until terminalization.
+- <certain> A retry after terminalization creates a new invocation under the same operation.
+- <certain> A semantic change to goal, subject, intent, or acceptance contract creates a new operation.
+- <certain> Changing executor strategy, model, limits, runtime environment, or retry creates a new invocation without changing the operation.
+- <certain> Execution status and domain-result status remain separate.
+- <certain> A failed, cancelled, timed-out, or lost invocation may still carry its latest schema-valid partial result.
+- <certain> Failure before the first valid checkpoint may carry no domain result.
+- <certain> Domain result types own their partial-completion ledgers.
+
+### Execution and handoff IDs
+
+- <certain> Execution operation_id and Handoff operation_id are always distinct.
+- <certain> Execution operation_id names the semantic request.
+- <certain> Handoff operation_id is a commit-idempotency key for applying one continuity transition.
+- <certain> Handoff provenance links the related execution invocation IDs and terminal outcome digest.
+- <certain> Easy Cheese IDs and Milknado IDs remain separate namespaces.
+- <certain> Milknado run_id is task-dispatch provenance and never aliases invocation_id.
+
+### Lost-executor recovery
+
+- <certain> A failed, lost, cancelled, or timed-out invocation never reopens.
+- <certain> Recovery creates exactly one successor invocation under the same operation.
+- <certain> A unique predecessor_invocation_id enforces at most one successor.
+- <certain> Timeout or unresponsiveness triggers termination of the runtime-owned process group: TERM, grace period, KILL if needed, then confirmation that the process is gone.
+- <certain> Only confirmed termination permits predecessor terminalization, managed-worktree transfer, and successor admission.
+- <certain> If termination cannot be confirmed, recovery becomes manual and no successor is admitted.
+- <certain> The predecessor's terminal status preserves the initiating cause: timed_out, cancelled, lost, or failed; forced kill is diagnostic detail.
+- <certain> Recovery resumes the work, not the old transcript or uncertain agent.
+- <certain> A successor starts a fresh Codex or Claude session seeded only from durable state.
+- <certain> Crash-time transcript resume and session forking are excluded.
+- <certain> The existing managed worktree transfers to the successor only after confirmed termination.
+- <certain> Recovery may proceed from the surviving managed worktree when no checkpoint exists.
+- <certain> The successor receives the original request, worktree identity and status, predecessor terminal cause, and latest checkpoint when present.
+- <certain> Old transcript and progress events are excluded from the successor seed.
+- <certain> The runtime records a canonical worktree fingerprint at confirmed termination covering HEAD, index, tracked content, and untracked content; ignored files are excluded.
+- <certain> The runtime recomputes that fingerprint immediately before successor admission.
+- <certain> Any mismatch requires manual recovery.
+- <certain> Automatic v1 recovery covers runtime-owned protocol state, managed worktrees, and Git state only.
+- <certain> Arbitrary unmanaged external effects require manual recovery.
+- <certain> V1 has no generic effect taxonomy, reconciliation plugin system, public ReconciliationEvidence type, recovery-hold entity, central coordinator service, or fencing epoch.
+- <certain> The active invocation_id gates protocol writes; the proposed fence_token was removed from v1.
+
+### Normal execution and checkpoints
+
+- <certain> One normal Ralph iteration remains inside the same Milknado run and invocation.
+- <certain> Ralph iteration progress stays Milknado-local; the shared protocol has no ProgressEvent.
+- <certain> A known-exclusive normal continuation may resume the same harness session.
+- <certain> Uncertain, failed, lost, or recovered execution never resumes the old harness session.
+- <certain> Checkpoints occur at explicit durable domain boundaries, not after every Ralph iteration.
+- <certain> Every checkpoint is a complete schema-valid snapshot rather than a delta.
+- <certain> The admitting runtime atomically assigns checkpoint identity and order, validates the snapshot, and computes its canonical digest.
+- <certain> Repeating identical checkpoint content returns the latest matching checkpoint.
+- <certain> Changed checkpoint content creates the next checkpoint.
+- <certain> Checkpoint retention is reachability-based.
+- <certain> Retain checkpoint data while the operation remains recoverable or a successor or outcome requires the reference to resolve.
+- <certain> A terminal outcome permanently retains checkpoint digest and provenance.
+- <certain> Unreferenced checkpoint data may be garbage-collected after terminal operation completion.
+- <certain> Configurable extra checkpoint history is excluded from v1.
+
+### WorkRecord and WorkAttempt
+
+- <certain> WorkRecord is the living continuity authority for one user work item.
+- <certain> WorkAttempt is a first-class independently resumable orchestration lineage under one WorkRecord.
+- <certain> WorkAttempt identity is independent of branch, worktree, harness, remote worker, executor, and Milknado graph.
+- <certain> A WorkAttempt owns tentative context and groups multiple operations across phases and environments.
+- <certain> WorkRecord creation atomically creates its initial WorkAttempt.
+- <certain> Additional WorkAttempts require an explicit fork_attempt action with rationale and parent-attempt references.
+- <certain> Replanning, phase changes, retries, model changes, and environment moves normally remain inside the same WorkAttempt.
+- <certain> Converging approaches creates a new WorkAttempt referencing all parents; historical attempts are not rewritten.
+- <certain> Accepted shared context belongs to WorkRecord; attempt-local context remains tentative until explicitly promoted.
+
+### Plan and curd identity
+
+- <certain> Every successful planning operation produces a new immutable CurdPlan with a new plan_id and canonical digest.
+- <certain> Replanning references prior plans by stable ID and digest and never mutates an earlier plan.
+- <certain> An unchanged curd retains the same curd_id and digest across plans.
+- <certain> A semantic change to curd goal, scope, inputs, outputs, or acceptance contract creates a new curd_id with derivation from its predecessor.
+- <certain> Physical placement, batch, wave, node, executor, and model changes do not change curd identity.
+- <certain> Easy Cheese alone mints Easy Cheese work, attempt, operation, invocation, plan, curd, compaction, continuation, and artifact identities.
+- <certain> Milknado alone mints Milknado identities and never invents a value in the Easy Cheese namespace.
+- <certain> Human-readable slugs, timestamps, paths, branches, database row IDs, array positions, and Milknado IDs are labels or provenance, not Easy Cheese identity.
+
+### Wheypoint and compaction contract
+
+- <certain> Wheypoint is a workflow-compaction operation over WorkRecord, not a second durable authority.
+- <certain> A compaction atomically updates the living WorkRecord and emits an immutable CompactionRecord receipt.
+- <certain> The cold-reader Markdown Wheypoint is a projection of WorkRecord and CompactionRecord state.
+- <certain> Repeated compactions retain work and attempt identity while receiving new compaction identities.
+- <certain> OperationCheckpoint and WorkRecord compaction solve different problems.
+- <certain> Session, Git, harness, model, transcript, and creation time are provenance, not identity.
+- <certain> Wheypoint split explicitly creates child WorkAttempts with parent-attempt and compaction references.
+- <certain> Joining attempts inside one WorkRecord creates a convergence WorkAttempt; unresolved conflicts remain gated.
+- <speculative> Joining different WorkRecords should require an explicit authority decision rather than silently merging them.
+
+### Agent-facing compaction helper
+
+- <certain> The chosen helper direction is the A2 single-shot semantic-delta model.
+- <certain> Managed agents perform one checkpoint call; OperationInvocation supplies the continuity reference.
+- <certain> Standalone Wheypoint may use current-work resolution only when work and attempt resolution are deterministic.
+- <certain> An optional read-only prepare or inspection path is reserved for ambiguity, conflict, stale state, joins, or explicit mutation of existing structured entries.
+- <certain> Agents submit orientation, compact narrative, new decisions and questions, artifact references, explicit resolutions, and desired continuation.
+- <certain> The runtime owns IDs, revisions, parentage, paths, canonical digests, provenance, carry-forward, preservation ledger, atomic persistence, and replay handling.
+- <certain> Omitted protected state is carried forward; omission never means deletion.
+- <certain> Generic deletion is absent from the agent contract.
+- <certain> Closure uses explicit verbs such as resolve, park, supersede, unlink, or abandon.
+- <certain> The full Pydantic CompactionRecord is runtime output and fixture material rather than agent-authored input.
+- <certain> Ambiguity or conflict returns a structured no-write error.
+
+### Continuation contract
+
+- <certain> Outcome evidence does not request or select the next phase by default.
+- <certain> ContinuationAssessment carries at least complete, blocked, choice_required, or continuable.
+- <certain> Assessment candidates are unranked and preserve origin and rationale.
+- <certain> preferred is null unless explicit intent or authorized deterministic policy supports a choice.
+- <certain> Agents may add relevant candidates; a phase registry validates them; agents do not rank or select them.
+- <certain> ContinuationDecision records a selected phase, hold, or null with basis explicit_user, authorized_policy, or deterministic_singleton.
+- <certain> ContinuationRecord applies the decision and WorkRecord revision atomically.
+- <certain> Multiple valid transitions without user intent produce choices without preselection.
+- <certain> gated is a continuation state and not an execution failure.
+- <certain> The older dual-purpose Handoff concept is split into evidence, assessment, decision, and applied transition even though exact type names remain open.
+
+### Canonical schema, wire format, and validation
+
+- <certain> Pydantic v2 models are the canonical contract-authoring source.
+- <certain> Generated JSON Schema 2020-12 is the portable interchange artifact.
+- <certain> Agent requests, agent results, protocol envelopes, and compatibility fixtures use JSON by default.
+- <certain> YAML and Markdown may remain human configuration or projection formats where explicitly retained; they are not the canonical contract definition.
+- <certain> cheese.pyz strictly decodes bounded UTF-8 JSON, rejects duplicate keys and non-finite numbers, and validates payloads at each trust boundary.
+- <certain> cheese.pyz bundles generated model-specific pure-Python validators.
+- <certain> cheese.pyz does not require Pydantic, pydantic-core, jsonschema, jschon, or another generic JSON Schema runtime.
+- <certain> Build-time parity tests prove Pydantic and generated validators accept and reject the same fixture corpus.
+- <certain> No Draft 7 down-conversion is used.
+
+### Shared Pydantic package distribution
+
+- <certain> Milknado imports Easy Cheese's versioned Python contract package and uses the shared Pydantic models.
+- <certain> Milknado does not maintain parallel local Pydantic equivalents for the public cross-repository contract.
+- <certain> The same canonical models generate the JSON Schema, fixture corpus, and standalone cheese.pyz validators.
+- <certain> The July 31 choice that Milknado would implement the contract locally without importing an Easy Cheese package is superseded by the user's August 1 clarification.
+- <don't know> The package name, repository location, publication mechanism, version pinning, and compatibility-range policy remain open.
+
+### Delivery shape and order
+
+- <certain> Produce two coupled specs and one shared compatibility and fixture matrix rather than one blended monolith.
+- <certain> Define Pydantic models, generated schemas, fixtures, identity and error rules, and generated validators before orchestration depends on them.
+- <certain> Both repositories implement producer and consumer behavior against the same fixture matrix.
+- <certain> Milknado then implements curd import, graph mapping, runtime persistence, checkpoint and outcome production, recovery, and result adaptation.
+- <certain> Easy Cheese then wires standalone execution, root orchestration, review-to-planner flow, WorkRecord compaction, and continuation.
+- <certain> Earlier ADRs, PR #331, and PR #358 must be explicitly retained, amended, rejected, or superseded.
+- <certain> A Milknado follow-up for curd-local physical splitting is deferred until the boundary contract is fixed.
+- <certain> The follow-up must preserve curd acceptance semantics and aggregate subnode verification into one CurdResult.
+
+## Reconstructed interface sketches
+
+### Package and validation flow
+
+<certain> One authoring source serves both repositories and the standalone zipapp.
+
+~~~text
+Easy Cheese Pydantic v2 models
+          |
+          +--> versioned Python contract package --> imported by Milknado
+          |
+          +--> JSON Schema 2020-12
+          |
+          +--> valid / invalid / partial / replay fixtures
+          |
+          +--> generated model-specific pure-Python validators
+                                                 |
+                                                 +--> bundled in cheese.pyz
+~~~
+
+### Execution and recovery flow
+
+<certain> Recovery creates a successor only after the predecessor cannot write again.
+
+~~~text
+Operation
+  |
+  +-- Invocation A admitted
+        |
+        +-- Checkpoint 1
+        +-- executor becomes unresponsive
+        +-- TERM -> grace -> KILL if required
+        +-- confirm owned process is gone
+        +-- terminalize Invocation A with initiating cause
+        +-- capture worktree fingerprint
+        +-- verify fingerprint immediately before admission
+        |
+        +-- Invocation B admitted with predecessor=A
+              |
+              +-- fresh harness session
+              +-- original request
+              +-- transferred worktree
+              +-- latest checkpoint when present
+              +-- one terminal outcome
+~~~
+
+### Wheypoint target flow
+
+<certain> The future note is a validated projection, not mutable source-of-truth prose.
+
+~~~text
+WorkRecord revision N
+        +
+active WorkAttempt
+        +
+prior CompactionRecord
+        +
+semantic delta from agent or user
+        |
+        v
+runtime validation and reconciliation
+  - preserve omitted protected decisions
+  - explicit resolve / park / supersede
+  - stable IDs and digests
+  - reject stale or ambiguous writes
+        |
+        +--> WorkRecord revision N+1
+        +--> immutable CompactionRecord receipt
+        +--> generated cold-reader Wheypoint projection
+~~~
+
+## Candidate record fields for spec reconstruction
+
+<certain> These are reconstruction constraints and candidate fields; exact model definitions remain gated.
+
+### OperationInvocation
+
+- <certain> Required concepts include operation_id, invocation_id, request schema identifier and version, immutable request digest, admitted-at provenance, runtime owner, execution request, resolved execution configuration, and optional predecessor_invocation_id.
+- <don't know> Exact timestamp, issuer, capability, redaction, environment-reference, and idempotency-key fields remain to be drafted.
+- <certain> The request body is a typed domain payload rather than an unbounded generic mapping.
+
+### OperationCheckpoint
+
+- <certain> Required concepts include operation_id, invocation_id, runtime-assigned checkpoint identity and order, full typed result snapshot, canonical snapshot digest, creation provenance, and schema version.
+- <certain> The producer validates the snapshot before persistence and exposure.
+- <don't know> Exact sequence-conflict, replay, late-write, size-bound, and storage-reference fields remain open.
+
+### OperationOutcome
+
+- <certain> Required concepts include operation_id, invocation_id, terminal execution status, terminal cause, optional complete or partial typed domain result, result digest, latest checkpoint reference, runtime diagnostics, usage, executor provenance, and terminal timestamp.
+- <certain> The outcome is self-contained even when older checkpoint bodies are later garbage-collected.
+- <don't know> Exact diagnostic schema and artifact ownership fields remain open.
+
+### Recovery state or transaction
+
+- <certain> Required concepts include predecessor invocation, initiating cause, termination attempts and confirmation, managed worktree identity, captured fingerprint, latest eligible checkpoint reference, successor admission result, and manual-recovery reason when blocked.
+- <certain> No public recovery-hold identity or fencing epoch exists in v1.
+- <don't know> Whether this is a first-class persisted record, a transaction journal, or fields across invocation records remains open.
+
+### WorkRecord and CompactionRecord
+
+- <certain> WorkRecord requires stable work identity, active and historical attempt references, accepted shared context, current continuation state, revision, and protected decision, question, blocker, and artifact-link entries.
+- <certain> CompactionRecord requires stable compaction identity, prior revision, resulting revision, request fingerprint, preservation ledger, explicit resolutions, provenance, digest, and generated-projection reference.
+- <certain> Entries require stable IDs so carry-forward, resolution, parking, and supersession can be proven.
+- <don't know> Exact bounded narrative fields, storage format, concurrency token, and garbage-collection rules remain open.
+
+### CurdPlan and CurdResult
+
+- <certain> CurdPlan requires stable plan and curd identities, canonical digests, semantic goals, bounded scope, inputs, outputs, acceptance contracts, and derivation references.
+- <certain> CurdResult requires curd identity and digest, completion disposition, acceptance-result ledger, semantic evidence and deliverables, completed and missed work, follow-up candidates, and foreign runtime provenance.
+- <don't know> Exact enums, field names, artifact-reference placement, and valid-partial invariants remain open.
+
+## Complete unresolved backlog
+
+### Recovery and checkpoint protocol
+
+1. <certain> Resolved: a lost predecessor terminalizes before recovery; the successor is a new invocation under the same operation.
+2. <certain> Resolved for local v1: confirmed process-group termination is the ownership proof; no successor is admitted without it.
+3. <certain> Resolved: terminal causes preserve timed_out, cancelled, lost, or failed; forced kill is diagnostic.
+4. <don't know> Draft the exact predecessor, successor, resume, checkpoint-reference, and compatibility fields.
+5. <certain> Resolved: every checkpoint carries a full valid domain snapshot.
+6. <don't know> Define exact sequence origin, monotonicity, gap handling, out-of-order delivery, and concurrent-write rejection.
+7. <certain> Partially resolved: identical content is idempotent and changed content advances; exact conflict behavior for reused order or identity remains open.
+8. <don't know> Define duplicate outcome replay, late writes after terminalization, and durable idempotency lookup.
+9. <certain> Partially resolved: explicit domain boundaries and reachability retention are fixed; exact byte limits and cost accounting remain open.
+10. <don't know> Define crash recovery for the WorkRecord and CompactionRecord transaction itself.
+
+### Identity and provenance
+
+11. <don't know> Draft WorkAttempt lifecycle fields and distinguish stored control state from progress derived from operations.
+12. <don't know> Define when a changed user objective remains one WorkRecord versus creates a new WorkRecord.
+13. <don't know> Define stable review request and result item identities for batch correlation.
+14. <don't know> Define identities and reference lifetimes for assessment, decision, continuation transaction, and handoff projection.
+15. <don't know> Define exact CompactionRecord identity and parent-compaction references.
+16. <don't know> Decide whether every artifact receives an Easy Cheese artifact_id in addition to its digest.
+17. <don't know> Define foreign runtime-reference fields for issuer, subsystem, project or database, graph, goal, task, node, run, and executor attempt.
+18. <certain> Resolved: execution and handoff operation IDs are distinct and explicitly related.
+
+### WorkRecord, compaction, and continuation
+
+19. <don't know> Draft exact WorkRecord and WorkAttempt fields, bounded context sections, revision rules, and accepted-versus-tentative promotion operations.
+20. <don't know> Draft exact compaction request, CompactionRecord, preservation ledger, and cold-reader projection schemas.
+21. <don't know> Specify the single-shot helper request, managed continuity-reference injection, standalone current-work resolution, optional prepare flow, and structured errors.
+22. <don't know> Define stable decision, question, blocker, and artifact-link entries plus their resolve, park, supersede, unlink, and abandon transitions.
+23. <don't know> Define concurrent compaction, stale snapshot, canonical request fingerprint, replay lookup, and lost-response recovery.
+24. <don't know> Define same-WorkRecord split and join transactions and convergence-attempt creation.
+25. <don't know> Decide cross-WorkRecord join behavior.
+26. <certain> Resolved as policy: model transcripts and compaction summaries are not authoritative continuity state.
+27. <don't know> Decide whether raw transcripts receive optional digests or provenance references or are deliberately excluded.
+28. <don't know> Bound CompactionRecord history and define archival or garbage collection without breaking auditability.
+29. <don't know> Choose persisted representations for WorkRecord, CompactionRecord, continuation records, and Markdown projections.
+30. <don't know> Finish exact boundaries between immutable evidence, assessment, decision, applied transition, and projection.
+31. <don't know> Define assessment staleness, registry validation, candidate schema, decision basis, application conflicts, and gated projection.
+
+### Artifact and result ownership
+
+32. <don't know> Confirm the final boundary between semantic deliverables in domain results and runtime diagnostics in OperationOutcome.
+33. <don't know> Draft artifact references including ID, digest algorithm and value, media type, role, producer, size, URI or path, availability, and redaction metadata.
+34. <don't know> Decide whether stored artifacts repeat their path, derive it from identity, or support relocation.
+35. <don't know> Define artifacts in partial results, failed invocations, checkpoints, retries, and aggregation.
+36. <don't know> Define path normalization, digest verification, bounded reads, missing content, and mutable external-URL checks.
+
+### Planner, review, and CurdResult
+
+37. <don't know> Draft exact PlannerRequest fields, evidence unions, intent invariants, and subject references.
+38. <don't know> Define PlannerResult completion and valid-partial dispositions.
+39. <don't know> Draft ReviewRequest and ReviewResult types, discriminators, correlation, and item-level partial failure.
+40. <don't know> Draft exact CurdResult fields and acceptance-ledger invariants.
+41. <don't know> Define semantic curd digest normalization rules.
+42. <don't know> Choose deterministic interim behavior for a curd too large for one physical task when no splitter exists.
+
+### Milknado adapter
+
+43. <don't know> Draft raw-goal and approved-CurdPlan ingress request and result models.
+44. <don't know> Define mapping from Easy Cheese work, attempt, operation, invocation, plan, and curd references to Milknado runtime provenance.
+45. <don't know> Define package and schema-version negotiation, capability advertisement, supported ranges, and compatibility failures.
+46. <don't know> Define rejection, fallback, and no-work behavior for invalid plans, unsupported features, missing capabilities, digest conflicts, and oversized curds.
+47. <don't know> Define graph-persistence and recovery links to invocation checkpoints and outcomes.
+48. <don't know> Define CurdResult aggregation from tasks and nodes under partial runtime failure.
+49. <don't know> Define executor configuration references or snapshots, precedence, immutable resolution, and secret redaction.
+50. <don't know> Define deterministic physical grouping, deduplication, ambiguity detection, and agent-planner boundary.
+51. <don't know> Define admission and result behavior for replay, digest conflict, partial import, executor unavailability, and cross-database references.
+
+### Schema, package, validation, and fixtures
+
+52. <don't know> Draft exact Pydantic fields, enums, discriminators, conditional requirements, closed-object rules, and version identifiers.
+53. <don't know> Define additive and breaking evolution rules, unknown-field handling, and Easy Cheese to Milknado compatibility ranges.
+54. <don't know> Decide whether the bounded PhaseContract vocabulary remains for human-authored declarations, compiles from generated schema, or is superseded.
+55. <don't know> Specify generated validator architecture, covered constraints, error paths, recursion and size bounds, and zipapp packaging.
+56. <don't know> Define positive, negative, partial, replay, identity-conflict, stale-revision, recovery, and cross-version fixtures.
+57. <don't know> Choose package name and location, generated-schema and fixture paths, publication workflow, version pinning, and cross-repository compatibility command.
+58. <don't know> Prove canonical Pydantic, generated validators, Easy Cheese producers and consumers, and Milknado producers and consumers agree on every fixture.
+
+### Delivery and migration
+
+59. <don't know> Draw the exact requirement boundary between the Easy Cheese spec, Milknado spec, and shared compatibility matrix.
+60. <don't know> Finalize implementation dependency order and cumulative quality gates.
+61. <don't know> Complete explicit retain, amend, reject, or supersede mapping for relevant ADRs, PR #331, and PR #358.
+62. <don't know> Define migration from positional handoff notes and the PR #331 WorkRecord model.
+63. <don't know> Define backwards-compatible rendering and /cheese --continue behavior while preventing legacy notes from becoming a second authority.
+64. <don't know> File and define the Milknado curd-local physical-splitting follow-up after its boundary is fixed.
+
+## Decision dossier
+
+### Fork 1: Python contract package location and release
+
+- <certain> Option A places an importable versioned contract package in the Easy Cheese project or its release distribution.
+- <certain> Option B publishes a separate contracts-only package or repository governed by Easy Cheese.
+- <certain> Option C distributes only JSON Schema and fixtures while Milknado maintains local Pydantic models.
+- <certain> The user rejected Option C's duplicated-model outcome and requires Milknado to import Easy Cheese's models.
+- <speculative> Option A is the shortest path while the contracts have one owner; Option B may become justified if release cadence or non-Easy-Cheese consumers create pressure.
+- <speculative> Option A couples Milknado upgrades to Easy Cheese package releases; Option B adds a third release artifact and governance surface.
+- <certain> Prior leaning is Option A in ownership terms; exact package boundary and name remain undecided.
+- <certain> Evidence: current recovery Wheypoint, Decision-provenance audit and Shared Pydantic package distribution sections in this file.
+
+### Fork 2: runtime persistence
+
+- <certain> Option A uses runtime-local SQLite ledgers with atomic transactions and indexed replay lookup.
+- <certain> Option B uses append-only JSON records plus derived current-state projections.
+- <certain> Option C uses YAML or Markdown living records as authoritative state.
+- <certain> Runtime-local ownership is fixed regardless of format.
+- <speculative> SQLite most directly supports unique predecessor constraints, atomic checkpoint ordering, replay lookup, and recovery transactions.
+- <speculative> Append-only JSON is easier to inspect and exchange but requires careful locking and derived indexes.
+- <certain> The incident demonstrates that mutable Markdown must not be the only continuity authority.
+- <don't know> No prior user choice selects SQLite versus append-only JSON.
+
+### Fork 3: exact shared record family
+
+- <certain> Option A keeps generic OperationInvocation, OperationCheckpoint, and OperationOutcome envelopes with typed domain payloads.
+- <certain> Option B defines only operation-specific records without the generic envelope.
+- <certain> Option C routes all execution and continuity facts through one universal WorkRecord record.
+- <certain> Prior decisions select Option A.
+- <speculative> Option B duplicates execution invariants across planner, review, curd, and compaction operations.
+- <speculative> Option C mixes execution, domain, and continuation authorities and recreates the dual-purpose handoff problem.
+- <don't know> Exact fields and module boundaries inside Option A remain to be drafted.
+
+### Fork 4: Wheypoint authority and preservation
+
+- <certain> Option A uses WorkRecord as living authority, immutable CompactionRecord receipts, stable entry IDs, preservation ledger, and a generated Markdown projection.
+- <certain> Option B keeps a mutable Markdown Wheypoint as the continuity authority.
+- <certain> Option C relies on the current model transcript or automatic compaction summary.
+- <certain> Earlier decisions select Option A.
+- <certain> The user rejects Option C as a persistence mechanism and wants model compaction avoided.
+- <certain> The July 31 incident demonstrates that Option B can silently delete state during same-path replacement.
+- <speculative> Option A prevents this incident only if carry-forward, explicit supersession, immutable receipts, and stale-write rejection are mandatory and validated.
+
+### Fork 5: package and schema version negotiation
+
+- <certain> Option A pins a compatible Python-package version range and verifies schema IDs plus fixture compatibility.
+- <certain> Option B pins exact artifact digests for generated schemas and fixtures in addition to package version.
+- <certain> Option C consumes whichever contract version is latest at runtime.
+- <speculative> Option B offers the strongest reproducibility but adds update ceremony.
+- <certain> Option C conflicts with deterministic recovery and repeatable fixture validation.
+- <don't know> No prior user decision selects Option A versus B.
+
+### Fork 6: initial implementation boundary
+
+- <certain> Option A implements the bounded operation, checkpoint, outcome, recovery, shared package, and Milknado adapter slice first while keeping wider contracts in the specs.
+- <certain> Option B implements the complete WorkRecord, planner, review, continuation, artifact, and migration design before any recovery integration.
+- <certain> Option C narrows the specs so aggressively that the wider locked decisions disappear.
+- <speculative> Option A is the smallest shippable sequence that preserves the whole design without blocking recovery on every broader schema.
+- <certain> Option C is rejected by this incident because scope narrowing cannot erase prior decisions.
+- <certain> Prior July 31 simplification and the current recovery note lean toward Option A.
+
+## Wheypoint bugs to file
+
+### Bug 1: same-slug replacement silently drops prior decisions
+
+- <certain> Reproduction: start from the full note committed at 4690aed, resume it, then run Wheypoint with the same slug after narrowing the active topic.
+- <certain> Actual result: the path is replaced and earlier decisions disappear unless independently versioned elsewhere.
+- <certain> Expected result: every prior decision is retained, explicitly superseded, or explicitly deferred, and the prior revision remains immutable.
+- <speculative> Acceptance: add a prior-note reconciliation pass, immutable revision or receipt, and a regression fixture based on this incident.
+
+### Bug 2: generated handoff can violate status and blocker invariants
+
+- <certain> Reproduction: write a note with status: ok and multiple unresolved human design forks under Open questions and blockers.
+- <certain> Actual result: Wheypoint writes the note and /cheese --continue auto-dispatches mold.
+- <certain> Expected result: the artifact is rejected or rewritten as status: gated with a complete decision dossier.
+- <speculative> Acceptance: validate generated notes rather than only linting SKILL.md prose.
+
+### Bug 3: compacted sessions do not rehydrate before checkpointing
+
+- <certain> Reproduction: resume a rich handoff, allow one or more harness context_compacted events, then write a new Wheypoint.
+- <certain> Actual result: no mandatory step reloads and reconciles the starting handoff.
+- <certain> Expected result: a detected compaction blocks superseding decisions and checkpoint writes until durable state is rehydrated.
+- <speculative> Acceptance: record compaction detection in provenance and require a reconciliation report.
+
+### Bug 4: stale or incomplete artifact references satisfy no-duplication guidance
+
+- <certain> Reproduction: point artifact at an audit written before later decisions, then omit those decisions from the new note.
+- <certain> Actual result: the note appears compact and linked but the link cannot reconstruct the missing state.
+- <certain> Expected result: referenced artifacts are checked for existence, revision, freshness, and coverage before they substitute for carried state.
+- <speculative> Acceptance: require immutable digest or revision references and a coverage reconciliation.
+
+### Bug 5: continuation ignores lineage and prior revisions
+
+- <certain> Reproduction: continue a note whose parents or Git provenance identify prior state that the selected file no longer carries.
+- <certain> Actual result: /cheese --continue reads one file and does not traverse or validate lineage.
+- <certain> Expected result: the current projection is validated against its immutable compaction parent and required artifacts before dispatch.
+- <speculative> Acceptance: use stable compaction and WorkRecord references rather than recursive slug-only traversal.
+
+### Bug 6: unresolved parent references are allowed
+
+- <certain> Reproduction: write parents: [global-fanout-policy] when no local note with that slug exists.
+- <certain> Actual result: the handoff is accepted and a cold reader cannot resolve the parent locally.
+- <certain> Expected result: each parent resolves to an immutable local or remote reference, or the handoff records the unresolved external URL explicitly.
+- <speculative> Acceptance: validate parent resolution and include remote commit, PR, or artifact URL.
+
+### Bug 7: provenance records only the latest session
+
+- <certain> Reproduction: repeatedly resume and checkpoint a design across several sessions.
+- <certain> Actual result: session records only the current writer; source-session lineage is retained only in prose or raw logs.
+- <certain> Expected result: the CompactionRecord references the prior compaction and optionally records the bounded set of source sessions used for reconciliation.
+- <speculative> Acceptance: add structured prior-compaction provenance without making session identity authoritative.
+
+### Bug 8: ignored Wheypoints are not durable by default
+
+- <certain> Reproduction: create a critical new note under the normally ignored .cheese/ tree without an explicit publication step.
+- <certain> Actual result: the note survives locally but can disappear with checkout cleanup and is not available remotely.
+- <certain> Expected result: a full or critical Wheypoint surfaces its durability state and routes to an explicit preserve or publish choice.
+- <speculative> Acceptance: add a durability field or warning without silently committing user work.
+
+## Would the proposed new Wheypoint contract have prevented this?
+
+| Incident mechanism | Proposed protection | Prevention assessment |
+| --- | --- | --- |
+| Same-path overwrite | <certain> Immutable CompactionRecord plus revisioned WorkRecord | <speculative> Yes, if the old receipt is retained and the write uses optimistic revision checks. |
+| Omitted prior decisions | <certain> Omission never deletes protected state; preservation ledger carries it forward | <speculative> Yes, if every durable decision has a stable ID and protected status. |
+| Silent change of meaning | <certain> Explicit resolve, park, supersede, unlink, or abandon verbs | <speculative> Yes, because disappearance without an explicit transition would fail validation. |
+| Compacted model context | <certain> WorkRecord rather than transcript is continuity authority | <speculative> Mostly, but the contract needs an explicit detected-compaction rehydration gate. |
+| status: ok with human forks | <certain> Typed ContinuationAssessment and gated projection | <speculative> Yes, if projection validation rejects inconsistent status and blockers. |
+| Stale artifact pointer | <certain> Artifact IDs, digests, revisions, and immutable compaction parentage | <speculative> Yes, after exact reference and freshness rules are specified. |
+| Missing parent slug | <certain> Stable IDs and revisions replace slug-only lineage | <speculative> Yes, if every parent must resolve before commit. |
+| Writer invents IDs or rewrites history | <certain> Runtime owns IDs, revisions, parentage, preservation, and atomic persistence | <speculative> Yes, because the agent submits only a semantic delta. |
+| No generated-output validator | <certain> Canonical Pydantic contracts and generated validators | <speculative> Yes, after Wheypoint projection and transition invariants are included in the schema and fixtures. |
+
+- <speculative> The proposed WorkRecord and CompactionRecord contract would have prevented the exact July 31 loss if its preservation ledger, immutable receipt, explicit supersession, stale-write rejection, and output validation were implemented as mandatory invariants.
+- <certain> The current prompt-only Wheypoint skill does not implement those protections.
+- <certain> The new contract must explicitly state that model context and model compaction summaries are non-authoritative caches.
+- <certain> The new contract must require rehydration from durable state after a detected compaction.
+- <certain> The new contract must preserve a full decision ledger even when the generated cold-reader projection is scoped to a narrower next task.
+
+## Coherence and non-goal checks still required
+
+- <don't know> Confirm every domain fact has exactly one producer and every mutable state transition has exactly one owner.
+- <don't know> Confirm standalone Easy Cheese can execute, checkpoint, recover, and continue without Milknado.
+- <don't know> Confirm Milknado can import and return the shared models without depending on an Easy Cheese state service.
+- <don't know> Confirm execution, domain, continuation, and transport statuses cannot contradict or shadow one another.
+- <don't know> Confirm all unbounded histories, payloads, transcripts, fixtures, and artifact reads have explicit limits.
+- <don't know> Confirm every replay and recovery seam has an idempotency rule and observable failure.
+- <don't know> Confirm the first implementation slice does not silently delete the wider planner, review, identity, WorkRecord, or migration requirements.
+- <certain> V1 deliberately excludes a central coordinator service, generic external-effect framework, recovery-hold entity, fencing epoch, shared progress stream, per-iteration checkpoints, configurable checkpoint history, and crash-time transcript resume.
+- <certain> Model-context compaction is not a recovery mechanism and is excluded from the durable contract.
+
+## Approval and extraction gate
+
+- <certain> No implementation may begin until the remaining active forks are resolved and the user provides the first literal approval key: curdle, ship it, extract, or that's enough.
+- <certain> After the first key, mold must produce the Easy Cheese spec, Milknado spec, and shared compatibility matrix.
+- <certain> The user must separately confirm the produced artifacts before implementation.
+- <certain> The specs must link this full reconstruction checkpoint and the context-loss audit so later narrowing cannot erase their requirements.
+
+## Artifacts and research
+
+- [Current recovery-focused Wheypoint](./root-cheese-milknado-orchestration.md)
+- [Preserved July 29 full-protocol Wheypoint](https://github.com/paulnsorensen/easy-cheese/blob/4690aed3df94a4098cc2c86c3706a18da85326fd/.cheese/notes/root-cheese-milknado-orchestration.md)
+- [Decision audit](./root-cheese-milknado-decision-audit.md)
+- [Wheypoint context-loss audit](./wheypoint-root-cheese-context-loss-audit.md)
+- [PR #331 cross-skill contract](https://github.com/paulnsorensen/easy-cheese/pull/331)
+- [PR #358 orchestration and parent policy](https://github.com/paulnsorensen/easy-cheese/pull/358)
+- .cheese/research/lost-executor-recovery/lost-executor-recovery.md
+- .cheese/research/frameworks-durable-execution/frameworks-durable-execution.md
+- /home/paul/.local/share/cheese/paulnsorensen-easy-cheese/research/agent-executor-recovery-practices/agent-executor-recovery-practices.md
+- /home/paul/.local/share/cheese/paulnsorensen-easy-cheese/research/agentic-invocation-envelope-patterns/agentic-invocation-envelope-patterns.md
+- /home/paul/.local/share/cheese/paulnsorensen-easy-cheese/research/operation-invocation-retry-identity/operation-invocation-retry-identity.md
+
+## Suggested skills
+
+- <certain> Resume with /cheese --continue root-cheese-milknado-full-protocol-reconstruction.
+- <certain> Re-enter /mold and resolve the decision dossier in this order: exact shared records, package location and versioning, runtime persistence, Wheypoint integrity contract, then spec boundaries and coherence checks.
+- <certain> After separate spec approval, implement canonical models and fixtures first, then both consumers and producers, then recovery and orchestration.
+- <certain> File the eight Wheypoint bugs above as independently testable issues before changing the skill contract.
+- <certain> Use /cook only after the two-key mold approval gate.
+
+## Environment
+
+- <certain> Repository: /home/paul/Dev/easy-cheese.
+- <certain> Branch: checkpoint/root-cheese-milknado-orchestration.
+- <certain> Commit: 4690aed3df94a4098cc2c86c3706a18da85326fd.
+- <certain> Tracking branch: origin/checkpoint/root-cheese-milknado-orchestration.
+- <certain> Status before this file was written: modified tracked .cheese/notes/root-cheese-milknado-orchestration.md and untracked .claude/.
+- <certain> The current full note is normally ignored by Git and requires an explicit later preservation step.
+- <certain> Current session: codex:019fb751-d863-7d62-a3db-78e8e3dd1453.
+- <certain> Current session automatically compacted at 2026-08-01T08:16:48Z.
+- <certain> No secrets, tokens, passwords, or sensitive values are included.

--- a/.cheese/notes/root-cheese-milknado-full-protocol-reconstruction.md
+++ b/.cheese/notes/root-cheese-milknado-full-protocol-reconstruction.md
@@ -1,16 +1,16 @@
 ## Handoff slug
 
 ~~~text
-status: gated: finalize record fields, package and versioning, persistence, and Wheypoint integrity before spec approval
+status: ok
 next: mold
 mode: single
 artifact: .cheese/notes/root-cheese-milknado-decision-audit.md
-session: codex:019fb751-d863-7d62-a3db-78e8e3dd1453
+session: codex:019fbc9c-05fc-74e0-a76d-b6680c30b857
 git: checkpoint/root-cheese-milknado-orchestration@4690aed
-created: 2026-08-01T08:51:33Z
+created: 2026-08-01T21:15:41Z
 parents: [root-cheese-milknado-orchestration, wheypoint-root-cheese-context-loss-audit]
 baseline: none
-<certain> This is the full reconstruction checkpoint for the Root Cheese and Milknado protocol, recovery slice, shared Pydantic contract, and Wheypoint integrity incident; resume by reading this file before any narrower artifact.
+<certain> The full reconstruction remains the durable design record; resume by specifying the PyPI and bundle bootstrap first, then the minimal Wheypoint continuity kernel.
 ~~~
 
 ## Document
@@ -729,4 +729,77 @@ runtime validation and reconciliation
 - <certain> The current full note is normally ignored by Git and requires an explicit later preservation step.
 - <certain> Current session: codex:019fb751-d863-7d62-a3db-78e8e3dd1453.
 - <certain> Current session automatically compacted at 2026-08-01T08:16:48Z.
+- <certain> No secrets, tokens, passwords, or sensitive values are included.
+
+## Iteration cut: package first, continuity second
+
+### State
+
+- <certain> The design dialogue reached its practical context limit before spec extraction or implementation.
+- <certain> No implementation spec, production Pydantic package, schema corpus, PyPI release, or runtime adapter exists yet.
+- <certain> The complete unresolved backlog above remains preserved but is deferred unless an item blocks the two selected slices.
+- <certain> This section supersedes the earlier implementation ordering and suggested-skills sequence at lines 714-720 without deleting their history.
+
+### Selected implementation order
+
+1. <certain> First, establish the Easy Cheese-owned Python package on PyPI and the standalone bundle path.
+2. <certain> Second, implement the minimal safety-first Wheypoint continuity kernel.
+3. <certain> Third, return to the bounded executor-recovery kernel.
+4. <certain> Planner, review, rich CurdResult, the full Milknado adapter, advanced continuation, split/join, task lifecycle, and migration remain later slices.
+
+### Step 1: PyPI and bundling bootstrap
+
+- <certain> Easy Cheese owns one versioned Python contract package that Milknado will import; Milknado will not maintain parallel public Pydantic models.
+- <certain> Pydantic v2 remains the canonical contract-authoring source for cross-runtime models; generated JSON Schema 2020-12, fixtures, and pure-Python model validators derive from it.
+- <certain> Persisted WorkRecord and Handoff frontmatter remains schema-bounded YAML followed by Markdown. CLI requests and responses remain JSON.
+- <certain> cheese.pyz vendors the exact pinned pure-Python PyYAML package and its license, excludes native extensions and package metadata, and bundles generated validators without requiring Pydantic or a generic JSON Schema runtime.
+- <certain> The July 26 JSON-persistence implementation-gap direction is superseded by the accepted July 27 YAML-restoration ADR.
+- <don't know> The package name, distribution layout, first version, publication workflow, and compatibility declaration still belong in the narrow Step 1 mold spec.
+
+Verification target:
+
+- <certain> A clean environment installs and imports the built package.
+- <certain> python3 -S executes cheese.pyz, loads the compiled phase registry, round-trips bounded YAML WorkRecord and Handoff documents, and validates representative JSON contract fixtures without ambient packages.
+- <certain> The release archive contains the pinned pure-Python YAML package and license, generated validators, and no native extension, bytecode cache, or package metadata.
+- <certain> just check is green before publication.
+
+### Step 2: minimal Wheypoint continuity kernel
+
+- <certain> Implement only WorkRecord, WorkDelta, immutable WorkRevision, and a generated Markdown Wheypoint projection.
+- <certain> WorkRevision absorbs the proposed CompactionRecord receipt for this slice; the applied delta and stable entry transitions provide the preservation ledger.
+- <certain> WorkRecord is the sole living authority. The Markdown note is a cold-reader projection and never a second mutable authority.
+- <certain> WorkDelta carries an expected revision plus explicit additions and transitions. Omission never deletes protected state.
+- <certain> Stable runtime-owned IDs cover protected decisions, questions, blockers, artifacts, work, and revisions.
+- <certain> Persist canonical records under the accepted XDG work root using bounded YAML and Markdown; an optional repo-local snapshot is explicit and non-authoritative.
+- <certain> Defer WorkAttempt, WorkTask, ContinuationAssessment, ContinuationDecision, ContinuationRecord, split/join, cross-WorkRecord convergence, and history garbage collection.
+
+Verification target:
+
+- <certain> A regression fixture based on the July 29 full note and July 31 narrowed replacement proves that omitted protected decisions survive same-slug compaction.
+- <certain> Stale revisions reject before persistence; identical replay returns the committed revision; changed replay content conflicts.
+- <certain> Generated status: ok is rejected when unresolved human forks remain; gated projections require a decision dossier.
+- <certain> A detected model-context compaction blocks a new durable update until WorkRecord state is rehydrated.
+- <certain> /cheese --continue resolves the current WorkRevision projection without relying on mtime, session identity, or a mutable slug as authority.
+- <certain> just check is green.
+
+### Later executor-recovery slice
+
+- <certain> The later bounded family remains OperationInvocation, OperationCheckpoint, OperationOutcome, RecoveryRequest, and RecoveryResult.
+- <certain> Recovery uses a runtime-private journal behind recover(RecoveryRequest) -> RecoveryResult.
+- <certain> predecessor_invocation_id is the natural recovery idempotency key; V1 has no separate recovery request ID or public RecoveryRecord.
+- <certain> The wider protocol and Milknado requirements remain preserved above and must be linked from later specs rather than silently discarded.
+
+### Immediate next move
+
+- <certain> Resume /mold to extract a narrow Step 1 PyPI-and-bundling spec with no continuity or recovery implementation mixed into it.
+- <certain> After Step 1 receives both mold approval keys, extract and approve a separate Step 2 continuity-kernel spec.
+- <certain> Use /cook only after each narrow spec independently passes the two-key approval gate.
+
+### Environment update
+
+- <certain> Repository: /home/paul/Dev/easy-cheese.
+- <certain> Branch: checkpoint/root-cheese-milknado-orchestration at 4690aed.
+- <certain> Tracking branch: origin/checkpoint/root-cheese-milknado-orchestration.
+- <certain> Working state before this Wheypoint update: modified tracked .cheese/notes/root-cheese-milknado-orchestration.md and untracked .claude/.
+- <certain> Current session: codex:019fbc9c-05fc-74e0-a76d-b6680c30b857.
 - <certain> No secrets, tokens, passwords, or sensitive values are included.


### PR DESCRIPTION
Preserves the full Root Cheese and Milknado protocol reconstruction as a tracked safety checkpoint.

This PR intentionally contains only `.cheese/notes/root-cheese-milknado-full-protocol-reconstruction.md`.

Validation: `just check` (passed).
