### PR TITLE
feat(hard-cheese): report the judge score in the gate output

### DIFF
--- a/skills/hard-cheese/SKILL.md
+++ b/skills/hard-cheese/SKILL.md
@@ -155,8 +155,11 @@ When the gate ends, print:
 ```
 Hard-cheese artifact: .cheese/hard-cheese/<slug>.md
 Status: PASS | FAILED | LOGGED | ERROR
+Score: <n>/5 (<SOLO level>, pass ≥ <passing-score>)
 Attempts: <n>
 ```
+
+The `Score` line reports the latest judged attempt. Omit it when no attempt was judged — LOGGED mode, or an ERROR run with no scored attempts.
 
 Followed by:
 


### PR DESCRIPTION
## What changed

The gate's closing output block gains a `Score` line between `Status` and `Attempts`:

```
Hard-cheese artifact: .cheese/hard-cheese/<slug>.md
Status: PASS | FAILED | LOGGED | ERROR
Score: <n>/5 (<SOLO level>, pass ≥ <passing-score>)
Attempts: <n>
```

The line reports the latest judged attempt and is omitted when nothing was judged (LOGGED mode, or an ERROR run with no scored attempts).

## Why

The judge already produces a SOLO score (1–5) and the pass threshold is configurable via `--passing-score` (#208), but the closing block only said PASS/FAIL. A PASS at 3/5 and a PASS at 5/5 read identically, so the author never sees how close to the threshold they landed. Surfacing the score makes the result actionable — the full detail still lives in the artifact's attempt table.

## How to verify

Docs-only change to the skill prose. Ran locally:

```
python3 .github/scripts/validate_skills.py   # exit 0
python3 -m pytest tests/python -q            # 885 passed, 1 skipped
```

## Risk / rollout notes

none — output-format addition only; no script or judge-contract changes.

## Checklist

- [x] Conventional Commits PR title (`feat:`, `fix:`, `chore:`, `docs:`, ...)
- [x] Tests added or updated (or N/A)
- [x] Documentation updated (or N/A)
- [x] No secrets or credentials added