### PR TITLE
fix(pyz): make currency checks index-pure

### DIFF
--- a/.hallouminate/wiki/adr/pyz-pipeline-contracts-006.md
+++ b/.hallouminate/wiki/adr/pyz-pipeline-contracts-006.md
@@ -1,4 +1,4 @@
-# ADR: The Astro site source moves out of src/ to website/, leaving src/ purely Python
+# ADR: The Astro site source moves out of src/ to website/, leaving src/ Python sources plus docs
 
 Status: accepted (2026-08-18)
 
@@ -10,7 +10,7 @@ Astro's default srcDir made src/ simultaneously the docs-site source tree and th
 
 ## Decision
 
-Move components/, pages/, styles/, content/, sidebar.mjs, content.config.ts to website/ via the srcDir config key; gen_docs.py, the docs workflow, and tests/js follow; a src-purity test locks src/ as Python-only. Rejected: moving Python out (60+ file moves) and nesting both (maximum churn).
+Move components/, pages/, styles/, content/, sidebar.mjs, content.config.ts to website/ via the srcDir config key; gen_docs.py, the docs workflow, and tests/js follow. A src-layout test permits Python sources plus `PYTHON_SCRIPTS.md` and `README.md`, and rejects Astro/site sources or config under `src/`. Rejected: moving Python out (60+ file moves) and nesting both (maximum churn).
 
 ## Consequences
 

--- a/.hallouminate/wiki/specs/pyz-pipeline-contracts.md
+++ b/.hallouminate/wiki/specs/pyz-pipeline-contracts.md
@@ -58,13 +58,22 @@ common.pyz fallback for cook that is never built).
 
 Six settled decisions, one per fork:
 
-1. import-closure-check — after staging each bundle, AST-scan every staged file and
-   assert each absolute import (module-level AND function-body) resolves to stdlib, a
-   staged module, or a vendored dependency; unresolved imports fail the build naming
-   the module and importer.
+1. import-closure-check — after staging each bundle, AST-scan every staged Python file
+   and apply one resolution policy to module-level and function-body imports. An import
+   resolves only when it is in the interpreter stdlib, a vendored package copied into
+   the stage, or a source-layout module/package actually copied into that stage; merely
+   existing under `src/` or `shared/` is not enough. Host-provided names are an explicit
+   allowlist for test/development runners and resolve as runtime-provided dependencies.
+   An intentionally optional import is valid when its `ImportError` handler only raises;
+   an import fallback is valid only when at least one alternative resolves under this
+   same policy. A fallback with no resolving alternative, an unstaged source-layout
+   import, or any other unresolved import fails the build naming the module and importer.
 2. currency-enforcement — wire scripts/check_bundles.py into `just check` and add a
-   prek pre-commit hook scoped to src/**, shared/**, and skills/*/phase-contract.yaml
-   so stale bundles fail before CI.
+   prek pre-commit hook scoped to the complete bundle-producing input set below.
+   The hook compares rebuilt member manifests with the staged-index blobs (not the
+   working tree or HEAD), so a source and its correctly staged bundle pass while a
+   staged source change with a stale indexed bundle fails before CI. Its trigger/input
+   set is the build-pyz workflow set plus authored phase-contract YAML, listed below.
 3. discoverability-surfaces — generate src/PYTHON_SCRIPTS.md (subcommand → source
    file → bundle table compiled from SKILLS, COMMON_SUBCOMMANDS, EXTRA_MODULES,
    PACKAGE_TREES) with a build_pyz staleness gate exactly like the schema catalog;
@@ -81,7 +90,9 @@ Six settled decisions, one per fork:
    test also asserts common.pyz prose references imply consumer membership.
 6. restructure-shape — move the Astro site source out of src/ to website/ via the
    srcDir config key (components, pages, styles, content, sidebar.mjs,
-   content.config.ts), leaving src/ purely Python.
+   content.config.ts). `src/` contains Python source files plus the required
+   `PYTHON_SCRIPTS.md` and `README.md` documentation; it contains no Astro/site
+   source files (components, pages, styles, content, or site config).
 
 ## Decisions
 
