### PR TITLE
feat(pyz): enforce bundle closure and currency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: bundle-currency
+        name: bundle-currency
+        entry: bash -c 'python3 scripts/build_pyz.py && python3 scripts/check_bundles.py --against index'
+        language: system
+        files: '^(src/|shared/|skills/[^/]+/phase-contract\.yaml$)'
+        pass_filenames: false

--- a/justfile
+++ b/justfile
@@ -36,6 +36,10 @@ test: vendor
 test-skill-overlap:
     cargo test --manifest-path tools/skill-overlap/Cargo.toml
 
+# Verify rebuilt .pyz bundles match HEAD (check/ci rebuild first)
+check-bundles:
+    python3 scripts/check_bundles.py
+
 # Build self-contained .pyz bundles for shared-consuming skills (CI rebuilds on every push to main)
 bundle: vendor
     python3 scripts/build_pyz.py
@@ -74,10 +78,10 @@ update-skill-budgets:
     python3 .github/scripts/validate_skills.py --write-budgets
 
 # Full local check with autofixes
-check: lint-md-fix lint-yaml-fix lint-yaml lint-py-fix lint-sh test docs-build
+check: lint-md-fix lint-yaml-fix lint-yaml lint-py-fix lint-sh test bundle check-bundles docs-build
 
 # CI-mode verification (no autofixes)
-ci: lint-md lint-yaml lint-sh test docs-build
+ci: lint-md lint-yaml lint-sh test bundle check-bundles docs-build
 
 # Install docs build dependencies
 docs-install:

