### PR TITLE
chore(deps): @cheeselord/design 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@astrojs/starlight": "^0.41.3",
-    "@cheeselord/design": "^0.3.0",
+    "@cheeselord/design": "^0.4.0",
     "astro": "^7.1.0",
     "sharp": "^0.35.3",
     "typescript": "^5.8.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.41.3
         version: 0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3)
       '@cheeselord/design':
-        specifier: ^0.3.0
-        version: 0.3.0(@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3))(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))
+        specifier: ^0.4.0
+        version: 0.4.0(@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3))(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))
       astro:
         specifier: ^7.1.0
         version: 7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2)
@@ -240,8 +240,8 @@ packages:
     resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
     engines: {node: '>=18'}
 
-  '@cheeselord/design@0.3.0':
-    resolution: {integrity: sha512-qSeOZjzZ3IG3xc/A5Oyw2LSvI7bEysVshTcS+26vZKkVJn275zie06ftZo9CFebIn/ux3wGJFvnFxxDtEic6tQ==}
+  '@cheeselord/design@0.4.0':
+    resolution: {integrity: sha512-gDbo51kQhFN2DNoxPcaTLS/IIJXTOj2zQyzpYS7jxY38FTI6NrLq9EMqspgn1tqGqQwxwgBXzwOTG/OQPmecIA==}
     peerDependencies:
       '@astrojs/starlight': ^0.35.0 || ^0.41.0
       astro: ^5.0.0 || ^7.0.0
@@ -2239,8 +2239,8 @@ snapshots:
       hast-util-from-html: 2.0.3
       satteri: 0.9.5
 
-  ? '@astrojs/mdx@7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))'
-  : dependencies:
+  '@astrojs/mdx@7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))':
+    dependencies:
       '@astrojs/internal-helpers': 0.10.1
       '@astrojs/markdown-remark': 7.2.1
       '@mdx-js/mdx': 3.1.1
@@ -2271,8 +2271,8 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  ? '@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3)'
-  : dependencies:
+  '@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3)':
+    dependencies:
       '@astrojs/markdown-satteri': 0.3.3
       '@astrojs/mdx': 7.0.2(@astrojs/markdown-satteri@0.3.3)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))
       '@astrojs/sitemap': 3.7.3
@@ -2395,8 +2395,8 @@ snapshots:
     dependencies:
       fontkitten: 1.0.3
 
-  ? '@cheeselord/design@0.3.0(@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3))(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))'
-  : dependencies:
+  '@cheeselord/design@0.4.0(@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3))(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))':
+    dependencies:
       '@astrojs/starlight': 0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))(typescript@5.9.3)
       astro: 7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2)
 
@@ -2960,8 +2960,8 @@ snapshots:
 
   astring@1.9.0: {}
 
-  ? astro-expressive-code@0.44.0(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2))
-  : dependencies:
+  astro-expressive-code@0.44.0(astro@7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2)):
+    dependencies:
       astro: 7.1.0(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.2)(rollup@4.62.2)
       rehype-expressive-code: 0.44.0
       url-extras: 0.1.0


### PR DESCRIPTION
Bumps `@cheeselord/design` from `^0.3.0` to `^0.4.0`.

## Why it is only a bump

0.4.0 removes `--cl-focus` and `FlavorDefinition.typography`, and derives the neutral ramp (`--bone`, `--dim`, and Starlight's whole `--sl-color-white`/`--sl-color-gray-*` ramp) from each flavor's `--cl-ink` instead of a hue-95 literal. This site references neither removed surface.

The derivation only resolves correctly when the page actually loads a flavor sheet. This one does — `src/pages/index.astro` already imports both:

```js
import '@cheeselord/design/styles/cheeselord.css';
import '@cheeselord/design/styles/flavors/easy-cheese.css';
```

The shell imports its own `flavors/cheeselord.css` into a cascade layer, so the unlayered site import outranks it regardless of order. Confirmed in the built bundle, which carries both declarations with the site's winning:

```
--cl-ink:oklch(16.9% .007 156)   /* portal, layered */
--cl-ink:oklch(17.5% .012 65)    /* easy-cheese, unlayered — wins */
```

## Verification

Resolved tokens measured on the built landing page, painted onto a probe element so relative colors collapse to used pixels:

| token | value |
|---|---|
| `--cellar` | `oklch(0.175 0.012 65)` |
| `--cl-ink` | `oklch(0.175 0.012 65)` |
| `--bone` | `oklch(0.91 0.021 65)` |
| `--dim` | `oklch(0.61 0.02 65)` |
| `--glow` | `oklch(0.29 0.035 65 / 0.55)` |
| `--panel` | `oklch(0.205 0.0108 55)` |

All descend from one primitive. `pnpm run docs:build` builds 25 pages; landing and docs screenshotted in light and dark.

For contrast, the same measurement on hallouminate's landing page found `--bone` at hue 156 against a hue-50 field, because that page hand-rolled `--cellar` instead of importing a flavor sheet — fixed in paulnsorensen/hallouminate#344. This site had already adopted the shell, so it needed nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)