### PR TITLE
docs(spec): define pyz pipeline contracts

### DIFF
--- a/.github/scripts/test_validate_wiki.py
+++ b/.github/scripts/test_validate_wiki.py
@@ -133,6 +133,27 @@ class ValidateWikiTest(unittest.TestCase):
         rc, _, err = self._run()
         self.assertEqual(rc, 0, err)
 
+    def test_frontmatter_before_h1_passes(self) -> None:
+        # Mold-handshook specs open with YAML frontmatter; the H1 requirement
+        # applies to the first line after the closed block.
+        self._write_valid_wiki()
+        self._write(
+            f"{WIKI}/topic-one.md",
+            "---\nsource: mold-handshake\nslug: topic-one\n---\n\n# Topic one\n\nbody\n",
+        )
+        rc, _, err = self._run()
+        self.assertEqual(rc, 0, err)
+
+    def test_unclosed_frontmatter_fails_h1_check(self) -> None:
+        self._write_valid_wiki()
+        self._write(
+            f"{WIKI}/topic-one.md",
+            "---\nsource: mold-handshake\n\n# Topic one\n",
+        )
+        rc, _, err = self._run()
+        self.assertEqual(rc, 1)
+        self.assertIn("not a single '# ' H1", err)
+
     def test_non_kebab_stem_fails(self) -> None:
         self._write_valid_wiki()
         self._write(f"{WIKI}/Bad_Stem.md", "# Bad stem\n")

--- a/.github/scripts/validate_wiki.py
+++ b/.github/scripts/validate_wiki.py
@@ -45,8 +45,23 @@ def validate_page(path: Path) -> list[str]:
     except UnicodeDecodeError as exc:
         errors.append(f"{path}: page is not valid UTF-8 ({exc.reason} at byte {exc.start})")
         return errors
+    lines = text.splitlines()
+    # A page may open with a closed YAML frontmatter block (Mold-handshook
+    # specs carry gate metadata there); the H1 requirement applies to the
+    # first line after it. Frontmatter content itself is a separate seam.
+    if lines and lines[0].strip() == "---":
+        close = next(
+            (
+                index
+                for index, line in enumerate(lines[1:], start=1)
+                if line.strip() == "---"
+            ),
+            None,
+        )
+        if close is not None:
+            lines = lines[close + 1 :]
     first_line = next(
-        (line for line in text.splitlines() if line.strip()),
+        (line for line in lines if line.strip()),
         None,
     )
     if first_line is None:

--- a/.hallouminate/wiki/adr/index.md
+++ b/.hallouminate/wiki/adr/index.md
@@ -37,6 +37,12 @@
 - [plate-publication-boundary-001](./plate-publication-boundary-001.md) — ADR: plate owns the commit-to-PR publication boundary
 - [post-pr-wiki-writeback-001](./post-pr-wiki-writeback-001.md) — ADR: curdle wiki writes enforced by gate node + read-back verify, not a Stop-hook
 - [post-pr-wiki-writeback-002](./post-pr-wiki-writeback-002.md) — ADR: post-PR learnings write-back reuses wiki-ingest, not the personal wiki-curator skill
+- [pyz-pipeline-contracts-001](./pyz-pipeline-contracts-001.md) — ADR: Bundle builds verify the staged import closure, including function-body imports  [status: accepted]
+- [pyz-pipeline-contracts-002](./pyz-pipeline-contracts-002.md) — ADR: Bundle currency is enforced locally by just check and a scoped prek hook  [status: accepted]
+- [pyz-pipeline-contracts-003](./pyz-pipeline-contracts-003.md) — ADR: Script locations are published as a generated, gated map plus per-source banners  [status: accepted]
+- [pyz-pipeline-contracts-004](./pyz-pipeline-contracts-004.md) — ADR: The subcommand registry is pruned to the prose-referenced set with strict two-way equality  [status: accepted]
+- [pyz-pipeline-contracts-005](./pyz-pipeline-contracts-005.md) — ADR: cook joins COMMON_CONSUMERS so its documented common.pyz fallback ships  [status: accepted]
+- [pyz-pipeline-contracts-006](./pyz-pipeline-contracts-006.md) — ADR: The Astro site source moves out of src/ to website/, leaving src/ purely Python  [status: accepted]
 - [skill-docs-single-page-001](./skill-docs-single-page-001.md) — ADR-001: Fold skill references into one docs page instead of separate sub-pages  [status: accepted]
 - [skill-docs-single-page-002](./skill-docs-single-page-002.md) — ADR-002: Left-nav heading TOC is h2-only, via a custom Starlight Sidebar override  [status: accepted]
 - [skill-overlap-ratchet-001](./skill-overlap-ratchet-001.md) — ADR: Own the Snowflake overlap analyzer in easy-cheese