--- a/scripts/build_pyz.py
+++ b/scripts/build_pyz.py
@@ -205,6 +205,9 @@ COMMON_SUBCOMMANDS: dict[str, str] = {
 # Wave 1: consumer skills receive common.pyz
 COMMON_CONSUMERS: frozenset[str] = frozenset({"cure", "age", "ultracook", "cook"})
 
+# Host-only imports that staged scripts may load at runtime, but bundles do not ship.
+HOST_IMPORTS: frozenset[str] = frozenset({"pytest", "_pytest"})
+
 # Bundles that ship the compiled phase registry data module.
 PHASE_REGISTRY_CONSUMERS: frozenset[str] = frozenset(
     {COMMON, "cook", "ultracook", "wheypoint"}
@@ -372,6 +375,103 @@ def _checked_in_script_map_bytes(expected_source: str) -> bytes:
 
 
 
+def _guards_import_error(handlers: list[ast.ExceptHandler]) -> bool:
+    guard_names = {"ImportError", "ModuleNotFoundError"}
+
+    def names(expr: ast.expr | None) -> list[str]:
+        if isinstance(expr, ast.Name):
+            return [expr.id]
+        if isinstance(expr, ast.Tuple):
+            return [e.id for e in expr.elts if isinstance(e, ast.Name)]
+        return []
+
+    def is_raise_only(handler: ast.ExceptHandler) -> bool:
+        return (
+            len(handler.body) == 1
+            and isinstance(handler.body[0], ast.Raise)
+            and handler.body[0].exc is None
+        )
+
+    return any(
+        guard_names & set(names(h.type)) and not is_raise_only(h)
+        for h in handlers
+    )
+
+
+class _UnguardedImportVisitor(ast.NodeVisitor):
+    """Collects absolute-import top names, skipping imports inside a
+    try/except ImportError (or ModuleNotFoundError) block and inside the
+    matching except handler's body — both sides of a deliberate flat-vs-
+    package import fallback are optional, not a bundling gap."""
+
+    def __init__(self) -> None:
+        self.names: set[str] = set()
+
+    def visit_Import(self, node: ast.Import) -> None:
+        self.names.update(alias.name.split(".")[0] for alias in node.names)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.level == 0 and node.module:
+            self.names.add(node.module.split(".")[0])
+
+    def visit_Try(self, node: ast.Try) -> None:
+        if not _guards_import_error(node.handlers):
+            for stmt in node.body:
+                self.visit(stmt)
+        for handler in node.handlers:
+            if not _guards_import_error([handler]):
+                self.visit(handler)
+        for stmt in [*node.orelse, *node.finalbody]:
+            self.visit(stmt)
+
+
+def _layout_packages(skill: str) -> set[str]:
+    """src/ directory names that exist as packages in a checkout, not in the zip."""
+    names = {SRC_DIRS.get(skill, skill)}
+    names.update(subdir for subdir, _ in EXTRA_MODULES.get(skill, []))
+    names.discard("")
+    return names
+
+
+@functools.cache
+def _unguarded_imports_text(source: str) -> frozenset[str]:
+    visitor = _UnguardedImportVisitor()
+    visitor.visit(ast.parse(source))
+    return frozenset(visitor.names)
+
+
+def _unguarded_imports(path: Path) -> set[str]:
+    return set(_unguarded_imports_text(path.read_text(encoding="utf-8")))
+
+
+def _check_import_closure(skill: str, stage: Path) -> None:
+    """Fail loudly if a staged first-party script imports something the
+    bundle doesn't ship, module-level or from inside a function body.
+    Imports guarded by try/except ImportError (or ModuleNotFoundError) are
+    deliberately optional and exempt. Host runners (pytest) and source-checkout
+    package names (`from cut import ...` behind `_BUNDLE_PATH`) are allowlisted.
+    Vendored dependency trees are resolution targets, not scan subjects."""
+    resolvable = set(sys.stdlib_module_names)
+    resolvable |= {p.stem for p in stage.glob("*.py")}
+    resolvable |= {p.name for p in stage.iterdir() if p.is_dir()}
+    resolvable |= HOST_IMPORTS
+    resolvable |= _layout_packages(skill)
+    vendored_stage_names: set[str] = set()
+    if skill in VENDORED_DEP_BUNDLES:
+        trees = vendored_dep_trees()
+        vendored_stage_names = {tree.name for tree in trees}
+        resolvable |= {tree.stem if tree.is_file() else tree.name for tree in trees}
+    problems = [
+        f"[{skill}] unresolved import {name!r} in {path.relative_to(stage)}"
+        for path in sorted(stage.rglob("*.py"))
+        if path.relative_to(stage).parts[0] not in vendored_stage_names
+        for name in sorted(_unguarded_imports(path))
+        if name not in resolvable
+    ]
+    if problems:
+        raise RuntimeError("; ".join(problems))
+
+
 def _src_dir(skill: str) -> Path:
     """The src/ subdir a skill's scripts live in (usually the skill name)."""
     return SRC_ROOT / SRC_DIRS.get(skill, skill)
@@ -409,15 +509,20 @@ def _source_path(skill: str, source: str | Shared) -> Path:
     return _src_dir(skill) / source
 
 
-def _imported_top_names(path: Path) -> set[str]:
-    tree = ast.parse(path.read_text(encoding="utf-8"))
+@functools.cache
+def _imported_top_names_text(source: str) -> frozenset[str]:
+    tree = ast.parse(source)
     names: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             names.update(alias.name.split(".")[0] for alias in node.names)
         elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
             names.add(node.module.split(".")[0])
-    return names
+    return frozenset(names)
+
+
+def _imported_top_names(path: Path) -> set[str]:
+    return set(_imported_top_names_text(path.read_text(encoding="utf-8")))
 
 
 def _local_skill_modules(skill: str) -> set[str]:
@@ -591,6 +696,7 @@ def _build_bundle(
         (stage / "__main__.py").write_text(
             _dispatcher_source(sub_to_module), encoding="utf-8"
         )
+        _check_import_closure(skill, stage)
         _write_zipapp(stage, target)
     return target
 

--- a/scripts/check_bundles.py
+++ b/scripts/check_bundles.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
-"""Check every committed .pyz still matches its sources, by content.
+"""Check every rebuilt .pyz still matches the git copy it will ship.
 
-Run after `build_pyz.py` has rebuilt the working tree: this compares each
-rebuilt bundle against the copy committed at HEAD.
+Run after `build_pyz.py` has rebuilt the working tree. Compares each rebuilt
+bundle to a git blob — HEAD for `just check` / CI, the index for the pre-commit
+hook — by member name, CRC, and uncompressed size rather than raw bytes.
 
-The comparison is per-member name, CRC, and uncompressed size rather than raw
-bytes. Bundles are ZIP_DEFLATED, and two zlib builds compress identical input
-to different bytes -- observed on one machine across two CPython builds
-reporting the same zlib 1.3.1. A raw-byte diff would therefore fail for any
-contributor whose zlib differs from whoever last committed, which is noise, not
-staleness. Member CRCs still catch the signal this gate exists for: a source
-edit that never made it into the committed bundle.
+Bundles are ZIP_DEFLATED, and two zlib builds compress identical input to
+different bytes. A raw-byte diff would fail for any contributor whose zlib
+differs from whoever last committed. Member CRCs still catch the signal this
+gate exists for: a source edit that never made it into the compared blob.
 
 Byte-for-byte reproducibility is deliberately not asserted; see the spec's
 accepted risk on ZIP_DEFLATED determinism.
@@ -18,6 +16,7 @@ accepted risk on ZIP_DEFLATED determinism.
 
 from __future__ import annotations
 
+import argparse
 import io
 import subprocess
 import sys
@@ -26,6 +25,12 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BUNDLE_GLOB = "skills/*/scripts/*.pyz"
+_MISSING_MARKERS = (
+    b"exists on disk, but not in",
+    b"does not exist in",
+    b"path does not exist",
+    b"does not exist",
+)
 
 
 def _manifest(data: bytes) -> dict[str, tuple[int, int]]:
@@ -34,41 +39,91 @@ def _manifest(data: bytes) -> dict[str, tuple[int, int]]:
         return {i.filename: (i.CRC, i.file_size) for i in archive.infolist()}
 
 
-def _committed(path: Path) -> bytes | None:
-    """The blob at HEAD, or None when the bundle is newly added."""
+def classify_git_show(returncode: int, stderr: bytes) -> str:
+    """ok | missing | error. `missing` is a newly added bundle; anything else
+    nonzero is a git failure the gate must not swallow as 'new'."""
+    if returncode == 0:
+        return "ok"
+    lowered = stderr.lower()
+    if any(marker in lowered for marker in _MISSING_MARKERS):
+        return "missing"
+    return "error"
+
+
+def _spec(path: Path, against: str) -> str:
+    posix = path.as_posix()
+    return f":{posix}" if against == "index" else f"HEAD:{posix}"
+
+
+def _git_blob(path: Path, against: str) -> bytes | None:
+    """The blob at HEAD or the index, or None when the path is newly added."""
     result = subprocess.run(
-        ["git", "show", f"HEAD:{path.as_posix()}"],
+        ["git", "show", _spec(path, against)],
         cwd=REPO_ROOT,
         capture_output=True,
     )
-    return result.stdout if result.returncode == 0 else None
+    kind = classify_git_show(result.returncode, result.stderr)
+    if kind == "ok":
+        return result.stdout
+    if kind == "missing":
+        return None
+    sys.stderr.write(result.stderr.decode("utf-8", errors="replace"))
+    raise RuntimeError(
+        f"git show {_spec(path, against)!r} failed (exit {result.returncode})"
+    )
 
 
-def _describe(rebuilt: dict[str, tuple[int, int]], committed: dict[str, tuple[int, int]]) -> list[str]:
+def _describe(
+    rebuilt: dict[str, tuple[int, int]], compared: dict[str, tuple[int, int]]
+) -> list[str]:
     problems = []
-    for name in sorted(set(rebuilt) - set(committed)):
-        problems.append(f"    + {name} (built, not in the committed bundle)")
-    for name in sorted(set(committed) - set(rebuilt)):
-        problems.append(f"    - {name} (committed, no longer built)")
-    for name in sorted(set(rebuilt) & set(committed)):
-        if rebuilt[name] != committed[name]:
+    for name in sorted(set(rebuilt) - set(compared)):
+        problems.append(f"    + {name} (built, not in the compared bundle)")
+    for name in sorted(set(compared) - set(rebuilt)):
+        problems.append(f"    - {name} (compared, no longer built)")
+    for name in sorted(set(rebuilt) & set(compared)):
+        if rebuilt[name] != compared[name]:
             problems.append(f"    ~ {name} (content differs)")
     return problems
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--against",
+        choices=("head", "index"),
+        default="head",
+        help="blob to compare the rebuilt worktree against (default: HEAD)",
+    )
+    args = parser.parse_args(argv)
     stale: list[str] = []
     checked = 0
-    for path in sorted(REPO_ROOT.glob(BUNDLE_GLOB)):
-        relative = path.relative_to(REPO_ROOT)
-        committed = _committed(relative)
-        if committed is None:
-            print(f"new bundle, nothing to compare: {relative}")
-            continue
-        checked += 1
-        problems = _describe(_manifest(path.read_bytes()), _manifest(committed))
-        if problems:
-            stale.append(f"  {relative}\n" + "\n".join(problems))
+    found = list(sorted(REPO_ROOT.glob(BUNDLE_GLOB)))
+    if not found:
+        print("::error::no .pyz bundles found under skills/*/scripts/", file=sys.stderr)
+        return 1
+    try:
+        for path in found:
+            relative = path.relative_to(REPO_ROOT)
+            compared = _git_blob(relative, args.against)
+            if compared is None:
+                print(f"new bundle, nothing to compare: {relative}")
+                continue
+            checked += 1
+            problems = _describe(_manifest(path.read_bytes()), _manifest(compared))
+            if problems:
+                stale.append(f"  {relative}\n" + "\n".join(problems))
+    except RuntimeError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+
+    if found and checked == 0:
+        print(
+            "::error::.pyz bundles exist but none could be compared; "
+            "git did not return a blob for any of them.",
+            file=sys.stderr,
+        )
+        return 1
 
     if stale:
         print(

--- a/tests/python/test_check_bundles.py
+++ b/tests/python/test_check_bundles.py
@@ -1,0 +1,32 @@
+"""Unit tests for scripts/check_bundles.py classification."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import check_bundles  # noqa: E402
+
+
+def test_classify_git_show_missing_path_is_new_bundle() -> None:
+    assert (
+        check_bundles.classify_git_show(
+            128, b"fatal: path 'skills/cut/scripts/cut.pyz' does not exist in 'HEAD'\n"
+        )
+        == "missing"
+    )
+    assert (
+        check_bundles.classify_git_show(
+            128,
+            b"fatal: path 'x.pyz' exists on disk, but not in 'HEAD'\n",
+        )
+        == "missing"
+    )
+
+
+def test_classify_git_show_other_failures_are_errors() -> None:
+    assert check_bundles.classify_git_show(128, b"fatal: not a git repository\n") == "error"
+    assert check_bundles.classify_git_show(128, b"fatal: Invalid object name 'HEAD'.\n") == "error"
+    assert check_bundles.classify_git_show(0, b"") == "ok"

--- a/tests/python/test_pyz_pipeline_tracers.py
+++ b/tests/python/test_pyz_pipeline_tracers.py
@@ -8,6 +8,7 @@ no tracer ever mutates the project.
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import sys
@@ -83,3 +84,81 @@ def test_script_map_gate(tmp_path: Path) -> None:
     detail = f"exit={proc.returncode}\n{_output(proc)}"
     assert proc.returncode != 0, f"{WITNESS_SCRIPT_MAP}\n{detail}"
     assert "PYTHON_SCRIPTS.md" in _output(proc), f"{WITNESS_SCRIPT_MAP}\n{detail}"
+
+
+WITNESS_IMPORT_CLOSURE = (
+    "On main, staging a script whose function-body imports an undeclared "
+    "cross-directory module builds cleanly; the closure gate must exit "
+    "nonzero naming the unresolved module and its importer"
+)
+WITNESS_BUNDLE_CURRENCY = (
+    "On main just check passes with a stale bundle because check_bundles.py "
+    "is not wired into the recipe"
+)
+
+
+def test_import_closure_gate(tmp_path: Path) -> None:
+    sandbox = tmp_path / "project"
+    _copy_project_subset(
+        sandbox,
+        dirs=("scripts", "src", "shared", "vendor"),
+        files=("requirements-vendor.txt",),
+    )
+    probe = sandbox / "src" / "melt" / "batch-resolve.py"
+    probe.write_text(
+        probe.read_text(encoding="utf-8")
+        + "\n\ndef _cut_red_tracer_probe():\n    import wiring_topo_sort\n",
+        encoding="utf-8",
+    )
+    proc = _run(
+        [sys.executable, "scripts/build_pyz.py", "--out-dir", str(tmp_path / "out"), "melt"],
+        cwd=sandbox,
+    )
+    detail = f"exit={proc.returncode}\n{_output(proc)}"
+    assert proc.returncode != 0, f"{WITNESS_IMPORT_CLOSURE}\n{detail}"
+    assert "wiring_topo_sort" in _output(proc), f"{WITNESS_IMPORT_CLOSURE}\n{detail}"
+    assert "batch_resolve" in _output(proc) or "batch-resolve" in _output(proc), (
+        f"{WITNESS_IMPORT_CLOSURE}\n{detail}"
+    )
+
+
+def test_bundle_currency_wired_into_check(tmp_path: Path) -> None:
+    sandbox = tmp_path / "project"
+    _copy_project_subset(
+        sandbox,
+        dirs=("scripts", "src", "shared", "skills", "vendor"),
+        files=("requirements-vendor.txt", "justfile"),
+    )
+    git = ["git", "-c", "user.email=cut@tracer", "-c", "user.name=cut", "-c", "commit.gpgsign=false"]
+    assert _run([*git, "init", "-q"], cwd=sandbox).returncode == 0
+    assert _run([*git, "add", "-A", "-f"], cwd=sandbox).returncode == 0
+    assert _run([*git, "commit", "-q", "-m", "base"], cwd=sandbox).returncode == 0
+
+    match = re.search(
+        r"^check:(.*)$",
+        (sandbox / "justfile").read_text(encoding="utf-8"),
+        re.M,
+    )
+    assert match is not None, WITNESS_BUNDLE_CURRENCY
+    deps = match.group(1).split()
+    detail = f"check deps={deps}"
+    assert "bundle" in deps and "check-bundles" in deps, (
+        f"{WITNESS_BUNDLE_CURRENCY}\n{detail}"
+    )
+    assert deps.index("bundle") < deps.index("check-bundles"), (
+        f"{WITNESS_BUNDLE_CURRENCY}\n{detail}"
+    )
+
+    stale_source = sandbox / "src" / "melt" / "batch-resolve.py"
+    stale_source.write_text(
+        stale_source.read_text(encoding="utf-8") + "\n# cut tracer staleness probe\n",
+        encoding="utf-8",
+    )
+    rebuild = _run([sys.executable, "scripts/build_pyz.py", "melt"], cwd=sandbox)
+    assert rebuild.returncode == 0, f"{WITNESS_BUNDLE_CURRENCY}\n{_output(rebuild)}"
+
+    recipe = _run([sys.executable, "scripts/check_bundles.py"], cwd=sandbox)
+    detail = f"exit={recipe.returncode}\n{_output(recipe)}"
+    assert recipe.returncode != 0 and "stale" in _output(recipe), (
+        f"{WITNESS_BUNDLE_CURRENCY}\n{detail}"
+    )


### PR DESCRIPTION
## What changed\n\nAdds AST-based import-closure enforcement and fail-closed HEAD/index bundle-currency checks, then wires the currency gate into markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Finding: skills/**/*.md .agents/**/*.md *.md
Linting: 104 files
Summary: 0 issues in 0 files
./pnpm-lock.yaml
  16:201    warning  line too long (351 > 200 characters)  (line-length)
  2274:201  warning  line too long (207 > 200 characters)  (line-length)
  2398:201  warning  line too long (359 > 200 characters)  (line-length)
  2400:201  warning  line too long (210 > 200 characters)  (line-length)

./.worktrees/pr439-enforcement/pnpm-lock.yaml
  16:201    warning  line too long (351 > 200 characters)  (line-length)
  2274:201  warning  line too long (207 > 200 characters)  (line-length)
  2398:201  warning  line too long (359 > 200 characters)  (line-length)
  2400:201  warning  line too long (210 > 200 characters)  (line-length)

./.worktrees/cheeselord-design-adoption/pnpm-lock.yaml
  2661:201  warning  line too long (207 > 200 characters)  (line-length)

./.worktrees/pr439-spec/pnpm-lock.yaml
  16:201    warning  line too long (351 > 200 characters)  (line-length)
  2274:201  warning  line too long (207 > 200 characters)  (line-length)
  2398:201  warning  line too long (359 > 200 characters)  (line-length)
  2400:201  warning  line too long (210 > 200 characters)  (line-length)

./.worktrees/pr439-surface/pnpm-lock.yaml
  16:201    warning  line too long (351 > 200 characters)  (line-length)
  2274:201  warning  line too long (207 > 200 characters)  (line-length)
  2398:201  warning  line too long (359 > 200 characters)  (line-length)
  2400:201  warning  line too long (210 > 200 characters)  (line-length)

./.worktrees/pr439-baseline-repair/pnpm-lock.yaml
  16:201    warning  line too long (351 > 200 characters)  (line-length)
  2274:201  warning  line too long (207 > 200 characters)  (line-length)
  2398:201  warning  line too long (359 > 200 characters)  (line-length)
  2400:201  warning  line too long (210 > 200 characters)  (line-length)

All checks passed!
/Users/paul/Dev/easy-cheese/vendor is already current for requirements-vendor.txt
OK: validated 19 SKILL.md file(s)
Frontmatter tokens (reporting only, not gated): aggregate 2628 across 19 skill(s) (17 shipped + 2 repo-local under .agents/skills/)
  .agents/skills/python-authoring/SKILL.md: 109
  .agents/skills/skill-authoring/SKILL.md: 95
  skills/affinage/SKILL.md: 112
  skills/age/SKILL.md: 167
  skills/briesearch/SKILL.md: 199
  skills/cheese/SKILL.md: 98
  skills/cook/SKILL.md: 150
  skills/culture/SKILL.md: 136
  skills/cure/SKILL.md: 102
  skills/cut/SKILL.md: 91
  skills/easy-cheese-setup/SKILL.md: 160
  skills/hard-cheese/SKILL.md: 159
  skills/melt/SKILL.md: 212
  skills/mold/SKILL.md: 181
  skills/pasteurize/SKILL.md: 196
  skills/plate/SKILL.md: 118
  skills/press/SKILL.md: 85
  skills/ultracook/SKILL.md: 80
  skills/wheypoint/SKILL.md: 178

Body-size goal (reporting only, not gated; 1800 tokens approximates the measured median body size of Anthropic's own shipped skills, not a published Anthropic recommendation): 3/19 skill(s) at or under goal today; aggregate excess 20970 tokens -- a direction-of-travel number expected to shrink over time, not a failure count
  .agents/skills/skill-authoring/SKILL.md: +67 over goal
  skills/affinage/SKILL.md: +1693 over goal
  skills/age/SKILL.md: +1698 over goal
  skills/briesearch/SKILL.md: +264 over goal
  skills/cheese/SKILL.md: +1473 over goal
  skills/cook/SKILL.md: +1716 over goal
  skills/culture/SKILL.md: +721 over goal
  skills/cure/SKILL.md: +1749 over goal
  skills/cut/SKILL.md: +669 over goal
  skills/hard-cheese/SKILL.md: +1335 over goal
  skills/melt/SKILL.md: +378 over goal
  skills/mold/SKILL.md: +1423 over goal
  skills/pasteurize/SKILL.md: +2434 over goal
  skills/plate/SKILL.md: +1278 over goal
  skills/press/SKILL.md: +1439 over goal
  skills/wheypoint/SKILL.md: +2633 over goal
OK: validated 88 wiki page(s)
........................................................................ [  6%]
........................................................................ [ 12%]
........................................................................ [ 18%]
........................................................................ [ 24%]
................................................s....................... [ 31%]
........................................................................ [ 37%]
........................................................................ [ 43%]
........................................................................ [ 49%]
........................................................................ [ 55%]
........................................................................ [ 62%]
........................................................................ [ 68%]
.....................FFFFFFFF........................................... [ 74%]
........................................................................ [ 80%]
........................................................................ [ 86%]
........................................................................ [ 93%]
........................................................................ [ 99%]
.........                                                                [100%]
=================================== FAILURES ===================================
_____ test_probe_replays_native_context_in_both_safe_modes[code-safe-off] ______

tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont0')
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x10a385630>
safe_mode = False, profile = 'code'

    @pytest.mark.parametrize("safe_mode", [False, True], ids=["safe-off", "safe-on"])
    @pytest.mark.parametrize("profile", ["code", "script", "pytest", "unittest"])
    def test_probe_replays_native_context_in_both_safe_modes(
        tmp_path: Path,
        monkeypatch: pytest.MonkeyPatch,
        safe_mode: bool,
        profile: str,
    ) -> None:
        shadow = tmp_path / "shadow"
        shadow.mkdir()
        if profile in {"code", "script"}:
            for module_name in ("dataclasses", "pathlib"):
                (shadow / f"{module_name}.py").write_text(
                    "TARGET_LOCAL = True\n",
                    encoding="utf-8",
                )
        if profile != "pytest":
            (shadow / "json.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        if profile in {"code", "script"}:
            (shadow / "unittest.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        (shadow / "cut_assertion_probe.py").write_text(
            "TARGET_LOCAL = True\n",
            encoding="utf-8",
        )
        environment = os.environ.copy()
        inherited_pythonpath = os.environ.get("PYTHONPATH")
        pythonpath = [
            str(REPO_ROOT / "src"),
            str(shadow),
            str(REPO_ROOT / "shared" / "scripts"),
            str(REPO_ROOT / "vendor"),
        ]
        if inherited_pythonpath:
            pythonpath.append(inherited_pythonpath)
        environment["PYTHONPATH"] = os.pathsep.join(pythonpath)
        if safe_mode:
            environment["PYTHONSAFEPATH"] = "1"
        else:
            environment.pop("PYTHONSAFEPATH", None)
        command = _matrix_command(profile, tmp_path, _native_context_source())
    
        native = subprocess.run(
            command,
            cwd=tmp_path,
            capture_output=True,
            text=True,
            env=environment,
        )
        assert native.returncode == 1, native.stdout + native.stderr
        native_observation = _observed_matrix_value(native.stdout + native.stderr)
    
        monkeypatch.setenv("PYTHONPATH", environment["PYTHONPATH"])
        if "PYTHONSAFEPATH" in environment:
            monkeypatch.setenv("PYTHONSAFEPATH", environment["PYTHONSAFEPATH"])
        else:
            monkeypatch.delenv("PYTHONSAFEPATH", raising=False)
        replay = red_gate._run_case(command, tmp_path)
        assert (
            replay.returncode,
            replay.error,
            replay.assertion_origin,
        ) == (1, None, True), replay.output
        replay_observation = _observed_matrix_value(replay.output)
>       assert replay_observation == native_observation
E       assert (False, '', [...ns/3.14', ...) == (False, '', [...ns/3.14', ...)
E         
E         At index 3 diff: ['/opt/homebrew/opt/python@3.14/bin/python3.14', '-c', "import __main__, cut_assertion_probe, dataclasses, json, pathlib, sys, unittest; main = vars(__main__); loader = getattr(__main__, '__loader__', None); main_console = getattr(__main__, '_console_main', None); config_module = sys.modules.get('_pytest.config'); config_console = getattr(config_module, '_console_main', None); builtins_value = main.get('__builtins__'); print('OBS ' + repr((sys.flags.safe_path, sys.path[0], sys.argv, sys.orig_argv, sys.executable, sys.prefix, sys.exec_prefix, sys.base_pr...
E         
E         ...Full output truncated (2 lines hidden), use '-vv' to show

tests/python/test_red_gate_validator.py:994: AssertionError
______ test_probe_replays_native_context_in_both_safe_modes[code-safe-on] ______

tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont1')
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x10ad369e0>
safe_mode = True, profile = 'code'

    @pytest.mark.parametrize("safe_mode", [False, True], ids=["safe-off", "safe-on"])
    @pytest.mark.parametrize("profile", ["code", "script", "pytest", "unittest"])
    def test_probe_replays_native_context_in_both_safe_modes(
        tmp_path: Path,
        monkeypatch: pytest.MonkeyPatch,
        safe_mode: bool,
        profile: str,
    ) -> None:
        shadow = tmp_path / "shadow"
        shadow.mkdir()
        if profile in {"code", "script"}:
            for module_name in ("dataclasses", "pathlib"):
                (shadow / f"{module_name}.py").write_text(
                    "TARGET_LOCAL = True\n",
                    encoding="utf-8",
                )
        if profile != "pytest":
            (shadow / "json.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        if profile in {"code", "script"}:
            (shadow / "unittest.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        (shadow / "cut_assertion_probe.py").write_text(
            "TARGET_LOCAL = True\n",
            encoding="utf-8",
        )
        environment = os.environ.copy()
        inherited_pythonpath = os.environ.get("PYTHONPATH")
        pythonpath = [
            str(REPO_ROOT / "src"),
            str(shadow),
            str(REPO_ROOT / "shared" / "scripts"),
            str(REPO_ROOT / "vendor"),
        ]
        if inherited_pythonpath:
            pythonpath.append(inherited_pythonpath)
        environment["PYTHONPATH"] = os.pathsep.join(pythonpath)
        if safe_mode:
            environment["PYTHONSAFEPATH"] = "1"
        else:
            environment.pop("PYTHONSAFEPATH", None)
        command = _matrix_command(profile, tmp_path, _native_context_source())
    
        native = subprocess.run(
            command,
            cwd=tmp_path,
            capture_output=True,
            text=True,
            env=environment,
        )
        assert native.returncode == 1, native.stdout + native.stderr
        native_observation = _observed_matrix_value(native.stdout + native.stderr)
    
        monkeypatch.setenv("PYTHONPATH", environment["PYTHONPATH"])
        if "PYTHONSAFEPATH" in environment:
            monkeypatch.setenv("PYTHONSAFEPATH", environment["PYTHONSAFEPATH"])
        else:
            monkeypatch.delenv("PYTHONSAFEPATH", raising=False)
        replay = red_gate._run_case(command, tmp_path)
        assert (
            replay.returncode,
            replay.error,
            replay.assertion_origin,
        ) == (1, None, True), replay.output
        replay_observation = _observed_matrix_value(replay.output)
>       assert replay_observation == native_observation
E       assert (True, '/User...ns/3.14', ...) == (True, '/User...ns/3.14', ...)
E         
E         At index 3 diff: ['/opt/homebrew/opt/python@3.14/bin/python3.14', '-c', "import __main__, cut_assertion_probe, dataclasses, json, pathlib, sys, unittest; main = vars(__main__); loader = getattr(__main__, '__loader__', None); main_console = getattr(__main__, '_console_main', None); config_module = sys.modules.get('_pytest.config'); config_console = getattr(config_module, '_console_main', None); builtins_value = main.get('__builtins__'); print('OBS ' + repr((sys.flags.safe_path, sys.path[0], sys.argv, sys.orig_argv, sys.executable, sys.prefix, sys.exec_prefix, sys.base_pr...
E         
E         ...Full output truncated (2 lines hidden), use '-vv' to show

tests/python/test_red_gate_validator.py:994: AssertionError
____ test_probe_replays_native_context_in_both_safe_modes[script-safe-off] _____

tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont2')
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x10a387460>
safe_mode = False, profile = 'script'

    @pytest.mark.parametrize("safe_mode", [False, True], ids=["safe-off", "safe-on"])
    @pytest.mark.parametrize("profile", ["code", "script", "pytest", "unittest"])
    def test_probe_replays_native_context_in_both_safe_modes(
        tmp_path: Path,
        monkeypatch: pytest.MonkeyPatch,
        safe_mode: bool,
        profile: str,
    ) -> None:
        shadow = tmp_path / "shadow"
        shadow.mkdir()
        if profile in {"code", "script"}:
            for module_name in ("dataclasses", "pathlib"):
                (shadow / f"{module_name}.py").write_text(
                    "TARGET_LOCAL = True\n",
                    encoding="utf-8",
                )
        if profile != "pytest":
            (shadow / "json.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        if profile in {"code", "script"}:
            (shadow / "unittest.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        (shadow / "cut_assertion_probe.py").write_text(
            "TARGET_LOCAL = True\n",
            encoding="utf-8",
        )
        environment = os.environ.copy()
        inherited_pythonpath = os.environ.get("PYTHONPATH")
        pythonpath = [
            str(REPO_ROOT / "src"),
            str(shadow),
            str(REPO_ROOT / "shared" / "scripts"),
            str(REPO_ROOT / "vendor"),
        ]
        if inherited_pythonpath:
            pythonpath.append(inherited_pythonpath)
        environment["PYTHONPATH"] = os.pathsep.join(pythonpath)
        if safe_mode:
            environment["PYTHONSAFEPATH"] = "1"
        else:
            environment.pop("PYTHONSAFEPATH", None)
        command = _matrix_command(profile, tmp_path, _native_context_source())
    
        native = subprocess.run(
            command,
            cwd=tmp_path,
            capture_output=True,
            text=True,
            env=environment,
        )
        assert native.returncode == 1, native.stdout + native.stderr
        native_observation = _observed_matrix_value(native.stdout + native.stderr)
    
        monkeypatch.setenv("PYTHONPATH", environment["PYTHONPATH"])
        if "PYTHONSAFEPATH" in environment:
            monkeypatch.setenv("PYTHONSAFEPATH", environment["PYTHONSAFEPATH"])
        else:
            monkeypatch.delenv("PYTHONSAFEPATH", raising=False)
        replay = red_gate._run_case(command, tmp_path)
        assert (
            replay.returncode,
            replay.error,
            replay.assertion_origin,
        ) == (1, None, True), replay.output
        replay_observation = _observed_matrix_value(replay.output)
>       assert replay_observation == native_observation
E       AssertionError: assert (False, '/pri...ns/3.14', ...) == (False, '/pri...ns/3.14', ...)
E         
E         At index 3 diff: ['/opt/homebrew/opt/python@3.14/bin/python3.14', '/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont2/matrix_script.py'] != ['/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python', '/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont2/matrix_script.py']
E         Use -v to get more diff

tests/python/test_red_gate_validator.py:994: AssertionError
_____ test_probe_replays_native_context_in_both_safe_modes[script-safe-on] _____

tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont3')
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x10a3b2890>
safe_mode = True, profile = 'script'

    @pytest.mark.parametrize("safe_mode", [False, True], ids=["safe-off", "safe-on"])
    @pytest.mark.parametrize("profile", ["code", "script", "pytest", "unittest"])
    def test_probe_replays_native_context_in_both_safe_modes(
        tmp_path: Path,
        monkeypatch: pytest.MonkeyPatch,
        safe_mode: bool,
        profile: str,
    ) -> None:
        shadow = tmp_path / "shadow"
        shadow.mkdir()
        if profile in {"code", "script"}:
            for module_name in ("dataclasses", "pathlib"):
                (shadow / f"{module_name}.py").write_text(
                    "TARGET_LOCAL = True\n",
                    encoding="utf-8",
                )
        if profile != "pytest":
            (shadow / "json.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        if profile in {"code", "script"}:
            (shadow / "unittest.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        (shadow / "cut_assertion_probe.py").write_text(
            "TARGET_LOCAL = True\n",
            encoding="utf-8",
        )
        environment = os.environ.copy()
        inherited_pythonpath = os.environ.get("PYTHONPATH")
        pythonpath = [
            str(REPO_ROOT / "src"),
            str(shadow),
            str(REPO_ROOT / "shared" / "scripts"),
            str(REPO_ROOT / "vendor"),
        ]
        if inherited_pythonpath:
            pythonpath.append(inherited_pythonpath)
        environment["PYTHONPATH"] = os.pathsep.join(pythonpath)
        if safe_mode:
            environment["PYTHONSAFEPATH"] = "1"
        else:
            environment.pop("PYTHONSAFEPATH", None)
        command = _matrix_command(profile, tmp_path, _native_context_source())
    
        native = subprocess.run(
            command,
            cwd=tmp_path,
            capture_output=True,
            text=True,
            env=environment,
        )
        assert native.returncode == 1, native.stdout + native.stderr
        native_observation = _observed_matrix_value(native.stdout + native.stderr)
    
        monkeypatch.setenv("PYTHONPATH", environment["PYTHONPATH"])
        if "PYTHONSAFEPATH" in environment:
            monkeypatch.setenv("PYTHONSAFEPATH", environment["PYTHONSAFEPATH"])
        else:
            monkeypatch.delenv("PYTHONSAFEPATH", raising=False)
        replay = red_gate._run_case(command, tmp_path)
        assert (
            replay.returncode,
            replay.error,
            replay.assertion_origin,
        ) == (1, None, True), replay.output
        replay_observation = _observed_matrix_value(replay.output)
>       assert replay_observation == native_observation
E       AssertionError: assert (True, '/User...ns/3.14', ...) == (True, '/User...ns/3.14', ...)
E         
E         At index 3 diff: ['/opt/homebrew/opt/python@3.14/bin/python3.14', '/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont3/matrix_script.py'] != ['/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python', '/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont3/matrix_script.py']
E         Use -v to get more diff

tests/python/test_red_gate_validator.py:994: AssertionError
____ test_probe_replays_native_context_in_both_safe_modes[pytest-safe-off] _____

tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont4')
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x10a82a6d0>
safe_mode = False, profile = 'pytest'

    @pytest.mark.parametrize("safe_mode", [False, True], ids=["safe-off", "safe-on"])
    @pytest.mark.parametrize("profile", ["code", "script", "pytest", "unittest"])
    def test_probe_replays_native_context_in_both_safe_modes(
        tmp_path: Path,
        monkeypatch: pytest.MonkeyPatch,
        safe_mode: bool,
        profile: str,
    ) -> None:
        shadow = tmp_path / "shadow"
        shadow.mkdir()
        if profile in {"code", "script"}:
            for module_name in ("dataclasses", "pathlib"):
                (shadow / f"{module_name}.py").write_text(
                    "TARGET_LOCAL = True\n",
                    encoding="utf-8",
                )
        if profile != "pytest":
            (shadow / "json.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        if profile in {"code", "script"}:
            (shadow / "unittest.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        (shadow / "cut_assertion_probe.py").write_text(
            "TARGET_LOCAL = True\n",
            encoding="utf-8",
        )
        environment = os.environ.copy()
        inherited_pythonpath = os.environ.get("PYTHONPATH")
        pythonpath = [
            str(REPO_ROOT / "src"),
            str(shadow),
            str(REPO_ROOT / "shared" / "scripts"),
            str(REPO_ROOT / "vendor"),
        ]
        if inherited_pythonpath:
            pythonpath.append(inherited_pythonpath)
        environment["PYTHONPATH"] = os.pathsep.join(pythonpath)
        if safe_mode:
            environment["PYTHONSAFEPATH"] = "1"
        else:
            environment.pop("PYTHONSAFEPATH", None)
        command = _matrix_command(profile, tmp_path, _native_context_source())
    
        native = subprocess.run(
            command,
            cwd=tmp_path,
            capture_output=True,
            text=True,
            env=environment,
        )
        assert native.returncode == 1, native.stdout + native.stderr
        native_observation = _observed_matrix_value(native.stdout + native.stderr)
    
        monkeypatch.setenv("PYTHONPATH", environment["PYTHONPATH"])
        if "PYTHONSAFEPATH" in environment:
            monkeypatch.setenv("PYTHONSAFEPATH", environment["PYTHONSAFEPATH"])
        else:
            monkeypatch.delenv("PYTHONSAFEPATH", raising=False)
        replay = red_gate._run_case(command, tmp_path)
        assert (
            replay.returncode,
            replay.error,
            replay.assertion_origin,
        ) == (1, None, True), replay.output
        replay_observation = _observed_matrix_value(replay.output)
>       assert replay_observation == native_observation
E       AssertionError: assert (False, '/pri...ns/3.14', ...) == (False, '/pri...ns/3.14', ...)
E         
E         At index 3 diff: ['/opt/homebrew/opt/python@3.14/bin/python3.14', '-m', 'pytest', '/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont4/tests/test_matrix.py', '-q'] != ['/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python', '-m', 'pytest', '/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont4/tests/test_matrix.py', '-q']
E         Use -v to get more diff

tests/python/test_red_gate_validator.py:994: AssertionError
_____ test_probe_replays_native_context_in_both_safe_modes[pytest-safe-on] _____

tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont5')
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x10a23fb60>
safe_mode = True, profile = 'pytest'

    @pytest.mark.parametrize("safe_mode", [False, True], ids=["safe-off", "safe-on"])
    @pytest.mark.parametrize("profile", ["code", "script", "pytest", "unittest"])
    def test_probe_replays_native_context_in_both_safe_modes(
        tmp_path: Path,
        monkeypatch: pytest.MonkeyPatch,
        safe_mode: bool,
        profile: str,
    ) -> None:
        shadow = tmp_path / "shadow"
        shadow.mkdir()
        if profile in {"code", "script"}:
            for module_name in ("dataclasses", "pathlib"):
                (shadow / f"{module_name}.py").write_text(
                    "TARGET_LOCAL = True\n",
                    encoding="utf-8",
                )
        if profile != "pytest":
            (shadow / "json.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        if profile in {"code", "script"}:
            (shadow / "unittest.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        (shadow / "cut_assertion_probe.py").write_text(
            "TARGET_LOCAL = True\n",
            encoding="utf-8",
        )
        environment = os.environ.copy()
        inherited_pythonpath = os.environ.get("PYTHONPATH")
        pythonpath = [
            str(REPO_ROOT / "src"),
            str(shadow),
            str(REPO_ROOT / "shared" / "scripts"),
            str(REPO_ROOT / "vendor"),
        ]
        if inherited_pythonpath:
            pythonpath.append(inherited_pythonpath)
        environment["PYTHONPATH"] = os.pathsep.join(pythonpath)
        if safe_mode:
            environment["PYTHONSAFEPATH"] = "1"
        else:
            environment.pop("PYTHONSAFEPATH", None)
        command = _matrix_command(profile, tmp_path, _native_context_source())
    
        native = subprocess.run(
            command,
            cwd=tmp_path,
            capture_output=True,
            text=True,
            env=environment,
        )
        assert native.returncode == 1, native.stdout + native.stderr
        native_observation = _observed_matrix_value(native.stdout + native.stderr)
    
        monkeypatch.setenv("PYTHONPATH", environment["PYTHONPATH"])
        if "PYTHONSAFEPATH" in environment:
            monkeypatch.setenv("PYTHONSAFEPATH", environment["PYTHONSAFEPATH"])
        else:
            monkeypatch.delenv("PYTHONSAFEPATH", raising=False)
        replay = red_gate._run_case(command, tmp_path)
        assert (
            replay.returncode,
            replay.error,
            replay.assertion_origin,
        ) == (1, None, True), replay.output
        replay_observation = _observed_matrix_value(replay.output)
>       assert replay_observation == native_observation
E       AssertionError: assert (True, '/priv...ns/3.14', ...) == (True, '/priv...ns/3.14', ...)
E         
E         At index 3 diff: ['/opt/homebrew/opt/python@3.14/bin/python3.14', '-m', 'pytest', '/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont5/tests/test_matrix.py', '-q'] != ['/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python', '-m', 'pytest', '/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont5/tests/test_matrix.py', '-q']
E         Use -v to get more diff

tests/python/test_red_gate_validator.py:994: AssertionError
___ test_probe_replays_native_context_in_both_safe_modes[unittest-safe-off] ____

tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont6')
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x10ad37930>
safe_mode = False, profile = 'unittest'

    @pytest.mark.parametrize("safe_mode", [False, True], ids=["safe-off", "safe-on"])
    @pytest.mark.parametrize("profile", ["code", "script", "pytest", "unittest"])
    def test_probe_replays_native_context_in_both_safe_modes(
        tmp_path: Path,
        monkeypatch: pytest.MonkeyPatch,
        safe_mode: bool,
        profile: str,
    ) -> None:
        shadow = tmp_path / "shadow"
        shadow.mkdir()
        if profile in {"code", "script"}:
            for module_name in ("dataclasses", "pathlib"):
                (shadow / f"{module_name}.py").write_text(
                    "TARGET_LOCAL = True\n",
                    encoding="utf-8",
                )
        if profile != "pytest":
            (shadow / "json.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        if profile in {"code", "script"}:
            (shadow / "unittest.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        (shadow / "cut_assertion_probe.py").write_text(
            "TARGET_LOCAL = True\n",
            encoding="utf-8",
        )
        environment = os.environ.copy()
        inherited_pythonpath = os.environ.get("PYTHONPATH")
        pythonpath = [
            str(REPO_ROOT / "src"),
            str(shadow),
            str(REPO_ROOT / "shared" / "scripts"),
            str(REPO_ROOT / "vendor"),
        ]
        if inherited_pythonpath:
            pythonpath.append(inherited_pythonpath)
        environment["PYTHONPATH"] = os.pathsep.join(pythonpath)
        if safe_mode:
            environment["PYTHONSAFEPATH"] = "1"
        else:
            environment.pop("PYTHONSAFEPATH", None)
        command = _matrix_command(profile, tmp_path, _native_context_source())
    
        native = subprocess.run(
            command,
            cwd=tmp_path,
            capture_output=True,
            text=True,
            env=environment,
        )
        assert native.returncode == 1, native.stdout + native.stderr
        native_observation = _observed_matrix_value(native.stdout + native.stderr)
    
        monkeypatch.setenv("PYTHONPATH", environment["PYTHONPATH"])
        if "PYTHONSAFEPATH" in environment:
            monkeypatch.setenv("PYTHONSAFEPATH", environment["PYTHONSAFEPATH"])
        else:
            monkeypatch.delenv("PYTHONSAFEPATH", raising=False)
        replay = red_gate._run_case(command, tmp_path)
        assert (
            replay.returncode,
            replay.error,
            replay.assertion_origin,
        ) == (1, None, True), replay.output
        replay_observation = _observed_matrix_value(replay.output)
>       assert replay_observation == native_observation
E       AssertionError: assert (False, '/pri...ns/3.14', ...) == (False, '/pri...ns/3.14', ...)
E         
E         At index 3 diff: ['/opt/homebrew/opt/python@3.14/bin/python3.14', '-m', 'unittest', 'discover', '-s', '/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont6/tests', '-p', 'test_matrix_unittest.py'] != ['/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python', '-m', 'unittest', 'discover', '-s', '/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont6/tests', '-p', 'test_matrix_unittest.py']
E         Use -v to get more diff

tests/python/test_red_gate_validator.py:994: AssertionError
____ test_probe_replays_native_context_in_both_safe_modes[unittest-safe-on] ____

tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont7')
monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x10a3869e0>
safe_mode = True, profile = 'unittest'

    @pytest.mark.parametrize("safe_mode", [False, True], ids=["safe-off", "safe-on"])
    @pytest.mark.parametrize("profile", ["code", "script", "pytest", "unittest"])
    def test_probe_replays_native_context_in_both_safe_modes(
        tmp_path: Path,
        monkeypatch: pytest.MonkeyPatch,
        safe_mode: bool,
        profile: str,
    ) -> None:
        shadow = tmp_path / "shadow"
        shadow.mkdir()
        if profile in {"code", "script"}:
            for module_name in ("dataclasses", "pathlib"):
                (shadow / f"{module_name}.py").write_text(
                    "TARGET_LOCAL = True\n",
                    encoding="utf-8",
                )
        if profile != "pytest":
            (shadow / "json.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        if profile in {"code", "script"}:
            (shadow / "unittest.py").write_text(
                "TARGET_LOCAL = True\n",
                encoding="utf-8",
            )
        (shadow / "cut_assertion_probe.py").write_text(
            "TARGET_LOCAL = True\n",
            encoding="utf-8",
        )
        environment = os.environ.copy()
        inherited_pythonpath = os.environ.get("PYTHONPATH")
        pythonpath = [
            str(REPO_ROOT / "src"),
            str(shadow),
            str(REPO_ROOT / "shared" / "scripts"),
            str(REPO_ROOT / "vendor"),
        ]
        if inherited_pythonpath:
            pythonpath.append(inherited_pythonpath)
        environment["PYTHONPATH"] = os.pathsep.join(pythonpath)
        if safe_mode:
            environment["PYTHONSAFEPATH"] = "1"
        else:
            environment.pop("PYTHONSAFEPATH", None)
        command = _matrix_command(profile, tmp_path, _native_context_source())
    
        native = subprocess.run(
            command,
            cwd=tmp_path,
            capture_output=True,
            text=True,
            env=environment,
        )
        assert native.returncode == 1, native.stdout + native.stderr
        native_observation = _observed_matrix_value(native.stdout + native.stderr)
    
        monkeypatch.setenv("PYTHONPATH", environment["PYTHONPATH"])
        if "PYTHONSAFEPATH" in environment:
            monkeypatch.setenv("PYTHONSAFEPATH", environment["PYTHONSAFEPATH"])
        else:
            monkeypatch.delenv("PYTHONSAFEPATH", raising=False)
        replay = red_gate._run_case(command, tmp_path)
        assert (
            replay.returncode,
            replay.error,
            replay.assertion_origin,
        ) == (1, None, True), replay.output
        replay_observation = _observed_matrix_value(replay.output)
>       assert replay_observation == native_observation
E       AssertionError: assert (True, '/priv...ns/3.14', ...) == (True, '/priv...ns/3.14', ...)
E         
E         At index 3 diff: ['/opt/homebrew/opt/python@3.14/bin/python3.14', '-m', 'unittest', 'discover', '-s', '/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont7/tests', '-p', 'test_matrix_unittest.py'] != ['/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python', '-m', 'unittest', 'discover', '-s', '/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-449/test_probe_replays_native_cont7/tests', '-p', 'test_matrix_unittest.py']
E         Use -v to get more diff

tests/python/test_red_gate_validator.py:994: AssertionError
=========================== short test summary info ============================
FAILED tests/python/test_red_gate_validator.py::test_probe_replays_native_context_in_both_safe_modes[code-safe-off]
FAILED tests/python/test_red_gate_validator.py::test_probe_replays_native_context_in_both_safe_modes[code-safe-on]
FAILED tests/python/test_red_gate_validator.py::test_probe_replays_native_context_in_both_safe_modes[script-safe-off]
FAILED tests/python/test_red_gate_validator.py::test_probe_replays_native_context_in_both_safe_modes[script-safe-on]
FAILED tests/python/test_red_gate_validator.py::test_probe_replays_native_context_in_both_safe_modes[pytest-safe-off]
FAILED tests/python/test_red_gate_validator.py::test_probe_replays_native_context_in_both_safe_modes[pytest-safe-on]
FAILED tests/python/test_red_gate_validator.py::test_probe_replays_native_context_in_both_safe_modes[unittest-safe-off]
FAILED tests/python/test_red_gate_validator.py::test_probe_replays_native_context_in_both_safe_modes[unittest-safe-on]
8 failed, 1152 passed, 1 skipped in 34.12s and pre-commit.\n\n## Why\n\nThis is the enforcement layer extracted from #439. It turns the preceding bundle contracts and discoverable surface into executable build and commit-time guarantees.\n\n## How to verify\n\nmarkdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Finding: skills/**/*.md .agents/**/*.md *.md
Linting: 104 files
Summary: 0 issues in 0 files
./pnpm-lock.yaml
  16:201    warning  line too long (351 > 200 characters)  (line-length)
  2274:201  warning  line too long (207 > 200 characters)  (line-length)
  2398:201  warning  line too long (359 > 200 characters)  (line-length)
  2400:201  warning  line too long (210 > 200 characters)  (line-length)

./.worktrees/pr439-enforcement/pnpm-lock.yaml
  16:201    warning  line too long (351 > 200 characters)  (line-length)
  2274:201  warning  line too long (207 > 200 characters)  (line-length)
  2398:201  warning  line too long (359 > 200 characters)  (line-length)
  2400:201  warning  line too long (210 > 200 characters)  (line-length)

./.worktrees/cheeselord-design-adoption/pnpm-lock.yaml
  2661:201  warning  line too long (207 > 200 characters)  (line-length)

./.worktrees/pr439-spec/pnpm-lock.yaml
  16:201    warning  line too long (351 > 200 characters)  (line-length)
  2274:201  warning  line too long (207 > 200 characters)  (line-length)
  2398:201  warning  line too long (359 > 200 characters)  (line-length)
  2400:201  warning  line too long (210 > 200 characters)  (line-length)

./.worktrees/pr439-surface/pnpm-lock.yaml
  16:201    warning  line too long (351 > 200 characters)  (line-length)
  2274:201  warning  line too long (207 > 200 characters)  (line-length)
  2398:201  warning  line too long (359 > 200 characters)  (line-length)
  2400:201  warning  line too long (210 > 200 characters)  (line-length)

./.worktrees/pr439-baseline-repair/pnpm-lock.yaml
  16:201    warning  line too long (351 > 200 characters)  (line-length)
  2274:201  warning  line too long (207 > 200 characters)  (line-length)
  2398:201  warning  line too long (359 > 200 characters)  (line-length)
  2400:201  warning  line too long (210 > 200 characters)  (line-length)

All checks passed!
/Users/paul/Dev/easy-cheese/vendor is already current for requirements-vendor.txt
OK: validated 19 SKILL.md file(s)
Frontmatter tokens (reporting only, not gated): aggregate 2628 across 19 skill(s) (17 shipped + 2 repo-local under .agents/skills/)
  .agents/skills/python-authoring/SKILL.md: 109
  .agents/skills/skill-authoring/SKILL.md: 95
  skills/affinage/SKILL.md: 112
  skills/age/SKILL.md: 167
  skills/briesearch/SKILL.md: 199
  skills/cheese/SKILL.md: 98
  skills/cook/SKILL.md: 150
  skills/culture/SKILL.md: 136
  skills/cure/SKILL.md: 102
  skills/cut/SKILL.md: 91
  skills/easy-cheese-setup/SKILL.md: 160
  skills/hard-cheese/SKILL.md: 159
  skills/melt/SKILL.md: 212
  skills/mold/SKILL.md: 181
  skills/pasteurize/SKILL.md: 196
  skills/plate/SKILL.md: 118
  skills/press/SKILL.md: 85
  skills/ultracook/SKILL.md: 80
  skills/wheypoint/SKILL.md: 178

Body-size goal (reporting only, not gated; 1800 tokens approximates the measured median body size of Anthropic's own shipped skills, not a published Anthropic recommendation): 3/19 skill(s) at or under goal today; aggregate excess 20970 tokens -- a direction-of-travel number expected to shrink over time, not a failure count
  .agents/skills/skill-authoring/SKILL.md: +67 over goal
  skills/affinage/SKILL.md: +1693 over goal
  skills/age/SKILL.md: +1698 over goal
  skills/briesearch/SKILL.md: +264 over goal
  skills/cheese/SKILL.md: +1473 over goal
  skills/cook/SKILL.md: +1716 over goal
  skills/culture/SKILL.md: +721 over goal
  skills/cure/SKILL.md: +1749 over goal
  skills/cut/SKILL.md: +669 over goal
  skills/hard-cheese/SKILL.md: +1335 over goal
  skills/melt/SKILL.md: +378 over goal
  skills/mold/SKILL.md: +1423 over goal
  skills/pasteurize/SKILL.md: +2434 over goal
  skills/plate/SKILL.md: +1278 over goal
  skills/press/SKILL.md: +1439 over goal
  skills/wheypoint/SKILL.md: +2633 over goal
OK: validated 88 wiki page(s)
........................................................................ [  6%]
........................................................................ [ 12%]
........................................................................ [ 18%]
........................................................................ [ 24%]
................................................s....................... [ 31%]
........................................................................ [ 37%]
........................................................................ [ 43%]
........................................................................ [ 49%]
........................................................................ [ 55%]
........................................................................ [ 62%]
........................................................................ [ 68%]
........................................................................ [ 74%]
........................................................................ [ 80%]
........................................................................ [ 86%]
........................................................................ [ 93%]
........................................................................ [ 99%]
.........                                                                [100%]
1160 passed, 1 skipped in 28.43s
........................................................................ [ 19%]
........................................................................ [ 38%]
........................................................................ [ 57%]
........................................................................ [ 77%]
........................................................................ [ 96%]
.............                                                            [100%]
373 passed in 3.83s
........................................................................ [ 11%]
........................................................................ [ 23%]
........................................................................ [ 35%]
....FFFFFF.FFFFFF.FFFFFFFF.............................................. [ 46%]
........................................................................ [ 58%]
........................................................................ [ 70%]
........................................................................ [ 82%]
........................................................................ [ 93%]
FFFFFFFF..............................                                   [100%]
=================================== FAILURES ===================================
___________ TestSetPhase.test_happy_path_updates_phase_and_validates ___________

self = <test_manifest_update.TestSetPhase object at 0x109b54c50>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_happy_path_updates_phase_0')

    def test_happy_path_updates_phase_and_validates(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        result = _run_cli("set-phase", "--manifest", str(path), "--phase", "seed_complete")
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/manifest_update.py", line 45, in <module>
E             from validate_manifest import validate_run_manifest  # noqa: E402
E             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/validate_manifest.py", line 17, in <module>
E             import wiring  # noqa: E402
E             ^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring.py", line 12, in <module>
E             from easy_cheese_schemas.wiring_graph import cycle_errors
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:106: AssertionError
___________________ TestSetPhase.test_invalid_phase_exits_2 ____________________

self = <test_manifest_update.TestSetPhase object at 0x109b54fb0>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_invalid_phase_exits_20')

    def test_invalid_phase_exits_2(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        original = path.read_bytes()
        result = _run_cli("set-phase", "--manifest", str(path), "--phase", "bogus_phase")
>       assert result.returncode == 2
E       assert 1 == 2
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:117: AssertionError
__________________ TestSetPhase.test_missing_manifest_exits_2 __________________

self = <test_manifest_update.TestSetPhase object at 0x109b55310>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_missing_manifest_exits_20')

    def test_missing_manifest_exits_2(self, tmp_path: Path) -> None:
        path = tmp_path / "does-not-exist.yaml"
        result = _run_cli("set-phase", "--manifest", str(path), "--phase", "seed_complete")
>       assert result.returncode == 2
E       assert 1 == 2
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:125: AssertionError
______________ TestSetPhase.test_preserves_top_level_field_order _______________

self = <test_manifest_update.TestSetPhase object at 0x109b55670>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_preserves_top_level_field0')

    def test_preserves_top_level_field_order(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        expected_keys = list(_manifest().keys())
        result = _run_cli("set-phase", "--manifest", str(path), "--phase", "seed_complete")
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/manifest_update.py", line 45, in <module>
E             from validate_manifest import validate_run_manifest  # noqa: E402
E             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/validate_manifest.py", line 17, in <module>
E             import wiring  # noqa: E402
E             ^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring.py", line 12, in <module>
E             from easy_cheese_schemas.wiring_graph import cycle_errors
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:132: AssertionError
_____________ TestSetCurdStatus.test_updates_status_and_commit_sha _____________

self = <test_manifest_update.TestSetCurdStatus object at 0x109b55a00>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_updates_status_and_commit0')

    def test_updates_status_and_commit_sha(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        result = _run_cli(
            "set-curd-status",
            "--manifest",
            str(path),
            "--curd",
            "3",
            "--status",
            "completed",
            "--commit-sha",
            "deadbeef",
            "--base-commit",
            "A" * 40,
            "--reviewed-tree-oid",
            "b" * 64,
            "--diff-hash",
            "sha256:" + "C" * 64,
            "--scope",
            "src/feature_2.ts",
        )
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/manifest_update.py", line 45, in <module>
E             from validate_manifest import validate_run_manifest  # noqa: E402
E             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/validate_manifest.py", line 17, in <module>
E             import wiring  # noqa: E402
E             ^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring.py", line 12, in <module>
E             from easy_cheese_schemas.wiring_graph import cycle_errors
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:159: AssertionError
_____ TestSetCurdStatus.test_completed_without_review_context_is_rejected ______

self = <test_manifest_update.TestSetCurdStatus object at 0x1096e1d30>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_completed_without_review_0')

    def test_completed_without_review_context_is_rejected(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        original = path.read_bytes()
        result = _run_cli(
            "set-curd-status",
            "--manifest",
            str(path),
            "--curd",
            "3",
            "--status",
            "completed",
            "--commit-sha",
            "deadbeef",
        )
>       assert result.returncode == 2
E       assert 1 == 2
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:186: AssertionError
________________ TestSetCurdStatus.test_invalid_status_exits_2 _________________

self = <test_manifest_update.TestSetCurdStatus object at 0x1095ca5a0>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_invalid_status_exits_20')

    def test_invalid_status_exits_2(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        result = _run_cli(
            "set-curd-status", "--manifest", str(path), "--curd", "1", "--status", "ok"
        )
>       assert result.returncode == 2
E       assert 1 == 2
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:202: AssertionError
________________ TestSetCurdStatus.test_missing_curd_id_exits_2 ________________

self = <test_manifest_update.TestSetCurdStatus object at 0x1096bcc50>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_missing_curd_id_exits_20')

    def test_missing_curd_id_exits_2(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        result = _run_cli(
            "set-curd-status", "--manifest", str(path), "--curd", "999", "--status", "running"
        )
>       assert result.returncode == 2
E       assert 1 == 2
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:210: AssertionError
_ TestSetPostReview.test_atomically_records_review_identity_and_allows_phase_advance _

self = <test_manifest_update.TestSetPostReview object at 0x1096be630>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_atomically_records_review0')

    def test_atomically_records_review_identity_and_allows_phase_advance(
        self, tmp_path: Path
    ) -> None:
        path = _write_fixture(tmp_path)
        result = _run_cli(
            "set-post-review",
            "--manifest",
            str(path),
            "--base-commit",
            "A" * 40,
            "--reviewed-tree-oid",
            "b" * 64,
            "--diff-hash",
            "sha256:" + "C" * 64,
            "--scope",
            "src",
            "--press-slug",
            ".cheese/press/feature.md",
            "--age-slug",
            ".cheese/age/feature.md",
            "--cure-slug",
            ".cheese/cure/feature.md",
            "--findings-applied",
            "2",
            "--findings-deferred",
            "0",
        )
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/manifest_update.py", line 45, in <module>
E             from validate_manifest import validate_run_manifest  # noqa: E402
E             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/validate_manifest.py", line 17, in <module>
E             import wiring  # noqa: E402
E             ^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring.py", line 12, in <module>
E             from easy_cheese_schemas.wiring_graph import cycle_errors
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:242: AssertionError
____________ TestSetWiringStatus.test_updates_status_and_commit_sha ____________

self = <test_manifest_update.TestSetWiringStatus object at 0x1096be270>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_updates_status_and_commit1')

    def test_updates_status_and_commit_sha(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        result = _run_cli(
            "set-wiring-status",
            "--manifest",
            str(path),
            "--wiring",
            "W1",
            "--status",
            "completed",
            "--commit-sha",
            "abc1234",
        )
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/manifest_update.py", line 45, in <module>
E             from validate_manifest import validate_run_manifest  # noqa: E402
E             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/validate_manifest.py", line 17, in <module>
E             import wiring  # noqa: E402
E             ^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring.py", line 12, in <module>
E             from easy_cheese_schemas.wiring_graph import cycle_errors
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:285: AssertionError
______________ TestSetWiringStatus.test_missing_wiring_id_exits_2 ______________

self = <test_manifest_update.TestSetWiringStatus object at 0x1096bdfa0>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_missing_wiring_id_exits_20')

    def test_missing_wiring_id_exits_2(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        result = _run_cli(
            "set-wiring-status", "--manifest", str(path), "--wiring", "W99", "--status", "running"
        )
>       assert result.returncode == 2
E       assert 1 == 2
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:297: AssertionError
______________ TestAtomicity.test_no_tmp_file_left_after_success _______________

self = <test_manifest_update.TestAtomicity object at 0x1096bfa70>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_no_tmp_file_left_after_su0')

    def test_no_tmp_file_left_after_success(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        result = _run_cli("set-phase", "--manifest", str(path), "--phase", "seed_complete")
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/manifest_update.py", line 45, in <module>
E             from validate_manifest import validate_run_manifest  # noqa: E402
E             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/validate_manifest.py", line 17, in <module>
E             import wiring  # noqa: E402
E             ^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring.py", line 12, in <module>
E             from easy_cheese_schemas.wiring_graph import cycle_errors
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:305: AssertionError
________________ TestCheckFiles.test_all_present_reports_clean _________________

self = <test_manifest_update.TestCheckFiles object at 0x1096be1e0>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_all_present_reports_clean0')

    def test_all_present_reports_clean(self, tmp_path: Path) -> None:
        manifest = _manifest()
        for curd in manifest["curds"]:
            for f in curd["files"]:
                target = tmp_path / f
                target.parent.mkdir(parents=True, exist_ok=True)
                target.write_text("", encoding="utf-8")
        path = tmp_path / "manifest.yaml"
        path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
        result = _run_cli("check-files", "--manifest", str(path), "--root", str(tmp_path))
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/manifest_update.py", line 45, in <module>
E             from validate_manifest import validate_run_manifest  # noqa: E402
E             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/validate_manifest.py", line 17, in <module>
E             import wiring  # noqa: E402
E             ^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring.py", line 12, in <module>
E             from easy_cheese_schemas.wiring_graph import cycle_errors
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:336: AssertionError
_____ TestCheckFiles.test_missing_files_reported_per_curd_without_failing ______

self = <test_manifest_update.TestCheckFiles object at 0x1096bdb80>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_missing_files_reported_pe0')

    def test_missing_files_reported_per_curd_without_failing(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        # Fixture files are never created on disk, so every curd is "missing".
        result = _run_cli("check-files", "--manifest", str(path), "--root", str(tmp_path))
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/manifest_update.py", line 45, in <module>
E             from validate_manifest import validate_run_manifest  # noqa: E402
E             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/validate_manifest.py", line 17, in <module>
E             import wiring  # noqa: E402
E             ^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring.py", line 12, in <module>
E             from easy_cheese_schemas.wiring_graph import cycle_errors
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:343: AssertionError
__________ TestCheckFiles.test_json_mode_reports_missing_per_curd_id ___________

self = <test_manifest_update.TestCheckFiles object at 0x1096bd040>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_json_mode_reports_missing0')

    def test_json_mode_reports_missing_per_curd_id(self, tmp_path: Path) -> None:
        manifest = _manifest()
        (tmp_path / "src").mkdir()
        (tmp_path / "src" / "feature_0.ts").write_text("", encoding="utf-8")
        path = tmp_path / "manifest.yaml"
        path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
        result = _run_cli("check-files", "--manifest", str(path), "--root", str(tmp_path), "--json")
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/manifest_update.py", line 45, in <module>
E             from validate_manifest import validate_run_manifest  # noqa: E402
E             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/validate_manifest.py", line 17, in <module>
E             import wiring  # noqa: E402
E             ^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring.py", line 12, in <module>
E             from easy_cheese_schemas.wiring_graph import cycle_errors
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:354: AssertionError
_________________ TestCheckFiles.test_missing_manifest_exits_2 _________________

self = <test_manifest_update.TestCheckFiles object at 0x1096bc530>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_missing_manifest_exits_21')

    def test_missing_manifest_exits_2(self, tmp_path: Path) -> None:
        path = tmp_path / "does-not-exist.yaml"
        result = _run_cli("check-files", "--manifest", str(path))
>       assert result.returncode == 2
E       assert 1 == 2
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:362: AssertionError
___________________ TestCheckFiles.test_invalid_root_exits_2 ___________________

self = <test_manifest_update.TestCheckFiles object at 0x1096e1730>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_invalid_root_exits_20')

    def test_invalid_root_exits_2(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        missing_root = tmp_path / "no-such-dir"
        result = _run_cli("check-files", "--manifest", str(path), "--root", str(missing_root))
>       assert result.returncode == 2
E       assert 1 == 2
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:369: AssertionError
______ TestCheckFiles.test_directory_where_file_expected_reported_missing ______

self = <test_manifest_update.TestCheckFiles object at 0x1096bce30>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_directory_where_file_expe0')

    def test_directory_where_file_expected_reported_missing(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        # Create a directory at a path where a curd expects a file: is_file()
        # must report it missing, unlike the looser exists() check.
        target = tmp_path / "src" / "feature_0.ts"
        target.mkdir(parents=True)
        result = _run_cli("check-files", "--manifest", str(path), "--root", str(tmp_path), "--json")
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/manifest_update.py", line 45, in <module>
E             from validate_manifest import validate_run_manifest  # noqa: E402
E             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/validate_manifest.py", line 17, in <module>
E             import wiring  # noqa: E402
E             ^^^^^^^^^^^^^
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring.py", line 12, in <module>
E             from easy_cheese_schemas.wiring_graph import cycle_errors
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/manifest_updat...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_manifest_update.py:379: AssertionError
________ TestConcurrentWrites.test_parallel_updates_never_corrupt_file _________

self = <test_manifest_update.TestConcurrentWrites object at 0x1096bd310>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_parallel_updates_never_co0')

    def test_parallel_updates_never_corrupt_file(self, tmp_path: Path) -> None:
        path = _write_fixture(tmp_path)
        n_curds = len(_curds())
        jobs = [(str(path), i + 1) for i in range(n_curds)]
        # Repeat the volley to widen the race window.
        for _ in range(3):
            with multiprocessing.Pool(processes=min(4, n_curds)) as pool:
                results = pool.map(_worker, jobs)
            # The advisory lock serialises all writes — no update should be lost
            # and no writer should fail due to a race condition.
            data = yaml.safe_load(path.read_text(encoding="utf-8"))
            assert isinstance(data, dict)
            assert len(data["curds"]) == n_curds
            for rc, err in results:
>               assert rc == 0, f"unexpected rc={rc} stderr={err!r}"
E               AssertionError: unexpected rc=1 stderr='Traceback (most recent call last):\n  File "/Users/paul/Dev/easy-cheese/src/fanout/manifest_update.py", line 45, in <module>\n    from validate_manifest import validate_run_manifest  # noqa: E402\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/Users/paul/Dev/easy-cheese/src/fanout/validate_manifest.py", line 17, in <module>\n    import wiring  # noqa: E402\n    ^^^^^^^^^^^^^\n  File "/Users/paul/Dev/easy-cheese/src/fanout/wiring.py", line 12, in <module>\n    from easy_cheese_schemas.wiring_graph import cycle_errors\n  File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>\n    from easy_cheese_schemas.compat import (\n  File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n'
E               assert 1 == 0

tests/fanout/python/test_manifest_update.py:426: AssertionError
____________ TestConcurrentWrites.test_all_distinct_updates_survive ____________

self = <test_manifest_update.TestConcurrentWrites object at 0x1096bef30>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_all_distinct_updates_surv0')

    def test_all_distinct_updates_survive(self, tmp_path: Path) -> None:
        """With N>=8 concurrent writers each targeting a DISTINCT curd id, every
        update must appear in the final manifest (no lost writes). This is the
        behavioral proof that the advisory lock wraps the full read-modify-write."""
        n = 10
        path = tmp_path / "manifest_big.yaml"
        manifest = _manifest()
        manifest["curds"] = [
            {
                "id": i + 1,
                "behavior": f"Feature {i + 1}",
                "acceptance_criterion": f"AC {i + 1}",
                "files": [f"src/f{i}.ts"],
                "test_target": f"pytest src/f{i}.ts",
                "status": "pending",
                "retry_count": 0,
            }
            for i in range(n)
        ]
        path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
    
        # All jobs target distinct curd ids with the same manifest file — genuine
        # concurrent contention with no serialisation at the test level.
        jobs = [(str(path), i + 1) for i in range(n)]
        with multiprocessing.Pool(processes=n) as pool:
            results = pool.map(_worker, jobs)
    
        # Every writer must have succeeded.
        for rc, err in results:
>           assert rc == 0, f"rc={rc} stderr={err!r}"
E           AssertionError: rc=1 stderr='Traceback (most recent call last):\n  File "/Users/paul/Dev/easy-cheese/src/fanout/manifest_update.py", line 45, in <module>\n    from validate_manifest import validate_run_manifest  # noqa: E402\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File "/Users/paul/Dev/easy-cheese/src/fanout/validate_manifest.py", line 17, in <module>\n    import wiring  # noqa: E402\n    ^^^^^^^^^^^^^\n  File "/Users/paul/Dev/easy-cheese/src/fanout/wiring.py", line 12, in <module>\n    from easy_cheese_schemas.wiring_graph import cycle_errors\n  File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>\n    from easy_cheese_schemas.compat import (\n  File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n'
E           assert 1 == 0

tests/fanout/python/test_manifest_update.py:459: AssertionError
_____________________ TestCLI.test_linear_chain_plain_text _____________________

self = <test_wiring_topo_sort.TestCLI object at 0x109fa0920>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_linear_chain_plain_text0')

    def test_linear_chain_plain_text(self, tmp_path: Path) -> None:
        manifest = tmp_path / "manifest.yaml"
        _write_manifest(
            manifest, _wiring(("W1", []), ("W2", ["W1"]), ("W3", ["W2"]))
        )
        result = _run_cli("--manifest", str(manifest))
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring_topo_sort.py", line 18, in <module>
E             from easy_cheese_schemas.wiring_graph import WiringCycleError, compute_waves
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/wiring_topo_so...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_wiring_topo_sort.py:94: AssertionError
____________________ TestCLI.test_branching_dag_plain_text _____________________

self = <test_wiring_topo_sort.TestCLI object at 0x109fa0c20>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_branching_dag_plain_text0')

    def test_branching_dag_plain_text(self, tmp_path: Path) -> None:
        manifest = tmp_path / "manifest.yaml"
        _write_manifest(
            manifest, _wiring(("W1", []), ("W2", ["W1"]), ("W3", ["W1"]))
        )
        result = _run_cli("--manifest", str(manifest))
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring_topo_sort.py", line 18, in <module>
E             from easy_cheese_schemas.wiring_graph import WiringCycleError, compute_waves
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/wiring_topo_so...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_wiring_topo_sort.py:103: AssertionError
________________________ TestCLI.test_json_output_shape ________________________

self = <test_wiring_topo_sort.TestCLI object at 0x109efbf20>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_json_output_shape0')

    def test_json_output_shape(self, tmp_path: Path) -> None:
        manifest = tmp_path / "manifest.yaml"
        _write_manifest(
            manifest, _wiring(("W1", []), ("W2", ["W1"]), ("W3", ["W1"]))
        )
        result = _run_cli("--manifest", str(manifest), "--json")
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring_topo_sort.py", line 18, in <module>
E             from easy_cheese_schemas.wiring_graph import WiringCycleError, compute_waves
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/wiring_topo_so...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_wiring_topo_sort.py:112: AssertionError
___________________ TestCLI.test_empty_wiring_emits_nothing ____________________

self = <test_wiring_topo_sort.TestCLI object at 0x109efbce0>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_empty_wiring_emits_nothin0')

    def test_empty_wiring_emits_nothing(self, tmp_path: Path) -> None:
        manifest = tmp_path / "manifest.yaml"
        manifest.write_text(yaml.safe_dump({"wiring": []}), encoding="utf-8")
        result = _run_cli("--manifest", str(manifest))
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring_topo_sort.py", line 18, in <module>
E             from easy_cheese_schemas.wiring_graph import WiringCycleError, compute_waves
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/wiring_topo_so...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_wiring_topo_sort.py:119: AssertionError
___________________ TestCLI.test_missing_manifest_exits_two ____________________

self = <test_wiring_topo_sort.TestCLI object at 0x109ef9e80>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_missing_manifest_exits_tw0')

    def test_missing_manifest_exits_two(self, tmp_path: Path) -> None:
        # A nonexistent path is a usage-shaped error per cli.run, so exit 2
        # (not 1) — the dispatcher distinguishes "bad invocation" from "valid
        # invocation, content failed".
        missing = tmp_path / "does-not-exist.yaml"
        result = _run_cli("--manifest", str(missing))
>       assert result.returncode == 2
E       assert 1 == 2
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/wiring_topo_so...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_wiring_topo_sort.py:128: AssertionError
________________ TestCLI.test_cycle_exits_two_with_legacy_error ________________

self = <test_wiring_topo_sort.TestCLI object at 0x109ef9460>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_cycle_exits_two_with_lega0')

    def test_cycle_exits_two_with_legacy_error(self, tmp_path: Path) -> None:
        manifest = tmp_path / "manifest.yaml"
        _write_manifest(manifest, _wiring(("W2", ["W1"]), ("W1", ["W2"])))
        result = _run_cli("--manifest", str(manifest))
>       assert result.returncode == 2
E       assert 1 == 2
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/wiring_topo_so...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_wiring_topo_sort.py:135: AssertionError
_________________ TestCLI.test_missing_manifest_flag_exits_two _________________

self = <test_wiring_topo_sort.TestCLI object at 0x109ee47a0>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_missing_manifest_flag_exi0')

    def test_missing_manifest_flag_exits_two(self, tmp_path: Path) -> None:
        # argparse's own missing-required-arg path also exits 2; check that
        # the CLI surface doesn't accidentally silently default the path.
        result = _run_cli()
>       assert result.returncode == 2
E       assert 1 == 2
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/wiring_topo_so...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_wiring_topo_sort.py:144: AssertionError
______________________ TestCLI.test_accepts_json_manifest ______________________

self = <test_wiring_topo_sort.TestCLI object at 0x109e91430>
tmp_path = PosixPath('/private/var/folders/75/d0gqnpf929ngj0tdp8jkmbr40000gn/T/pytest-of-paul/pytest-452/test_accepts_json_manifest0')

    def test_accepts_json_manifest(self, tmp_path: Path) -> None:
        # manifest_io tries JSON before YAML; a .json manifest must also work
        # so callers don't need to pre-convert.
        manifest = tmp_path / "manifest.json"
        manifest.write_text(
            json.dumps({"wiring": [{"id": "W1", "depends_on": []}]}),
            encoding="utf-8",
        )
        result = _run_cli("--manifest", str(manifest))
>       assert result.returncode == 0, result.stderr
E       AssertionError: Traceback (most recent call last):
E           File "/Users/paul/Dev/easy-cheese/src/fanout/wiring_topo_sort.py", line 18, in <module>
E             from easy_cheese_schemas.wiring_graph import WiringCycleError, compute_waves
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/__init__.py", line 12, in <module>
E             from easy_cheese_schemas.compat import (
E           File "/Users/paul/Dev/easy-cheese/src/easy_cheese_schemas/compat.py", line 31, in <module>
E             import attrs
E         ModuleNotFoundError: No module named 'attrs'
E         
E       assert 1 == 0
E        +  where 1 = CompletedProcess(args=['/private/tmp/ec-py312-env/bin/python3', '/Users/paul/Dev/easy-cheese/src/fanout/wiring_topo_so...y_cheese_schemas/compat.py", line 31, in <module>\n    import attrs\nModuleNotFoundError: No module named \'attrs\'\n').returncode

tests/fanout/python/test_wiring_topo_sort.py:155: AssertionError
=========================== short test summary info ============================
FAILED tests/fanout/python/test_manifest_update.py::TestSetPhase::test_happy_path_updates_phase_and_validates
FAILED tests/fanout/python/test_manifest_update.py::TestSetPhase::test_invalid_phase_exits_2
FAILED tests/fanout/python/test_manifest_update.py::TestSetPhase::test_missing_manifest_exits_2
FAILED tests/fanout/python/test_manifest_update.py::TestSetPhase::test_preserves_top_level_field_order
FAILED tests/fanout/python/test_manifest_update.py::TestSetCurdStatus::test_updates_status_and_commit_sha
FAILED tests/fanout/python/test_manifest_update.py::TestSetCurdStatus::test_completed_without_review_context_is_rejected
FAILED tests/fanout/python/test_manifest_update.py::TestSetCurdStatus::test_invalid_status_exits_2
FAILED tests/fanout/python/test_manifest_update.py::TestSetCurdStatus::test_missing_curd_id_exits_2
FAILED tests/fanout/python/test_manifest_update.py::TestSetPostReview::test_atomically_records_review_identity_and_allows_phase_advance
FAILED tests/fanout/python/test_manifest_update.py::TestSetWiringStatus::test_updates_status_and_commit_sha
FAILED tests/fanout/python/test_manifest_update.py::TestSetWiringStatus::test_missing_wiring_id_exits_2
FAILED tests/fanout/python/test_manifest_update.py::TestAtomicity::test_no_tmp_file_left_after_success
FAILED tests/fanout/python/test_manifest_update.py::TestCheckFiles::test_all_present_reports_clean
FAILED tests/fanout/python/test_manifest_update.py::TestCheckFiles::test_missing_files_reported_per_curd_without_failing
FAILED tests/fanout/python/test_manifest_update.py::TestCheckFiles::test_json_mode_reports_missing_per_curd_id
FAILED tests/fanout/python/test_manifest_update.py::TestCheckFiles::test_missing_manifest_exits_2
FAILED tests/fanout/python/test_manifest_update.py::TestCheckFiles::test_invalid_root_exits_2
FAILED tests/fanout/python/test_manifest_update.py::TestCheckFiles::test_directory_where_file_expected_reported_missing
FAILED tests/fanout/python/test_manifest_update.py::TestConcurrentWrites::test_parallel_updates_never_corrupt_file
FAILED tests/fanout/python/test_manifest_update.py::TestConcurrentWrites::test_all_distinct_updates_survive
FAILED tests/fanout/python/test_wiring_topo_sort.py::TestCLI::test_linear_chain_plain_text
FAILED tests/fanout/python/test_wiring_topo_sort.py::TestCLI::test_branching_dag_plain_text
FAILED tests/fanout/python/test_wiring_topo_sort.py::TestCLI::test_json_output_shape
FAILED tests/fanout/python/test_wiring_topo_sort.py::TestCLI::test_empty_wiring_emits_nothing
FAILED tests/fanout/python/test_wiring_topo_sort.py::TestCLI::test_missing_manifest_exits_two
FAILED tests/fanout/python/test_wiring_topo_sort.py::TestCLI::test_cycle_exits_two_with_legacy_error
FAILED tests/fanout/python/test_wiring_topo_sort.py::TestCLI::test_missing_manifest_flag_exits_two
FAILED tests/fanout/python/test_wiring_topo_sort.py::TestCLI::test_accepts_json_manifest
28 failed, 586 passed in 10.57s\n\n## Risk / rollout notes\n\n250 changed non-test lines. Import classification and Git comparison semantics are the main review areas. Depends on #455.\n\n## Checklist\n\n- [x] Conventional Commits PR title\n- [x] Tests added or updated\n- [x] Documentation updated\n- [x] No secrets or credentials added