### PR TITLE
docs(wiki): ratify canonical JSON persistence, extract Step 3 recovery decisions

### DIFF
--- a/.hallouminate/wiki/adr/index.md
+++ b/.hallouminate/wiki/adr/index.md
@@ -50,6 +50,7 @@
 - [wheypoint-continuity-kernel-001](./wheypoint-continuity-kernel-001.md) — Wheypoint continuity authority
 - [wheypoint-continuity-kernel-002](./wheypoint-continuity-kernel-002.md) — Dedicated Wheypoint runtime boundary
 - [wheypoint-continuity-kernel-003](./wheypoint-continuity-kernel-003.md) — Immutable Wheypoint updates and resolution
+- [wheypoint-continuity-kernel-004](./wheypoint-continuity-kernel-004.md) — Canonical JSON persistence for Wheypoint records
 - [wheypoint-provenance-schema-001](./wheypoint-provenance-schema-001.md) — ADR: wheypoint provenance as additive header fields with join/split verbs
 - [workflow-contract-milknado-seam-001](./workflow-contract-milknado-seam-001.md) — ADR: CurdPlan is the semantic work authority
 - [workflow-contract-milknado-seam-002](./workflow-contract-milknado-seam-002.md) — ADR: Agents write slim views and hosts normalize canonical contracts