--- a/.hallouminate/wiki/adr/pyz-pipeline-contracts-001.md
+++ b/.hallouminate/wiki/adr/pyz-pipeline-contracts-001.md
@@ -1,0 +1,17 @@
+# ADR: Bundle builds verify the staged import closure, including function-body imports
+
+Status: accepted (2026-08-18)
+
+Spec: pyz-pipeline-contracts (durable specs corpus).
+
+## Context
+
+Cross-directory imports ride on the hand-maintained EXTRA_MODULES dict; a missing entry ships a bundle that fails only when a lazy (function-body) import executes. The --help smoke test covers module-level imports only.
+
+## Decision
+
+After staging each bundle, build_pyz AST-scans every staged file and requires each absolute import — module-level and function-body — to resolve to stdlib, a staged module, or a vendored dependency; unresolved imports fail the build naming module and importer. Rejected: top-level-only checking (adds nothing over the existing smoke test).
+
+## Consequences
+
+Registry omissions become build failures instead of runtime ImportErrors on rare code paths.

--- a/.hallouminate/wiki/adr/pyz-pipeline-contracts-002.md
+++ b/.hallouminate/wiki/adr/pyz-pipeline-contracts-002.md
@@ -1,0 +1,17 @@
+# ADR: Bundle currency is enforced locally by just check and a scoped prek hook
+
+Status: accepted (2026-08-18)
+
+Spec: pyz-pipeline-contracts (durable specs corpus).
+
+## Context
+
+The CRC currency check ran only in CI (build-pyz.yml), so PRs recurrently failed 'check .pyz bundles are current' (e.g. PR #424) after src/ edits without just bundle.
+
+## Decision
+
+check_bundles.py joins the just check dependency chain, and a prek bundle-currency hook fires on commits touching src/, shared/, or skills/*/phase-contract.yaml. Rejected: CI auto-commit (bot pushes, rebase noise).
+
+## Consequences
+
+Staleness fails at the gate or the commit, not a CI round-trip later.

--- a/.hallouminate/wiki/adr/pyz-pipeline-contracts-003.md
+++ b/.hallouminate/wiki/adr/pyz-pipeline-contracts-003.md
@@ -1,0 +1,17 @@
+# ADR: Script locations are published as a generated, gated map plus per-source banners
+
+Status: accepted (2026-08-18)
+
+Spec: pyz-pipeline-contracts (durable specs corpus).
+
+## Context
+
+src/ mixed Astro site and Python sources with no artifact mapping subcommands to source files; the only explainer lived in .agents/skills/python-authoring/SKILL.md.
+
+## Decision
+
+build_pyz compiles src/PYTHON_SCRIPTS.md (bundle, subcommand, source path) from its registries with a byte-match staleness gate mirroring the schema catalog; every registered source opens with a one-line ships-as banner asserted by test; a thin hand-written src/README.md explains and points at the map. Rejected: hand-written docs alone (rot silently).
+
+## Consequences
+
+Where-does-this-live is answered by a generated artifact that cannot drift, at both the directory and the file.

--- a/.hallouminate/wiki/adr/pyz-pipeline-contracts-004.md
+++ b/.hallouminate/wiki/adr/pyz-pipeline-contracts-004.md
@@ -1,0 +1,17 @@
+# ADR: The subcommand registry is pruned to the prose-referenced set with strict two-way equality
+
+Status: accepted (2026-08-18)
+
+Spec: pyz-pipeline-contracts (durable specs corpus).
+
+## Context
+
+Three registries drifted independently: build_pyz SKILLS, skill markdown, and the hand-copied SKILL_SUBCOMMANDS test dict (already missing 3 entries). 3 registrations were dead (press red-gate, ultracook curd-block, ultracook age-route) and 9 were invoked only by tests.
+
+## Decision
+
+Registry equals prose: the 3 dead registrations are removed, the 9 test-only subcommands are demoted to direct module tests, and tests/python/test_skill_contract.py asserts strict two-way equality derived from build_pyz.SKILLS. The hand copy is deleted. Rejected: internal-flag equality (registry carries two meanings).
+
+## Consequences
+
+The registry means exactly one thing; bundle bloat and doc rot both fail tests.

--- a/.hallouminate/wiki/adr/pyz-pipeline-contracts-005.md
+++ b/.hallouminate/wiki/adr/pyz-pipeline-contracts-005.md
@@ -1,0 +1,17 @@
+# ADR: cook joins COMMON_CONSUMERS so its documented common.pyz fallback ships
+
+Status: accepted (2026-08-18)
+
+Spec: pyz-pipeline-contracts (durable specs corpus).
+
+## Context
+
+skills/cook/references/fan-pathway.md:33-35 documents a common.pyz read_handoff_slug fallback, but COMMON_CONSUMERS excluded cook, so bundle-only hosts had no handoff-read path.
+
+## Decision
+
+Add cook to COMMON_CONSUMERS and ship skills/cook/scripts/common.pyz; the contract test additionally asserts any common.pyz prose reference implies consumer membership. Rejected: correcting the doc (documents the hole instead of filling it).
+
+## Consequences
+
+The documented contract is true on bundle-only installs; the failure class is test-enforced.

--- a/.hallouminate/wiki/adr/pyz-pipeline-contracts-006.md
+++ b/.hallouminate/wiki/adr/pyz-pipeline-contracts-006.md
@@ -1,0 +1,17 @@
+# ADR: The Astro site source moves out of src/ to website/, leaving src/ purely Python
+
+Status: accepted (2026-08-18)
+
+Spec: pyz-pipeline-contracts (durable specs corpus).
+
+## Context
+
+Astro's default srcDir made src/ simultaneously the docs-site source tree and the Python source tree — the root cause of layout confusion.
+
+## Decision
+
+Move components/, pages/, styles/, content/, sidebar.mjs, content.config.ts to website/ via the srcDir config key; gen_docs.py, the docs workflow, and tests/js follow; a src-purity test locks src/ as Python-only. Rejected: moving Python out (60+ file moves) and nesting both (maximum churn).
+
+## Consequences
+
+src/ matches the universal convention; the smallest-diff restructure wins.

--- a/.hallouminate/wiki/architecture/index.md
+++ b/.hallouminate/wiki/architecture/index.md
@@ -2,6 +2,7 @@
 
 <!-- HALLOUMINATE:INDEX-START -->
 - [age-fanout-router](./age-fanout-router.md) — Age fan-out router
+- [pyz-bundling-pipeline](./pyz-bundling-pipeline.md) — Pyz bundling pipeline
 - [ultracook-agent-topology](./ultracook-agent-topology.md) — Ultracook agent topology (now owned by /cook's fan pathway)
 - [workflow-contract-map](./workflow-contract-map.md) — Workflow contract map
 <!-- HALLOUMINATE:INDEX-END -->

--- a/.hallouminate/wiki/architecture/pyz-bundling-pipeline.md
+++ b/.hallouminate/wiki/architecture/pyz-bundling-pipeline.md
@@ -1,0 +1,33 @@
+# Pyz bundling pipeline
+
+How per-skill `.pyz` bundles are built, gated, and verified. Rederived 2026-08-17 from a full trace; recorded because no wiki page covered it.
+
+## Build (`scripts/build_pyz.py`)
+
+One self-contained zipapp per skill, deployed to `skills/<skill>/scripts/<skill>.pyz`. Four layers:
+
+1. **Hand-authored registries** — `SKILLS` (subcommand → source script; generated `__main__.py` dispatches via `runpy`), `EXTRA_MODULES` (cross-src-dir imports the scanner cannot see), `PACKAGE_TREES` (whole packages, i.e. `easy_cheese_schemas`), `SRC_DIRS` (ultracook → `src/fanout/`). Subcommand registration is **manual** — see `.agents/skills/python-authoring/SKILL.md`.
+2. **AST inference** — `needed_shared` / `_local_skill_modules` compute the transitive import closure over `shared/scripts/` and flat skill-dir siblings. Flat modules only; packages must be declared in `PACKAGE_TREES`.
+3. **Generated-file gates** — every build recompiles in-memory and raises `RuntimeError` on mismatch with the checked-in copies:
+   - `contracts.py` `@contract` / `@schema_constraints` decorators → `_schema_catalog_compiler.collect/render` → `_schema_catalog.py` (decorator derivation landed in #417 / `999ced85`; it covers the **schema catalog only**, not subcommand registration).
+   - `skills/*/phase-contract.yaml` → `_phase_registry_compiler` → `_compiled_phase_registry.py`.
+   Regeneration is manual: run the build, commit the output. No pre-commit hook; CI is the enforcement point.
+4. **Deterministic packaging** — pinned zip timestamp/perms/entry order/compresslevel; `__pycache__` and the compiler modules excluded. `vendor_deps.py` (`vendor/`, stamp = sha256 of `requirements-vendor.txt`, attrs+cattrs wheels, hash-pinned) must be populated first via `just vendor`.
+
+## Currency check (CI)
+
+`check .pyz bundles are current` in `.github/workflows/build-pyz.yml` (ubuntu, py3.12): vendor → full rebuild → `scripts/check_bundles.py`.
+
+**`check_bundles.py` is not a byte compare.** It compares each archive member's name + CRC32 + uncompressed size against `git show HEAD:<path>`, deliberately ignoring compressed bytes because `ZIP_DEFLATED` output differs between stock zlib and zlib-ng (`check_bundles.py:7-16`, `build_pyz.py:38-41`). A red check therefore always means genuine staleness (source changed without rebuild, or a stale generated file made `build_pyz` raise) — never environment/zlib variance. Byte determinism is asserted separately by `test_the_wheypoint_bundle_is_deterministic`.
+
+A second workflow step asserts the bundled `easy_cheese_schemas.__version__` inside `ultracook.pyz` matches `pyproject.toml`.
+
+## Safety nets for missing modules
+
+- `tests/python/test_pyz_bundle.py::test_subcommand_resolves_inside_bundle` — every `(skill, subcommand)` run as `python <pyz> <sub> --help` in a `PYTHONPATH`-stripped subprocess; catches any missing top-level import.
+- ~30 test sites import real logic from `cached_bundle(skill)` artifacts rather than `src/`.
+- Residual gap: an undeclared cross-dir import deferred into a function body escapes both the build and the `--help` smoke test.
+
+## Known friction
+
+Nothing local enforces bundle currency: `just check` does not run `check_bundles.py` and there is no pre-commit hook, so "bundles stale" CI failures recur on PRs that touch `src/` without `just bundle` (e.g. #424).

--- a/.hallouminate/wiki/index.md
+++ b/.hallouminate/wiki/index.md
@@ -18,10 +18,11 @@ git-tracking axis (`skills/cheese/references/formatting.md:103`).
 - [specs/](./specs/index.md) — specs
 - [architecture](./architecture.md) — Architecture of easy-cheese
 - [docs-mermaid-rendering](./docs-mermaid-rendering.md) — Docs Mermaid rendering
-- [domain-model](./domain-model.md) — Easy-cheese domain model
+- [domain-model](./domain-model.md) — Easy Cheese domain model
 - [fanout-engine-entities](./fanout-engine-entities.md) — Fan-out engine entities
 - [log](./log.md) — Ingest Log
 - [post-pr-wiki-writeback](./post-pr-wiki-writeback.md) — Post-PR wiki write-back — plan and followups
+- [red-gate-environment-gotchas](./red-gate-environment-gotchas.md) — red-gate environment gotchas
 - [skill-parity-analysis](./skill-parity-analysis.md) — Skill-parity analysis
 - [skill-size-budget](./skill-size-budget.md) — Skill size budget
 - [spec-workflow-comparison](./spec-workflow-comparison.md) — Spec / brainstorm-to-spec workflow comparison

--- a/.hallouminate/wiki/red-gate-environment-gotchas.md
+++ b/.hallouminate/wiki/red-gate-environment-gotchas.md
@@ -1,0 +1,25 @@
+# red-gate environment gotchas
+
+Field notes from running the Cut→Cook gate end-to-end on the pyz-pipeline-contracts spec (2026-08). Each cost real diagnosis time; none is visible from the red_gate code alone.
+
+## node_modules breaks phase snapshotting
+
+`red-gate begin`/`issue`/`validate` walk the full project tree and refuse directory symlinks. pnpm's `node_modules/.pnpm` layout contains ~1500 of them, so **any red-gate operation fails while node_modules exists**. node_modules is gitignored and fully regenerable (`just docs-install`, frozen lockfile), so the working procedure is:
+
+1. Delete node_modules before entering a Cut/Press phase or replaying a receipt.
+2. Run Astro/pnpm gates (docs-build, tests needing node deps) **after** the last red-gate call of the session.
+
+A durable fix would add `node_modules` to `_EXCLUDED_SNAPSHOT_DIRS` in `src/cut/red_gate.py` — not done as of this note because it changes receipt semantics.
+
+## Cut production_paths: declare the blast radius you cannot see yet
+
+Everything outside `production_paths` is frozen as an oracle dependency; `validate --state green` flags any drift. Two classes of paths are easy to under-declare:
+
+- **`.gitignore`** — any restructure that moves gitignored generated outputs (e.g. Astro `src/` → `website/`) must rename ignore rules, so declare `.gitignore` whenever a spec moves directories.
+- **Every test suite whose conftest imports `build_pyz` or loads modules from a bundle** — pruning a registry entry ripples into `tests/schemas/python` (bundle-provenance assertions, validator fixtures), not just the suites that obviously test the pruned thing. Grep `import build_pyz` and `cached_bundle(` across `tests/**` before fixing the path list.
+
+The pyz-pipeline-contracts receipt carries exactly four green-validation variances from this (`.gitignore` + three `tests/schemas/python` files), each documented in `.cheese/cook/pyz-pipeline-contracts.md`.
+
+## Pruning a subcommand is not pruning a module
+
+`press.pyz red-gate` was removed as a *dispatchable subcommand*, but `src/fanout/press_route.py` still imports `cut.red_gate` at runtime, so `EXTRA_MODULES["press"]` must keep staging `red_gate.py` + `gate_receipts.py` + `taste_test.py` as plain modules. Before deleting a registry entry, distinguish its two roles: dispatcher surface (what the SKILLS map grants) vs staged import graph (what other staged files need).

--- a/.hallouminate/wiki/specs/index.md
+++ b/.hallouminate/wiki/specs/index.md
@@ -4,4 +4,5 @@
 - [cross-skill-work-contract-implementation-gaps](./cross-skill-work-contract-implementation-gaps.md) — Cross-skill work contract implementation gaps
 - [cross-skill-work-contract](./cross-skill-work-contract.md) — Cross-skill work contract
 - [milknado-executor-recovery](./milknado-executor-recovery.md) — Milknado executor recovery
+- [pyz-pipeline-contracts](./pyz-pipeline-contracts.md) — pyz pipeline contracts: closure gate, currency enforcement, discoverability, skill↔bundle equality
 <!-- HALLOUMINATE:INDEX-END -->

--- a/.hallouminate/wiki/specs/pyz-pipeline-contracts.md
+++ b/.hallouminate/wiki/specs/pyz-pipeline-contracts.md
@@ -1,0 +1,179 @@
+---
+source: mold-handshake
+slug: pyz-pipeline-contracts
+fork_taste:
+  draft_sha256: adb68a0e016ca01d522990d9d5bef3c7c692568970254dc17f5848f60b0149c2
+  verdict: pass
+  correction_round: 2
+typed_plan:
+  plan_id: plan-pyz-pipeline-contracts-001
+  curds: 5
+  waves: 3
+gate_applicability:
+  disposition: red-required
+  work_class: behavior
+  ui_surface: non-browser
+agent_introduced_scope: ["website/", "src/PYTHON_SCRIPTS.md", "ships-as banner"]
+entity_referent_bindings:
+  - {noun: "SKILLS registry", verdict: Bound, referent: "scripts/build_pyz.py", citation: "scripts/build_pyz.py:57", note: "hand-authored subcommand map; stays authoritative"}
+  - {noun: "COMMON_CONSUMERS", verdict: Bound, referent: "scripts/build_pyz.py", citation: "scripts/build_pyz.py:213", note: "gains cook"}
+  - {noun: "PACKAGE_TREES", verdict: Bound, referent: "scripts/build_pyz.py", citation: "scripts/build_pyz.py:172", note: "becomes the single schema-consumer authority"}
+  - {noun: "script map", verdict: "NEW ENTITY", referent: null, citation: null, note: "generated src/PYTHON_SCRIPTS.md, designed in this spec"}
+  - {noun: "import-closure gate", verdict: "NEW ENTITY", referent: null, citation: null, note: "build-time verification pass, designed in this spec"}
+  - {noun: "skill-bundle contract test", verdict: "NEW ENTITY", referent: null, citation: null, note: "supersedes the drifted SKILL_SUBCOMMANDS hand copy at tests/python/test_pyz_bundle.py:24"}
+---
+
+# pyz pipeline contracts: closure gate, currency enforcement, discoverability, skill↔bundle equality
+
+## Problem
+
+The .pyz build pipeline has four drift classes with no local gate: (1) cross-directory
+imports ride on the hand-maintained EXTRA_MODULES dict and a missing entry ships a
+bundle that fails only at runtime on a lazy import; (2) nothing local enforces bundle
+currency, so "bundles stale" CI failures recur (PR #424); (3) source layout is opaque —
+src/ mixes the Astro docs site with Python sources and no generated artifact says
+where a subcommand's source lives; (4) the SKILLS registry, skill markdown, and the
+test suite's hand-copied SKILL_SUBCOMMANDS dict are three unreconciled registries —
+already drifted (3 dead registrations, 9 test-only subcommands, and a documented
+common.pyz fallback for cook that is never built).
+
+## Ground evidence
+
+- scripts/build_pyz.py:57 SKILLS, :146 EXTRA_MODULES, :172 PACKAGE_TREES, :184 VENDORED_DEP_BUNDLES, :213 COMMON_CONSUMERS.
+- scripts/check_bundles.py:7-16 — CRC-based currency check, CI-only (.github/workflows/build-pyz.yml:44-70); justfile has no local equivalent.
+- tests/python/test_pyz_bundle.py:24-66 — hand-copied SKILL_SUBCOMMANDS, missing press red-gate, ultracook curd-block, ultracook age-route (the three dead registrations).
+- skills/cook/references/fan-pathway.md:33-35 — documents `common.pyz read_handoff_slug` fallback; COMMON_CONSUMERS excludes cook.
+- astro.config.mjs — default srcDir ./src; src/components, src/pages, src/styles, src/content are Astro; the rest is Python.
+- Dead registrations (3), no caller in src/**, shared/**, scripts/**, tests/**: press red-gate (registered scripts/build_pyz.py:116; absent from tests/python/test_pyz_bundle.py:55; all red-gate tests target cut.pyz — tests/cut/python/test_cook_red_gate.py:244); ultracook curd-block (registered scripts/build_pyz.py:134; tests/fanout/python/test_curd_block.py:21 imports the module directly; skills/mold/references/curdle.md:269 forbids invoking it); ultracook age-route (registered scripts/build_pyz.py:133; tests/fanout/python/test_age_route_cli.py:24,34 imports the module directly).
+- Test-only subcommands (9), invoked solely by tests: mold render_html, ultracook artifact-path/phase_decision/manifest_update/wiring_topo_sort, common slugify/handoff_cli/paths_cli/render_html — each exercised only via tests/python/test_pyz_bundle.py:24-66 (SKILL_SUBCOMMANDS smoke test) or direct module imports (tests/fanout/python/test_manifest_update.py:80, tests/shared/python/test_handoff_cli.py:24-27, tests/shared/python/test_paths_cli.py:22-26, tests/python/test_pyz_bundle.py:627-640).
+
+## Options considered
+
+- Do Nothing — CI keeps catching staleness late; registry drift keeps accreting (already 12 unreconciled entries). Rejected.
+- CI auto-commit of rebuilt bundles — zero local friction but bot pushes and rebase noise. Rejected at fork currency-enforcement.
+- Internal-flag equality (keep test-only subcommands, mark internal) — registry carries two meanings. Rejected at fork contract-strictness.
+- Move Python out of src/ or nest both — 60+ file moves versus one srcDir config key. Rejected at fork restructure-shape.
+
+## Approach
+
+Six settled decisions, one per fork:
+
+1. import-closure-check — after staging each bundle, AST-scan every staged file and
+   assert each absolute import (module-level AND function-body) resolves to stdlib, a
+   staged module, or a vendored dependency; unresolved imports fail the build naming
+   the module and importer.
+2. currency-enforcement — wire scripts/check_bundles.py into `just check` and add a
+   prek pre-commit hook scoped to src/**, shared/**, and skills/*/phase-contract.yaml
+   so stale bundles fail before CI.
+3. discoverability-surfaces — generate src/PYTHON_SCRIPTS.md (subcommand → source
+   file → bundle table compiled from SKILLS, COMMON_SUBCOMMANDS, EXTRA_MODULES,
+   PACKAGE_TREES) with a build_pyz staleness gate exactly like the schema catalog;
+   add a one-line ships-as banner to every registered source file, asserted by test;
+   add a thin hand-written src/README.md pointing at the generated map.
+4. contract-strictness — prune the registry to the prose-referenced set: remove the
+   3 dead registrations (press red-gate, ultracook curd-block, ultracook age-route),
+   demote the 9 test-only subcommands to direct module tests, then land a
+   skill-bundle contract test asserting strict equality between skill-markdown
+   references and build_pyz registries, derived from build_pyz.SKILLS (the
+   SKILL_SUBCOMMANDS hand copy is deleted, not kept in sync).
+5. cook-common-consumer — add cook to COMMON_CONSUMERS so the documented
+   common.pyz read_handoff_slug fallback exists on bundle-only hosts; the contract
+   test also asserts common.pyz prose references imply consumer membership.
+6. restructure-shape — move the Astro site source out of src/ to website/ via the
+   srcDir config key (components, pages, styles, content, sidebar.mjs,
+   content.config.ts), leaving src/ purely Python.
+
+## Decisions
+
+Consequential (settled at forks): import-closure-check includes function-body
+imports; currency-enforcement is just-check-plus-prek-hook; discoverability-surfaces
+is map+banner+README on top of restructure; contract-strictness is
+prune-to-prose-set with strict equality; cook-common-consumer adds cook rather than
+weakening the doc; restructure-shape is site-out-of-src.
+
+Minor (agent-decided): VENDORED_DEP_BUNDLES = tuple(PACKAGE_TREES); named
+PHASE_REGISTRY_CONSUMERS constant replaces the inline set at build_pyz.py:454;
+memoize the schema-catalog and phase-registry compiles once per process;
+scope sys.path insertions with try/finally and drop the _build_schema_contracts
+sys.modules registration; src/README.md explains, the generated map enumerates.
+
+## Interface sketches
+
+In scripts/build_pyz.py (import-closure-check, discoverability-surfaces, cook-common-consumer):
+
+```python
+def _verify_import_closure(stage: Path, skill: str) -> None:
+    """Raise RuntimeError listing every absolute import in staged files,
+    module-level and function-body, not resolved by stdlib, stage, or vendor."""
+
+def _render_script_map() -> str:
+    """Deterministic markdown for src/PYTHON_SCRIPTS.md: one row per (bundle,
+    subcommand, source path), compiled from SKILLS, COMMON_SUBCOMMANDS,
+    EXTRA_MODULES, PACKAGE_TREES."""
+
+def _checked_in_script_map_bytes(expected_source: str) -> bytes:
+    """Same gate pattern as _checked_in_schema_catalog_bytes; stale map fails build."""
+
+PHASE_REGISTRY_CONSUMERS: frozenset[str]     ... replaces the inline set at build_pyz.py:454
+VENDORED_DEP_BUNDLES = tuple(PACKAGE_TREES)  ... derived, no second list
+COMMON_CONSUMERS = frozenset({"cure", "age", "ultracook", "cook"})
+```
+
+In tests/python/test_skill_contract.py (contract-strictness, cook-common-consumer, discoverability-surfaces banner assertion):
+
+```python
+def referenced_subcommands() -> dict[str, frozenset[str]]:
+    """Parse skills/**/*.md for '<bundle>.pyz <subcommand>' invocations."""
+
+def test_registry_equals_prose(): ...          strict equality, both directions
+def test_common_consumers_cover_prose(): ...   a common.pyz reference implies consumer membership
+def test_source_banners(): ...                 every registered source opens with the ships-as banner
+```
+
+In the justfile and prek config (currency-enforcement): a `check-bundles` recipe running
+python3 scripts/check_bundles.py, added to the `check` dependency chain, plus a local
+prek hook `bundle-currency` scoped to files matching src/, shared/, and
+skills/*/phase-contract.yaml.
+
+In astro.config.mjs (restructure-shape): `srcDir: './website'` — site sources move to
+website/, and src/ is pure Python.
+
+## Test Contracts
+
+| acceptance id | interface | seam | expected_failure | mode |
+| --- | --- | --- | --- | --- |
+| AC-1 | python3 scripts/build_pyz.py (import-closure-check) | build subprocess exit code and stderr | On main, staging a script whose function-body imports an undeclared cross-directory module builds cleanly; the closure gate must exit nonzero naming the unresolved module and its importer | tracer |
+| AC-2 | pytest tests/python/test_skill_contract.py (contract-strictness) | pytest run against build_pyz registries and skills markdown | On main the equality assertion fails: 12 registered subcommands, including press.pyz red-gate, have no skill-markdown reference | tracer |
+| AC-3 | python3 skills/cook/scripts/common.pyz read_handoff_slug (cook-common-consumer) | bundle-dispatch subprocess on a bundle-only layout | On main the invocation fails because skills/cook/scripts/common.pyz is never built; after cook joins COMMON_CONSUMERS it resolves and exits 0 on --help | tracer |
+| AC-4 | python3 skills/press/scripts/press.pyz red-gate (contract-strictness) | dispatcher usage-rejection exit code | On main press.pyz red-gate dispatches successfully; asserting exit 2 usage-rejection fails until the dead registration is pruned | tracer |
+| AC-5 | python3 scripts/build_pyz.py (discoverability-surfaces) | build gate RuntimeError on stale generated file | On main no src/PYTHON_SCRIPTS.md exists; the gate must fail the build until the checked-in map byte-matches the registries | tracer |
+| AC-6 | just check (currency-enforcement) | recipe exit code with a deliberately stale committed bundle | On main just check passes with a stale bundle because check_bundles.py is not wired into the recipe | tracer |
+| AC-7 | pytest banner assertion in test_skill_contract.py (discoverability-surfaces) | pytest run over registered source files | On main the banner test fails: src/age/age-html-report.py has no ships-as header line | tracer |
+| AC-8 | pytest src purity assertion (restructure-shape) | pytest run over src/ tree contents | On main the assertion that src/ contains no Astro sources fails: src/components/Sidebar.astro exists | tracer |
+
+## Acceptance
+
+- AC-1: builds fail with a named unresolved import for any staged module gap, covering function-body imports (import-closure-check).
+- AC-2: skill-markdown references and build_pyz registries are provably equal both directions (contract-strictness); the SKILL_SUBCOMMANDS hand copy is gone.
+- AC-3: cook ships common.pyz and the documented fallback resolves (cook-common-consumer).
+- AC-4: pruned dead subcommands, press red-gate first, are rejected by the dispatcher (contract-strictness).
+- AC-5: src/PYTHON_SCRIPTS.md exists, is generated, and stale copies fail the build (discoverability-surfaces).
+- AC-6: just check fails on stale bundles locally; the prek hook fires on the scoped paths (currency-enforcement).
+- AC-7: every registered source file carries the ships-as banner (discoverability-surfaces).
+- AC-8: src/ contains only Python after the site moves to website/ (restructure-shape).
+
+## Quality gates
+
+- `just check` — vendor, tests, lint, and (new) bundle currency.
+- `python3 scripts/build_pyz.py && python3 scripts/check_bundles.py` — build with closure + map gates, then currency.
+- `pytest tests/python/test_skill_contract.py tests/python/test_pyz_bundle.py` — contract equality, banners, dispatcher behavior.
+- `npm run build` (Astro) — site builds from website/ after restructure-shape.
+
+## Typed plan (summary)
+
+Host-validated `plan-pyz-pipeline-contracts-001`: 5 curds / 3 waves — wave 1: pyz-core, currency-enforcement, site-out-of-src; wave 2: banners-and-readme; wave 3: skill-contract-tests. Full typed `PlannerResult`/`CurdPlan` persisted in the durable spec at `~/.local/share/cheese/paulnsorensen-easy-cheese/specs/pyz-pipeline-contracts.md`.
+
+## Non-goals
+
+- Decorator-based subcommand self-registration — tracked as [#437](https://github.com/paulnsorensen/easy-cheese/issues/437), not in this spec (user disposition).
+- Gitignoring/relocating the untracked site/ build output — tracked as [#438](https://github.com/paulnsorensen/easy-cheese/issues/438) (user disposition).


### PR DESCRIPTION
## What changed

Defines the canonical Python bundle registries, pipeline invariants, and failure contracts. Adds the matching wiki gotchas and validator coverage.

## Why

This is the contract layer extracted from #439 so the later implementation PRs can be reviewed against explicit rules.

## How to verify

`PATH=/private/tmp/ec-py312-env/bin:$PATH just check`

## Risk / rollout notes

Documentation and validation only. Stacked on #453.

## Checklist

- [x] Conventional Commits PR title
- [x] Tests added or updated
- [x] Documentation updated
- [x] No secrets or credentials added
