### PR TITLE
fix(mold): judge the handshake user key by intent, not spelling

### DIFF
--- a/skills/mold/references/handshake.md
+++ b/skills/mold/references/handshake.md
@@ -6,6 +6,8 @@ Curdle (artifact extraction) requires **both** keys. Neither is optional.
 
 The user must express explicit extraction intent: `curdle`, `ship it`, `extract`, or `that's enough`. A clear affirmative such as `ok let's go`, `sounds good`, or `go ahead` also turns the key when it directly answers an agent's extraction question.
 
+Key matching is case-insensitive and whitespace-tolerant: compare the trimmed, case-folded reply (`reply.strip().casefold()`) against each accepted key's case-folded form, so `Curdle`, `CURDLE`, and `  cUrDlE  ` all turn the key exactly as `curdle` does. Never demand an exact-case respelling or burn a round on capitalization alone. Normalization affects only spelling — it does not widen the gate: unrelated prose that merely mentions a key approves nothing, and both handshake keys must still turn.
+
 Do not infer the key from unrelated or ambiguous approval; ask explicitly when the context does not establish that the user is approving Curdle.
 
 ## Agent key — coherence self-check

--- a/skills/mold/references/handshake.md
+++ b/skills/mold/references/handshake.md
@@ -4,11 +4,9 @@ Curdle (artifact extraction) requires **both** keys. Neither is optional.
 
 ## User key
 
-The user must express explicit extraction intent: `curdle`, `ship it`, `extract`, or `that's enough`. A clear affirmative such as `ok let's go`, `sounds good`, or `go ahead` also turns the key when it directly answers an agent's extraction question.
+The user key is explicit extraction intent — approval to write the spec. The direct form is the word `curdle`; `ship it`, `extract`, or `that's enough` work the same, and a clear affirmative such as `ok let's go`, `sounds good`, or `go ahead` also turns the key when it directly answers an agent's extraction question.
 
-Key matching is case-insensitive and whitespace-tolerant: compare the trimmed, case-folded reply (`reply.strip().casefold()`) against each accepted key's case-folded form, so `Curdle`, `CURDLE`, and `  cUrDlE  ` all turn the key exactly as `curdle` does. Never demand an exact-case respelling or burn a round on capitalization alone. Normalization affects only spelling — it does not widen the gate: unrelated prose that merely mentions a key approves nothing, and both handshake keys must still turn.
-
-Do not infer the key from unrelated or ambiguous approval; ask explicitly when the context does not establish that the user is approving Curdle.
+Judge the key by intent, never by spelling: capitalization, surrounding whitespace, or punctuation never invalidate an otherwise-clear approval, and never demand an exact respelling or a magic string. Do not infer the key from unrelated or ambiguous approval; ask explicitly when the context does not establish that the user is approving Curdle.
 
 ## Agent key — coherence self-check
 

--- a/tests/python/test_mold_followup_routing.py
+++ b/tests/python/test_mold_followup_routing.py
@@ -64,6 +64,23 @@ def test_user_key_allows_contextual_affirmations_without_inference() -> None:
     assert "unrelated or ambiguous approval" in section
 
 
+def test_user_key_matching_is_case_insensitive_and_whitespace_tolerant() -> None:
+    """gh#394: capitalization ceremony must never bounce an otherwise-valid key."""
+    section = _section(HANDSHAKE, "User key")
+    assert "case-insensitive" in section
+    assert "whitespace-tolerant" in section
+    assert "reply.strip().casefold()" in section
+    assert "`CURDLE`" in section
+    assert "cUrDlE" in section
+    for phrase in (
+        "exact-case respelling",
+        "unrelated prose that merely mentions a key approves nothing",
+        "both handshake keys must still turn",
+    ):
+        assert phrase.casefold() in section.casefold(), phrase
+    assert "reply exactly" not in section.casefold()
+
+
 def test_candidate_collection_is_non_committing_dialogue_state() -> None:
     _assert_phrases(
         MOLD,

--- a/tests/python/test_mold_followup_routing.py
+++ b/tests/python/test_mold_followup_routing.py
@@ -65,17 +65,13 @@ def test_user_key_allows_contextual_affirmations_without_inference() -> None:
 
 
 def test_user_key_matching_is_case_insensitive_and_whitespace_tolerant() -> None:
-    """gh#394: capitalization ceremony must never bounce an otherwise-valid key."""
+    """gh#394: the key is approval intent — spelling ceremony never bounces it."""
     section = _section(HANDSHAKE, "User key")
-    assert "case-insensitive" in section
-    assert "whitespace-tolerant" in section
-    assert "reply.strip().casefold()" in section
-    assert "`CURDLE`" in section
-    assert "cUrDlE" in section
     for phrase in (
-        "exact-case respelling",
-        "unrelated prose that merely mentions a key approves nothing",
-        "both handshake keys must still turn",
+        "approval to write the spec",
+        "by intent, never by spelling",
+        "capitalization, surrounding whitespace, or punctuation never invalidate",
+        "never demand an exact respelling",
     ):
         assert phrase.casefold() in section.casefold(), phrase
     assert "reply exactly" not in section.casefold()


### PR DESCRIPTION
## Cause

The two-key handshake's User key section (`skills/mold/references/handshake.md`) listed accepted keys but never said how to judge a reply, so a downstream agent improvised strictness — printing `reply exactly: Curdle` and burning a turn when the user typed `curdle`. The user-key gate is instruction-level (no key-comparison code exists in `src/mold/` or the bundles), so the doc contract is the implementation and its contract-test file is the regression seam.

## Fix

Simplification, not more ceremony: the user key **is explicit approval to write the spec** — the word `curdle` is the direct form — and it is judged **by intent, never by spelling**. Capitalization, surrounding whitespace, or punctuation never invalidate an otherwise-clear approval, and no exact respelling or magic string may be demanded. Unrelated or ambiguous prose still approves nothing, and both handshake keys stay separate gates. The section is net shorter than before the bug.

## Tests

`test_user_key_matching_is_case_insensitive_and_whitespace_tolerant` (doc-contract seam) asserts the intent-not-spelling rule, the never-invalidate clause, the no-exact-respelling rule, and the absence of `reply exactly` language. `validate_skills.py`, `lint-md`, and the full `tests/python` suite are green.

Fixes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)