@@ -103,8 +114,11 @@ In scripts/build_pyz.py (import-closure-check, discoverability-surfaces, cook-co
 
 ```python
 def _verify_import_closure(stage: Path, skill: str) -> None:
-    """Raise RuntimeError listing every absolute import in staged files,
-    module-level and function-body, not resolved by stdlib, stage, or vendor."""
+    """Raise RuntimeError for staged module-level or function-body imports that
+    are not stdlib, vendored, actually staged source-layout modules, or explicitly
+    host-provided. A raise-only ImportError handler marks an import as optional;
+    fallback imports require at least one resolving runtime alternative. Report the
+    importer and unresolved name."""
 
 def _render_script_map() -> str:
     """Deterministic markdown for src/PYTHON_SCRIPTS.md: one row per (bundle,
@@ -131,41 +145,49 @@ def test_source_banners(): ...                 every registered source opens wit
 ```
 
 In the justfile and prek config (currency-enforcement): a `check-bundles` recipe running
-python3 scripts/check_bundles.py, added to the `check` dependency chain, plus a local
-prek hook `bundle-currency` scoped to files matching src/, shared/, and
-skills/*/phase-contract.yaml.
+`python3 scripts/check_bundles.py`, added to the `check` dependency chain, plus a local
+prek hook `bundle-currency` scoped to authored `skills/*/phase-contract.yaml` plus
+every bundle-producing input in
+`.github/workflows/build-pyz.yml`: `.github/workflows/build-pyz.yml`, `src/**`,
+`shared/scripts/**`, `scripts/build_pyz.py`, `scripts/check_bundles.py`,
+`skills/*/scripts/*.pyz`,
+`pyproject.toml`, `requirements-vendor.txt`, and `scripts/vendor_deps.py`. The hook
+must read the staged index and compare rebuilt member manifests with indexed bundle
+blobs, never the unstaged working tree.
 
 In astro.config.mjs (restructure-shape): `srcDir: './website'` — site sources move to
-website/, and src/ is pure Python.
+website/; `src/` retains Python sources plus `PYTHON_SCRIPTS.md` and `README.md`,
+and contains no Astro/site source or site configuration.
 
 ## Test Contracts
 
 | acceptance id | interface | seam | expected_failure | mode |
 | --- | --- | --- | --- | --- |
-| AC-1 | python3 scripts/build_pyz.py (import-closure-check) | build subprocess exit code and stderr | On main, staging a script whose function-body imports an undeclared cross-directory module builds cleanly; the closure gate must exit nonzero naming the unresolved module and its importer | tracer |
+| AC-1 | python3 scripts/build_pyz.py (import-closure-check) | isolated staged fixture, build exit code and stderr | Positive: stdlib, vendored, explicitly host-provided, and actually staged source-layout imports build; a raise-only `ImportError` guard permits an intentionally optional import; a fallback with one resolving alternative builds. Negative: a fallback with no resolving alternative or a function-body import whose source-layout module was not staged exits nonzero naming the unresolved name and importer | tracer |
 | AC-2 | pytest tests/python/test_skill_contract.py (contract-strictness) | pytest run against build_pyz registries and skills markdown | On main the equality assertion fails: 12 registered subcommands, including press.pyz red-gate, have no skill-markdown reference | tracer |
 | AC-3 | python3 skills/cook/scripts/common.pyz read_handoff_slug (cook-common-consumer) | bundle-dispatch subprocess on a bundle-only layout | On main the invocation fails because skills/cook/scripts/common.pyz is never built; after cook joins COMMON_CONSUMERS it resolves and exits 0 on --help | tracer |
 | AC-4 | python3 skills/press/scripts/press.pyz red-gate (contract-strictness) | dispatcher usage-rejection exit code | On main press.pyz red-gate dispatches successfully; asserting exit 2 usage-rejection fails until the dead registration is pruned | tracer |
 | AC-5 | python3 scripts/build_pyz.py (discoverability-surfaces) | build gate RuntimeError on stale generated file | On main no src/PYTHON_SCRIPTS.md exists; the gate must fail the build until the checked-in map byte-matches the registries | tracer |
-| AC-6 | just check (currency-enforcement) | recipe exit code with a deliberately stale committed bundle | On main just check passes with a stale bundle because check_bundles.py is not wired into the recipe | tracer |
+| AC-6 | just check + `prek run bundle-currency` (currency-enforcement) | staged-index fixture with rebuilt bundle manifests | Positive executable case: build every affected bundle, `git add` the source and generated `.pyz`, then run the hook and assert exit 0. Negative executable case: change and stage one bundle-producing input without restaging its generated `.pyz`, run the same hook, and assert nonzero with the stale bundle path; the hook must compare indexed blobs, not unstaged files or HEAD | tracer |
 | AC-7 | pytest banner assertion in test_skill_contract.py (discoverability-surfaces) | pytest run over registered source files | On main the banner test fails: src/age/age-html-report.py has no ships-as header line | tracer |
-| AC-8 | pytest src purity assertion (restructure-shape) | pytest run over src/ tree contents | On main the assertion that src/ contains no Astro sources fails: src/components/Sidebar.astro exists | tracer |
+| AC-8 | pytest src layout assertion (restructure-shape) | pytest run over `src/` tree contents | Positive: Python sources plus `src/PYTHON_SCRIPTS.md` and `src/README.md` are accepted. Negative: any Astro/site source or site config under `src/` (for example `components/Sidebar.astro`) fails the assertion; the site sources must be under `website/` | tracer |
 
 ## Acceptance
 
-- AC-1: builds fail with a named unresolved import for any staged module gap, covering function-body imports (import-closure-check).
+- AC-1: closure resolution accepts stdlib, vendored, explicitly host-provided, and actually staged source-layout imports. Raise-only `ImportError` handlers mark intentionally optional imports; fallback imports require at least one resolving alternative. Unstaged source-layout imports and fallbacks without a resolving alternative fail with the module and importer named (import-closure-check).
 - AC-2: skill-markdown references and build_pyz registries are provably equal both directions (contract-strictness); the SKILL_SUBCOMMANDS hand copy is gone.
 - AC-3: cook ships common.pyz and the documented fallback resolves (cook-common-consumer).
 - AC-4: pruned dead subcommands, press red-gate first, are rejected by the dispatcher (contract-strictness).
 - AC-5: src/PYTHON_SCRIPTS.md exists, is generated, and stale copies fail the build (discoverability-surfaces).
-- AC-6: just check fails on stale bundles locally; the prek hook fires on the scoped paths (currency-enforcement).
+- AC-6: `just check` fails on stale bundles, and executable prek coverage passes for correctly staged source/bundle pairs but rejects a staged source change against a stale indexed bundle. The hook compares staged-index blobs and covers every bundle-producing workflow input (currency-enforcement).
 - AC-7: every registered source file carries the ships-as banner (discoverability-surfaces).
-- AC-8: src/ contains only Python after the site moves to website/ (restructure-shape).
+- AC-8: `src/` contains Python sources plus `PYTHON_SCRIPTS.md` and `README.md`, no Astro/site sources or site config, after the site moves to `website/` (restructure-shape).
 
 ## Quality gates
 
 - `just check` — vendor, tests, lint, and (new) bundle currency.
-- `python3 scripts/build_pyz.py && python3 scripts/check_bundles.py` — build with closure + map gates, then currency.
+- `python3 scripts/build_pyz.py && python3 scripts/check_bundles.py --against index` — build with closure + map gates, then local staged-index currency.
+- `prek run bundle-currency --files <staged-inputs>` — executable staged-index success and stale-rejection fixtures; the hook must inspect indexed blobs.
 - `pytest tests/python/test_skill_contract.py tests/python/test_pyz_bundle.py` — contract equality, banners, dispatcher behavior.
 - `npm run build` (Astro) — site builds from website/ after restructure-shape.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: local
+    hooks:
+      - id: bundle-currency
+        name: bundle-currency
+        entry: python3 scripts/precommit_bundle_currency.py
+        language: system
+        files: >-
+          (?x)^(
+            src/|
+            shared/scripts/|
+            skills/[^/]+/(phase-contract\.yaml|scripts/[^/]+\.pyz)$|
+            scripts/(build_pyz|check_bundles|precommit_bundle_currency|vendor_deps)\.py$|
+            \.github/workflows/build-pyz\.yml$|
+            pyproject\.toml$|
+            requirements-vendor\.txt$
+          )
+        pass_filenames: false

--- a/justfile
+++ b/justfile
@@ -36,6 +36,14 @@ test: vendor
 test-skill-overlap:
     cargo test --manifest-path tools/skill-overlap/Cargo.toml
 
+# Verify staged .pyz bundles against the index (local check/pre-commit)
+check-bundles:
+    python3 scripts/check_bundles.py --against index
+
+# Verify rebuilt .pyz bundles match HEAD (CI)
+check-bundles-ci:
+    python3 scripts/check_bundles.py --against head
+
 # Build self-contained .pyz bundles for shared-consuming skills (CI rebuilds on every push to main)
 bundle: vendor
     python3 scripts/build_pyz.py
@@ -74,10 +82,10 @@ update-skill-budgets:
     python3 .github/scripts/validate_skills.py --write-budgets
 
 # Full local check with autofixes
-check: lint-md-fix lint-yaml-fix lint-yaml lint-py-fix lint-sh test docs-build
+check: lint-md-fix lint-yaml-fix lint-yaml lint-py-fix lint-sh test bundle check-bundles docs-build
 
 # CI-mode verification (no autofixes)
-ci: lint-md lint-yaml lint-sh test docs-build
+ci: lint-md lint-yaml lint-sh test bundle check-bundles-ci docs-build
 
 # Install docs build dependencies
 docs-install:

--- a/scripts/check_bundles.py
+++ b/scripts/check_bundles.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
-"""Check every committed .pyz still matches its sources, by content.
+"""Check every rebuilt .pyz still matches the git copy it will ship.
 
-Run after `build_pyz.py` has rebuilt the working tree: this compares each
-rebuilt bundle against the copy committed at HEAD.
+Run after `build_pyz.py` has rebuilt the working tree. Compares each rebuilt
+bundle to a git blob — HEAD in CI, the index for `just check` and the
+pre-commit hook — by member name, CRC, and uncompressed size rather than raw bytes.
 
-The comparison is per-member name, CRC, and uncompressed size rather than raw
-bytes. Bundles are ZIP_DEFLATED, and two zlib builds compress identical input
-to different bytes -- observed on one machine across two CPython builds
-reporting the same zlib 1.3.1. A raw-byte diff would therefore fail for any
-contributor whose zlib differs from whoever last committed, which is noise, not
-staleness. Member CRCs still catch the signal this gate exists for: a source
-edit that never made it into the committed bundle.
+Bundles are ZIP_DEFLATED, and two zlib builds compress identical input to
+different bytes. A raw-byte diff would fail for any contributor whose zlib
+differs from whoever last committed. Member CRCs still catch the signal this
+gate exists for: a source edit that never made it into the compared blob.
 
 Byte-for-byte reproducibility is deliberately not asserted; see the spec's
 accepted risk on ZIP_DEFLATED determinism.
@@ -18,6 +16,7 @@ accepted risk on ZIP_DEFLATED determinism.
 
 from __future__ import annotations
 
+import argparse
 import io
 import subprocess
 import sys
@@ -26,6 +25,12 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BUNDLE_GLOB = "skills/*/scripts/*.pyz"
+_MISSING_MARKERS = (
+    b"exists on disk, but not in",
+    b"does not exist in",
+    b"path does not exist",
+    b"does not exist",
+)
 
 
 def _manifest(data: bytes) -> dict[str, tuple[int, int]]:
@@ -34,41 +39,85 @@ def _manifest(data: bytes) -> dict[str, tuple[int, int]]:
         return {i.filename: (i.CRC, i.file_size) for i in archive.infolist()}
 
 
-def _committed(path: Path) -> bytes | None:
-    """The blob at HEAD, or None when the bundle is newly added."""
+def classify_git_show(returncode: int, stderr: bytes) -> str:
+    """ok | missing | error. Missing comparison blobs are stale bundles."""
+    if returncode == 0:
+        return "ok"
+    lowered = stderr.lower()
+    if any(marker in lowered for marker in _MISSING_MARKERS):
+        return "missing"
+    return "error"
+
+
+def _spec(path: Path, against: str) -> str:
+    posix = path.as_posix()
+    return f":{posix}" if against == "index" else f"HEAD:{posix}"
+
+
+def _git_blob(path: Path, against: str) -> bytes | None:
+    """The blob at HEAD or the index, or None when the path is absent."""
     result = subprocess.run(
-        ["git", "show", f"HEAD:{path.as_posix()}"],
+        ["git", "show", _spec(path, against)],
         cwd=REPO_ROOT,
         capture_output=True,
     )
-    return result.stdout if result.returncode == 0 else None
+    kind = classify_git_show(result.returncode, result.stderr)
+    if kind == "ok":
+        return result.stdout
+    if kind == "missing":
+        return None
+    sys.stderr.write(result.stderr.decode("utf-8", errors="replace"))
+    raise RuntimeError(
+        f"git show {_spec(path, against)!r} failed (exit {result.returncode})"
+    )
 
 
-def _describe(rebuilt: dict[str, tuple[int, int]], committed: dict[str, tuple[int, int]]) -> list[str]:
+def _describe(
+    rebuilt: dict[str, tuple[int, int]], compared: dict[str, tuple[int, int]]
+) -> list[str]:
     problems = []
-    for name in sorted(set(rebuilt) - set(committed)):
-        problems.append(f"    + {name} (built, not in the committed bundle)")
-    for name in sorted(set(committed) - set(rebuilt)):
-        problems.append(f"    - {name} (committed, no longer built)")
-    for name in sorted(set(rebuilt) & set(committed)):
-        if rebuilt[name] != committed[name]:
+    for name in sorted(set(rebuilt) - set(compared)):
+        problems.append(f"    + {name} (built, not in the compared bundle)")
+    for name in sorted(set(compared) - set(rebuilt)):
+        problems.append(f"    - {name} (compared, no longer built)")
+    for name in sorted(set(rebuilt) & set(compared)):
+        if rebuilt[name] != compared[name]:
             problems.append(f"    ~ {name} (content differs)")
     return problems
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--against",
+        choices=("head", "index"),
+        default="head",
+        help="blob to compare the rebuilt worktree against (default: HEAD)",
+    )
+    args = parser.parse_args(argv)
     stale: list[str] = []
     checked = 0
-    for path in sorted(REPO_ROOT.glob(BUNDLE_GLOB)):
-        relative = path.relative_to(REPO_ROOT)
-        committed = _committed(relative)
-        if committed is None:
-            print(f"new bundle, nothing to compare: {relative}")
-            continue
-        checked += 1
-        problems = _describe(_manifest(path.read_bytes()), _manifest(committed))
-        if problems:
-            stale.append(f"  {relative}\n" + "\n".join(problems))
+    found = list(sorted(REPO_ROOT.glob(BUNDLE_GLOB)))
+    if not found:
+        print("::error::no .pyz bundles found under skills/*/scripts/", file=sys.stderr)
+        return 1
+    try:
+        for path in found:
+            relative = path.relative_to(REPO_ROOT)
+            compared = _git_blob(relative, args.against)
+            if compared is None:
+                stale.append(
+                    f"  {relative}\n"
+                    "    + bundle is missing from the compared git tree"
+                )
+                continue
+            checked += 1
+            problems = _describe(_manifest(path.read_bytes()), _manifest(compared))
+            if problems:
+                stale.append(f"  {relative}\n" + "\n".join(problems))
+    except RuntimeError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
 
     if stale:
         print(

--- a/scripts/precommit_bundle_currency.py
+++ b/scripts/precommit_bundle_currency.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Run the bundle currency gate against a temporary checkout of the index."""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _wheel_cache(requirements: Path, common_dir: Path) -> Path:
+    digest = hashlib.sha256(requirements.read_bytes()).hexdigest()
+    cache_root = common_dir / "bundle-currency-wheel-cache"
+    cache_root.mkdir(parents=True, exist_ok=True)
+    cache = cache_root / digest
+    with (cache_root / f"{digest}.lock").open("w", encoding="utf-8") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        if cache.is_dir():
+            if not any(cache.glob("*.whl")):
+                raise RuntimeError(f"wheel cache is empty: {cache}")
+            return cache
+        with tempfile.TemporaryDirectory(prefix=f".{digest}-", dir=cache_root) as staging:
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "download",
+                    "--no-deps",
+                    "--only-binary=:all:",
+                    "--require-hashes",
+                    "--requirement",
+                    str(requirements),
+                    "--dest",
+                    staging,
+                ],
+                cwd=requirements.parent,
+                check=True,
+            )
+            if not list(Path(staging).glob("*.whl")):
+                raise RuntimeError(f"pip download produced no wheels in {staging}")
+            os.replace(staging, cache)
+    return cache
+
+
+def _absolute_git_path(path: str) -> str:
+    candidate = Path(path)
+    return str(candidate if candidate.is_absolute() else (REPO_ROOT / candidate).resolve())
+
+
+def main() -> int:
+    git_dir = _absolute_git_path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--git-dir"], cwd=REPO_ROOT, text=True
+        ).strip()
+    )
+    index_file = _absolute_git_path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--git-path", "index"],
+            cwd=REPO_ROOT,
+            text=True,
+        ).strip()
+    )
+    common_dir = _absolute_git_path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--git-common-dir"], cwd=REPO_ROOT, text=True
+        ).strip()
+    )
+
+    with tempfile.TemporaryDirectory(prefix="bundle-currency-") as raw_tmp:
+        checkout = Path(raw_tmp) / "repo"
+        checkout.mkdir()
+        subprocess.run(
+            ["git", "checkout-index", "--all", f"--prefix={checkout}/"],
+            cwd=REPO_ROOT,
+            check=True,
+        )
+        env = os.environ.copy()
+        env["GIT_DIR"] = git_dir
+        env["GIT_INDEX_FILE"] = index_file
+        cache = _wheel_cache(checkout / "requirements-vendor.txt", Path(common_dir))
+        offline_env = env | {"PIP_NO_INDEX": "1", "PIP_FIND_LINKS": str(cache)}
+        commands = (
+            ([sys.executable, "scripts/vendor_deps.py"], offline_env),
+            ([sys.executable, "scripts/build_pyz.py"], env),
+            ([sys.executable, "scripts/check_bundles.py", "--against", "index"], env),
+        )
+        for command, command_env in commands:
+            result = subprocess.run(command, cwd=checkout, env=command_env)
+            if result.returncode:
+                return result.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/python/test_check_bundles.py
+++ b/tests/python/test_check_bundles.py
@@ -1,0 +1,32 @@
+"""Unit tests for scripts/check_bundles.py classification."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import check_bundles  # noqa: E402
+
+
+def test_classify_git_show_missing_path_is_new_bundle() -> None:
+    assert (
+        check_bundles.classify_git_show(
+            128, b"fatal: path 'skills/cut/scripts/cut.pyz' does not exist in 'HEAD'\n"
+        )
+        == "missing"
+    )
+    assert (
+        check_bundles.classify_git_show(
+            128,
+            b"fatal: path 'x.pyz' exists on disk, but not in 'HEAD'\n",
+        )
+        == "missing"
+    )
+
+
+def test_classify_git_show_other_failures_are_errors() -> None:
+    assert check_bundles.classify_git_show(128, b"fatal: not a git repository\n") == "error"
+    assert check_bundles.classify_git_show(128, b"fatal: Invalid object name 'HEAD'.\n") == "error"
+    assert check_bundles.classify_git_show(0, b"") == "ok"

--- a/tests/python/test_pyz_pipeline_tracers.py
+++ b/tests/python/test_pyz_pipeline_tracers.py
@@ -8,10 +8,14 @@ no tracer ever mutates the project.
 
 from __future__ import annotations
 
+import os
+import re
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -39,8 +43,10 @@ def _copy_project_subset(dest: Path, dirs: tuple[str, ...], files: tuple[str, ..
         shutil.copy2(REPO_ROOT / name, dest / name)
 
 
-def _run(argv: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(argv, cwd=cwd, capture_output=True, text=True)
+def _run(
+    argv: list[str], cwd: Path, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(argv, cwd=cwd, capture_output=True, text=True, env=env)
 
 
 def _output(proc: subprocess.CompletedProcess[str]) -> str:
@@ -83,3 +89,143 @@ def test_script_map_gate(tmp_path: Path) -> None:
     detail = f"exit={proc.returncode}\n{_output(proc)}"
     assert proc.returncode != 0, f"{WITNESS_SCRIPT_MAP}\n{detail}"
     assert "PYTHON_SCRIPTS.md" in _output(proc), f"{WITNESS_SCRIPT_MAP}\n{detail}"
+
+
+WITNESS_BUNDLE_CURRENCY = (
+    "The bundle currency hook must build from the staged index, not an "
+    "unstaged source edit"
+)
+
+
+def test_bundle_currency_wired_into_check(tmp_path: Path) -> None:
+    sandbox = tmp_path / "project"
+    _copy_project_subset(
+        sandbox,
+        dirs=("scripts", "src", "shared", "skills", "vendor"),
+        files=("requirements-vendor.txt", "justfile", ".pre-commit-config.yaml"),
+    )
+    git = [
+        "git",
+        "-c",
+        "user.email=cut@tracer",
+        "-c",
+        "user.name=cut",
+        "-c",
+        "commit.gpgsign=false",
+    ]
+    assert _run([*git, "init", "-q"], cwd=sandbox).returncode == 0
+    assert _run([*git, "add", "-A", "-f"], cwd=sandbox).returncode == 0
+    assert _run([*git, "commit", "-q", "-m", "base"], cwd=sandbox).returncode == 0
+    assert _run([*git, "rm", "--cached", "-q", "-r", "vendor"], cwd=sandbox).returncode == 0
+
+    just = (sandbox / "justfile").read_text(encoding="utf-8")
+    check = re.search(r"^check:(.*)$", just, re.M)
+    ci = re.search(r"^ci:(.*)$", just, re.M)
+    assert check is not None and ci is not None, WITNESS_BUNDLE_CURRENCY
+    check_deps = check.group(1).split()
+    ci_deps = ci.group(1).split()
+    assert check_deps.index("bundle") < check_deps.index("check-bundles")
+    assert ci_deps.index("bundle") < ci_deps.index("check-bundles-ci")
+    assert "check_bundles.py --against index" in just
+    assert "check_bundles.py --against head" in just
+
+    config = yaml.safe_load(
+        (sandbox / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    )
+    hook = config["repos"][0]["hooks"][0]
+    trigger = re.compile(hook["files"])
+    for path in (
+        ".github/workflows/build-pyz.yml",
+        "src/melt/batch-resolve.py",
+        "shared/scripts/paths.py",
+        "skills/melt/phase-contract.yaml",
+        "skills/melt/scripts/melt.pyz",
+        "scripts/build_pyz.py",
+        "scripts/check_bundles.py",
+        "scripts/precommit_bundle_currency.py",
+        "scripts/vendor_deps.py",
+        "pyproject.toml",
+        "requirements-vendor.txt",
+    ):
+        assert trigger.search(path), path
+
+    source = sandbox / "src" / "melt" / "batch-resolve.py"
+    bundle = sandbox / "skills" / "melt" / "scripts" / "melt.pyz"
+    source.write_text(
+        source.read_text(encoding="utf-8") + "\n# staged pair probe\n",
+        encoding="utf-8",
+    )
+    rebuild = _run([sys.executable, "scripts/build_pyz.py", "melt"], cwd=sandbox)
+    assert rebuild.returncode == 0, f"{WITNESS_BUNDLE_CURRENCY}\n{_output(rebuild)}"
+    assert _run([*git, "add", str(source), str(bundle)], cwd=sandbox).returncode == 0
+
+    source.write_text(
+        source.read_text(encoding="utf-8") + "\n# unstaged source probe\n",
+        encoding="utf-8",
+    )
+    vendor_module = sandbox / "vendor" / "attr" / "__init__.py"
+    vendor_module.write_text(
+        vendor_module.read_text(encoding="utf-8") + "\n# unstaged vendor probe\n",
+        encoding="utf-8",
+    )
+    hook_run = _run(["bash", "-c", hook["entry"]], cwd=sandbox)
+    assert hook_run.returncode == 0, (
+        f"{WITNESS_BUNDLE_CURRENCY}\n{_output(hook_run)}"
+    )
+
+    offline_env = os.environ.copy()
+    offline_env["PIP_INDEX_URL"] = "http://127.0.0.1:9/simple"
+    offline_env["PIP_NO_INDEX"] = "1"
+    offline_hook_run = _run(
+        ["bash", "-c", hook["entry"]], cwd=sandbox, env=offline_env
+    )
+    assert offline_hook_run.returncode == 0, (
+        f"{WITNESS_BUNDLE_CURRENCY}\n{_output(offline_hook_run)}"
+    )
+
+    source.write_text(
+        source.read_text(encoding="utf-8") + "\n# stale staged source probe\n",
+        encoding="utf-8",
+    )
+    assert _run([*git, "add", str(source)], cwd=sandbox).returncode == 0
+    rebuild = _run([sys.executable, "scripts/build_pyz.py", "melt"], cwd=sandbox)
+    assert rebuild.returncode == 0, f"{WITNESS_BUNDLE_CURRENCY}\n{_output(rebuild)}"
+
+    recipe = _run(
+        [sys.executable, "scripts/check_bundles.py", "--against", "index"],
+        cwd=sandbox,
+    )
+    detail = f"exit={recipe.returncode}\n{_output(recipe)}"
+    assert recipe.returncode != 0 and "stale" in _output(recipe), (
+        f"{WITNESS_BUNDLE_CURRENCY}\n{detail}"
+    )
+
+
+def test_missing_bundle_from_index_fails_currency_check(tmp_path: Path) -> None:
+    sandbox = tmp_path / "project"
+    _copy_project_subset(
+        sandbox,
+        dirs=("scripts", "src", "shared", "skills", "vendor"),
+        files=("requirements-vendor.txt",),
+    )
+    git = [
+        "git",
+        "-c",
+        "user.email=cut@tracer",
+        "-c",
+        "user.name=cut",
+        "-c",
+        "commit.gpgsign=false",
+    ]
+    assert _run([*git, "init", "-q"], cwd=sandbox).returncode == 0
+    assert _run([*git, "add", "-A", "-f"], cwd=sandbox).returncode == 0
+    assert _run([*git, "commit", "-q", "-m", "base"], cwd=sandbox).returncode == 0
+
+    bundle = sandbox / "skills" / "melt" / "scripts" / "melt.pyz"
+    assert _run([*git, "rm", "--cached", "-q", str(bundle)], cwd=sandbox).returncode == 0
+    recipe = _run(
+        [sys.executable, "scripts/check_bundles.py", "--against", "index"],
+        cwd=sandbox,
+    )
+    detail = f"exit={recipe.returncode}\n{_output(recipe)}"
+    assert recipe.returncode != 0 and "stale" in _output(recipe), detail


### PR DESCRIPTION
## What changed

Clarifies the staged-index versus CI-HEAD contract, adds an index-materialized pre-commit bundle gate, rejects missing compared bundles, and caches hash-verified vendor wheels for offline reruns.

## Why

This cures the currency findings from the split #439 review without mixing import-closure analysis into the same review unit.

## How to verify

`just check`

Focused: `python3 -m pytest tests/python/test_pyz_pipeline_tracers.py tests/python/test_check_bundles.py -q`

## Risk / rollout notes

313 changed non-test text lines. The first hook run may populate a wheel cache under the Git common directory; later runs revalidate cached wheel hashes and work offline. Depends on #455.

## Checklist

- [x] Conventional Commits PR title
- [x] Tests added or updated
- [x] Documentation updated
- [x] No secrets or credentials added