--- a/.hallouminate/wiki/adr/wheypoint-continuity-kernel-004.md
+++ b/.hallouminate/wiki/adr/wheypoint-continuity-kernel-004.md
@@ -1,0 +1,19 @@
+
+# Canonical JSON persistence for Wheypoint records
+
+<certain> Wheypoint continuity records persist as canonical UTF-8 JSON digested with SHA-256; the accepted 2026-07-27 YAML restoration is superseded for continuity records.[^spec][^research]
+
+## ADR-004: Persist canonical JSON, not schema-bounded YAML [status: accepted]
+
+- **Context:** <certain> The protocol reconstruction checkpoint committed to schema-bounded YAML persistence (the 2026-07-27 YAML-restoration decision, still recorded on the cross-skill work contract page). The approved Wheypoint kernel spec (2026-08-02) reversed that to canonical JSON + SHA-256 as flagged agent-introduced scope, and PR #384 implemented the spec — leaving the wiki asserting YAML while the landed kernel writes JSON, with no ADR recording why.[^checkpoint][^kernel-pr]
+- **Decision:** Serialize every digested value as canonical UTF-8 JSON — sorted keys, tightest separators, literal UTF-8, non-finite refused — and take record digests, revision digests, and request fingerprints as SHA-256 over those bytes (`src/wheypoint/canonical.py`). Ratified 2026-08-11 on researched merits with packaging excluded from the analysis: document-level canonical YAML does not exist (the YAML spec's "canonical form" is per-scalar only; no RFC 8785 equivalent; no byte-stable Python emitter; surveyed YAML-native systems hash raw file bytes or decoded data, never canonical YAML), while canonical JSON has specified, production-proven prior art (RFC 8785, TUF). Record readability is delegated to Markdown projections; hand-editability of a digest-protected record is an anti-feature.
+- **Dialect caveat:** <certain> The encoding is canonical JSON in the Python `json.dumps` dialect, not RFC 8785 JCS. Known divergences: key order is Unicode code-point rather than UTF-16 code-unit (differs only for non-BMP keys), and numbers keep Python's int/float distinction and `repr` conventions (`5.0` vs `5`, exponent-notation thresholds and padding, exact arbitrary-precision integers). Latent while this runtime is the sole producer and consumer — no float-typed schema fields, runtime-assigned ASCII keys — but any independent fingerprint implementation must match this dialect, not JCS.
+- **Alternatives:** Restore schema-bounded YAML behind a bespoke canonical emitter (no spec, no prior art, PyYAML implements YAML 1.1 with implicit-typing ambiguity), or claim full RFC 8785 conformance (requires ECMAScript number serialization and UTF-16 key ordering).
+- **Consequences:** Digest computation stays a standard-library pure function of the value. The cross-skill work contract page's YAML-persistence language no longer governs continuity records. Cross-language digest reproduction requires a dialect-conformance test before trusting fingerprints.
+
+## References
+
+[^spec]: `/home/paul/.local/share/cheese/paulnsorensen-easy-cheese/specs/wheypoint-continuity-kernel.md`, approved 2026-08-02 — "canonical JSON and SHA-256" declared under `agent_introduced_scope`.
+[^research]: `.cheese/research/wheypoint-persistence-yaml-vs-json/wheypoint-persistence-yaml-vs-json.md` (untracked research corpus, 2026-08-11); decisive evidence inlined above.
+[^checkpoint]: Reconstruction checkpoint preserved on PR #370 (`docs/root-cheese-milknado-protocol-safety`), `.cheese/notes/root-cheese-milknado-full-protocol-reconstruction.md` lines 754-756 and 773. <https://github.com/paulnsorensen/easy-cheese/pull/370>
+[^kernel-pr]: Wheypoint kernel implementation. <https://github.com/paulnsorensen/easy-cheese/pull/384>

--- a/.hallouminate/wiki/specs/cross-skill-work-contract.md
+++ b/.hallouminate/wiki/specs/cross-skill-work-contract.md
@@ -1,6 +1,6 @@
 # Cross-skill work contract
 
-Status: approved; YAML serialization restoration accepted 2026-07-27
+Status: approved; YAML serialization restoration accepted 2026-07-27; persistence format for continuity records superseded by [wheypoint-continuity-kernel-004](../adr/wheypoint-continuity-kernel-004.md) (canonical JSON, 2026-08-11)
 Source: promoted from the Mold artifact at `$XDG_DATA_HOME/cheese/paulnsorensen-easy-cheese/specs/cross-skill-work-contract.md`
 
 This specification makes one `WorkRecord` the deterministic continuation authority for a user work item. Phase artifacts become validated, operation-scoped evidence around that record. Persisted runtime state and human-authored phase contracts use YAML; the released `cheese.pyz` bundles pinned pure-Python PyYAML and its license so users install no libraries separately.

--- a/.hallouminate/wiki/specs/index.md
+++ b/.hallouminate/wiki/specs/index.md
@@ -3,4 +3,5 @@
 <!-- HALLOUMINATE:INDEX-START -->
 - [cross-skill-work-contract-implementation-gaps](./cross-skill-work-contract-implementation-gaps.md) — Cross-skill work contract implementation gaps
 - [cross-skill-work-contract](./cross-skill-work-contract.md) — Cross-skill work contract
+- [milknado-executor-recovery](./milknado-executor-recovery.md) — Milknado executor recovery
 <!-- HALLOUMINATE:INDEX-END -->

--- a/.hallouminate/wiki/specs/milknado-executor-recovery.md
+++ b/.hallouminate/wiki/specs/milknado-executor-recovery.md
@@ -1,0 +1,90 @@
+
+# Milknado executor recovery
+
+Status: locked decisions; implementation spec pending (workflow-contracts roadmap F002)
+Source: extracted from the protocol reconstruction checkpoint preserved on [PR #370](https://github.com/paulnsorensen/easy-cheese/pull/370) (`.cheese/notes/root-cheese-milknado-full-protocol-reconstruction.md`, sections "Operation and invocation identity" through "Normal execution and checkpoints", "Later executor-recovery slice", and decision-dossier Fork 5)
+
+These are the locked Step 3 decisions for the deferred executor-recovery slice — the `OperationInvocation`/`OperationCheckpoint`/`OperationOutcome` family and `recover(RecoveryRequest) -> RecoveryResult`. They bound the future F002 spec; the shipped Wheypoint continuity kernel (ADRs 001-004) is unaffected. Until that spec exists, this page is the durable authority for these decisions.
+
+## Operation and invocation identity
+
+- <certain> The generic execution shape is OperationInvocation<TRequest> to zero or more OperationCheckpoint<TResult> records to one OperationOutcome<TResult>.
+- <certain> Operation is the correct term because the executor may be an agent, deterministic code, or a workflow.
+- <certain> operation_id identifies one immutable semantic request.
+- <certain> invocation_id identifies one admitted execution of that operation.
+- <certain> Transport replay and Milknado-internal transient retries remain inside the current invocation until terminalization.
+- <certain> A retry after terminalization creates a new invocation under the same operation.
+- <certain> A semantic change to goal, subject, intent, or acceptance contract creates a new operation.
+- <certain> Changing executor strategy, model, limits, runtime environment, or retry creates a new invocation without changing the operation.
+- <certain> Execution status and domain-result status remain separate.
+- <certain> A failed, cancelled, timed-out, or lost invocation may still carry its latest schema-valid partial result.
+- <certain> Failure before the first valid checkpoint may carry no domain result.
+- <certain> Domain result types own their partial-completion ledgers.
+
+## Execution and handoff IDs
+
+- <certain> Execution operation_id and Handoff operation_id are always distinct.
+- <certain> Execution operation_id names the semantic request.
+- <certain> Handoff operation_id is a commit-idempotency key for applying one continuity transition.
+- <certain> Handoff provenance links the related execution invocation IDs and terminal outcome digest.
+- <certain> Easy Cheese IDs and Milknado IDs remain separate namespaces.
+- <certain> Milknado run_id is task-dispatch provenance and never aliases invocation_id.
+
+## Lost-executor recovery
+
+- <certain> A failed, lost, cancelled, or timed-out invocation never reopens.
+- <certain> Recovery creates exactly one successor invocation under the same operation.
+- <certain> A unique predecessor_invocation_id enforces at most one successor.
+- <certain> Timeout or unresponsiveness triggers termination of the runtime-owned process group: TERM, grace period, KILL if needed, then confirmation that the process is gone.
+- <certain> Only confirmed termination permits predecessor terminalization, managed-worktree transfer, and successor admission.
+- <certain> If termination cannot be confirmed, recovery becomes manual and no successor is admitted.
+- <certain> The predecessor's terminal status preserves the initiating cause: timed_out, cancelled, lost, or failed; forced kill is diagnostic detail.
+- <certain> Recovery resumes the work, not the old transcript or uncertain agent.
+- <certain> A successor starts a fresh Codex or Claude session seeded only from durable state.
+- <certain> Crash-time transcript resume and session forking are excluded.
+- <certain> The existing managed worktree transfers to the successor only after confirmed termination.
+- <certain> Recovery may proceed from the surviving managed worktree when no checkpoint exists.
+- <certain> The successor receives the original request, worktree identity and status, predecessor terminal cause, and latest checkpoint when present.
+- <certain> Old transcript and progress events are excluded from the successor seed.
+- <certain> The runtime records a canonical worktree fingerprint at confirmed termination covering HEAD, index, tracked content, and untracked content; ignored files are excluded.
+- <certain> The runtime recomputes that fingerprint immediately before successor admission.
+- <certain> Any mismatch requires manual recovery.
+- <certain> Automatic v1 recovery covers runtime-owned protocol state, managed worktrees, and Git state only.
+- <certain> Arbitrary unmanaged external effects require manual recovery.
+- <certain> V1 has no generic effect taxonomy, reconciliation plugin system, public ReconciliationEvidence type, recovery-hold entity, central coordinator service, or fencing epoch.
+- <certain> The active invocation_id gates protocol writes; the proposed fence_token was removed from v1.
+
+## Normal execution and checkpoints
+
+- <certain> One normal Ralph iteration remains inside the same Milknado run and invocation.
+- <certain> Ralph iteration progress stays Milknado-local; the shared protocol has no ProgressEvent.
+- <certain> A known-exclusive normal continuation may resume the same harness session.
+- <certain> Uncertain, failed, lost, or recovered execution never resumes the old harness session.
+- <certain> Checkpoints occur at explicit durable domain boundaries, not after every Ralph iteration.
+- <certain> Every checkpoint is a complete schema-valid snapshot rather than a delta.
+- <certain> The admitting runtime atomically assigns checkpoint identity and order, validates the snapshot, and computes its canonical digest.
+- <certain> Repeating identical checkpoint content returns the latest matching checkpoint.
+- <certain> Changed checkpoint content creates the next checkpoint.
+- <certain> Checkpoint retention is reachability-based.
+- <certain> Retain checkpoint data while the operation remains recoverable or a successor or outcome requires the reference to resolve.
+- <certain> A terminal outcome permanently retains checkpoint digest and provenance.
+- <certain> Unreferenced checkpoint data may be garbage-collected after terminal operation completion.
+- <certain> Configurable extra checkpoint history is excluded from v1.
+
+## Later executor-recovery slice
+
+- <certain> The later bounded family remains OperationInvocation, OperationCheckpoint, OperationOutcome, RecoveryRequest, and RecoveryResult.
+- <certain> Recovery uses a runtime-private journal behind recover(RecoveryRequest) -> RecoveryResult.
+- <certain> predecessor_invocation_id is the natural recovery idempotency key; V1 has no separate recovery request ID or public RecoveryRecord.
+- <certain> The wider protocol and Milknado requirements remain preserved above and must be linked from later specs rather than silently discarded.
+
+## Open question: package and schema version negotiation
+
+Unresolved fork carried out of the checkpoint's decision dossier; the F002 spec must settle it.
+
+- <certain> Option A pins a compatible Python-package version range and verifies schema IDs plus fixture compatibility.
+- <certain> Option B pins exact artifact digests for generated schemas and fixtures in addition to package version.
+- <certain> Option C consumes whichever contract version is latest at runtime.
+- <speculative> Option B offers the strongest reproducibility but adds update ceremony.
+- <certain> Option C conflicts with deterministic recovery and repeatable fixture validation.
+- <don't know> No prior user decision selects Option A versus B.


### PR DESCRIPTION
Ratifies the Wheypoint canonical-JSON persistence decision as ADR-004 and extracts the Step 3 executor-recovery locked decisions from the protocol reconstruction checkpoint into a tracked wiki page, so no decision of record remains only in untracked or out-of-repo files.

## Changes

- **`adr/wheypoint-continuity-kernel-004.md`** (new): records why continuity records persist as canonical UTF-8 JSON + SHA-256 rather than the previously accepted schema-bounded YAML — provenance chain (2026-07-27 YAML restoration → agent-introduced reversal in the approved 2026-08-02 kernel spec → 2026-08-11 ratification on researched merits, packaging excluded), decisive evidence inlined, and a dialect caveat: the encoding is the Python `json.dumps` dialect, not RFC 8785 JCS.
- **`specs/milknado-executor-recovery.md`** (new): verbatim extraction of the Step 3 locked decisions (operation/invocation identity, execution and handoff IDs, lost-executor recovery, checkpoints, the later executor-recovery slice) plus the unresolved package/schema version-negotiation fork, all previously written down only in the reconstruction checkpoint preserved on PR #370.
- **`specs/cross-skill-work-contract.md`**: one-line status amendment pointing its YAML-persistence language at ADR-004.
- **`adr/index.md`, `specs/index.md`**: index entries for the two new pages (hand-edited; hallouminate daemon not attached).

## Review notes

Semantics-preserving: documentation only — records already-landed decisions (`src/wheypoint/canonical.py`, PR #384) and preserves checkpoint content; no production behavior changes. Verify that the extracted bullets match the checkpoint text on PR #370's branch (`.cheese/notes/root-cheese-milknado-full-protocol-reconstruction.md` at bdb285e, lines 181–245, 585–593, 785–791) and that the ADR's decision chain matches the approved kernel spec.

Closes out the decision-extraction half of the reconstruction audit; PR #370 will be closed in favor of these pages once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
