### PR TITLE
fix(skill-overlap): join report paths through TempDir

### DIFF
--- a/tools/skill-overlap/src/main.rs
+++ b/tools/skill-overlap/src/main.rs
@@ -3477,8 +3477,8 @@ mod tests {
     #[test]
     fn write_report_outputs_creates_missing_parent_directories() {
         let base = temp_dir("write-report-outputs");
-        let json_out = base.join("nested/json/report.json");
-        let markdown_out = base.join("other/md/report.md");
+        let json_out = base.path().join("nested/json/report.json");
+        let markdown_out = base.path().join("other/md/report.md");
         let report = Report {
             format: 1,
             detector: detector("lock"),


### PR DESCRIPTION
## What changed

Use `TempDir::path()` before joining the nested JSON and Markdown report paths in the skill-overlap regression test.

## Why

`tempfile::TempDir` does not expose `join`; the test prevented `just check` from compiling the Rust gate on current `main`.

## How to verify

- `cargo test --manifest-path tools/skill-overlap/Cargo.toml write_report_outputs_creates_missing_parent_directories`
- `just check` (Python 3.12 project prerequisites)

## Risk / rollout notes

Test-only path construction; no production behavior changes.

## Checklist

- [x] Conventional Commits PR title
- [x] Tests updated: N/A, this repairs the existing regression test
- [x] Documentation updated: N/A
- [x] No secrets or credentials added
