### PR TITLE
feat(docs): adopt @cheeselord/design starlight theme

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import mermaid from 'astro-mermaid';
+import { cheeselordTheme } from '@cheeselord/design/starlight';
 import { sidebar } from './src/sidebar.mjs';
 
 export default defineConfig({
@@ -17,6 +18,7 @@ export default defineConfig({
     }),
     starlight({
       title: 'easy-cheese',
+      plugins: [cheeselordTheme({ flavor: 'easy-cheese' })],
       description:
         'Harness-agnostic Agent Skills (agentskills.io) — the cheese-making pipeline that ages raw curds into shippable wheels of code.',
       logo: {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@astrojs/starlight": "^0.41.3",
+    "@cheeselord/design": "^0.1.0",
     "astro": "^7.1.0",
     "astro-mermaid": "^2.1.0",
     "mermaid": "^11.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@astrojs/starlight':
         specifier: ^0.41.3
         version: 0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3)
+      '@cheeselord/design':
+        specifier: ^0.1.0
+        version: 0.1.0(@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3))(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))
       astro:
         specifier: ^7.1.0
         version: 7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2)
@@ -248,6 +251,12 @@ packages:
   '@capsizecss/unpack@4.0.1':
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
     engines: {node: '>=18'}
+
+  '@cheeselord/design@0.1.0':
+    resolution: {integrity: sha512-j7gSQbNYb4sb4fGLdWWoUt6u/+5Vc+kef8yDR6yLynJI5+1Z+F5MRwCrrFBWl+IbRqRKCwgb2gPbPY5N/pQm5g==}
+    peerDependencies:
+      '@astrojs/starlight': ^0.35.0 || ^0.41.0
+      astro: ^5.0.0 || ^7.0.0
 
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
@@ -2626,8 +2635,8 @@ snapshots:
       hast-util-from-html: 2.0.3
       satteri: 0.9.5
 
-  ? '@astrojs/mdx@7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))'
-  : dependencies:
+  '@astrojs/mdx@7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))':
+    dependencies:
       '@astrojs/internal-helpers': 0.10.1
       '@astrojs/markdown-remark': 7.2.1
       '@mdx-js/mdx': 3.1.1
@@ -2658,8 +2667,8 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  ? '@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3)'
-  : dependencies:
+  '@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3)':
+    dependencies:
       '@astrojs/markdown-satteri': 0.3.3
       '@astrojs/mdx': 7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))
       '@astrojs/sitemap': 3.7.3
@@ -2783,6 +2792,11 @@ snapshots:
   '@capsizecss/unpack@4.0.1':
     dependencies:
       fontkitten: 1.0.3
+
+  '@cheeselord/design@0.1.0(@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3))(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))':
+    dependencies:
+      '@astrojs/starlight': 0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3)
+      astro: 7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2)
 
   '@chevrotain/types@11.1.2': {}
 
@@ -3485,14 +3499,14 @@ snapshots:
 
   astring@1.9.0: {}
 
-  ? astro-expressive-code@0.44.0(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))
-  : dependencies:
+  astro-expressive-code@0.44.0(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2)):
+    dependencies:
       astro: 7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2)
       rehype-expressive-code: 0.44.0
       url-extras: 0.1.0
 
-  ? astro-mermaid@2.1.0(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(mermaid@11.16.0)
-  : dependencies:
+  astro-mermaid@2.1.0(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(mermaid@11.16.0):
+    dependencies:
       astro: 7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2)
       import-meta-resolve: 4.2.0
       mdast-util-to-string: 4.0.0


### PR DESCRIPTION
## Summary

- Add `@cheeselord/design@^0.1.0` (npm registry) as a devDependency
- Register `cheeselordTheme({ flavor: 'easy-cheese' })` in the Starlight config; the plugin appends the packaged flavor stylesheet after the site's existing `customCss`

## Test plan

- [x] `pnpm docs:build` passes (24 pages)
- [x] Built CSS in `dist/_astro` contains the flavor tokens (`--cl-amber` et al.)
- [x] Packaged WOFF2 fonts (Fraunces 500/700, IBM Plex Mono) emitted to `dist/_astro` — no runtime font requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
