### PR TITLE
docs(plate): require BLUF commit style and sweep uncommitted wiki writes

### DIFF
--- a/.hallouminate/wiki/adr/plate-publication-boundary-001.md
+++ b/.hallouminate/wiki/adr/plate-publication-boundary-001.md
@@ -28,7 +28,9 @@ Before validation or publication, `/plate` inventories promised artifacts and du
 implementation learnings. It routes durable knowledge through the consumer repo's
 hallouminate writer when available, otherwise uses the tracked ADR/domain-model fallback,
 then reads every required output back and records `{target, backend, verified}`.[^3]
-An unverified required write halts the transaction. For a stack, `/plate` selects and
+An unverified required write halts the transaction. Staging additionally sweeps
+uncommitted `.hallouminate/wiki/` paths into the commit, so wiki writes made earlier in
+the session ship with the publication instead of being stranded locally. For a stack, `/plate` selects and
 creates or adopts provider lineage, then runs the write, validation, named-stage, commit,
 and verification transaction separately for each layer before submitting the chain.[^5]
 Shared durable writes live on the bottom/common branch or an explicit wiring branch.

--- a/skills/plate/SKILL.md
+++ b/skills/plate/SKILL.md
@@ -139,7 +139,11 @@ stack machinery below. Any other branch uses the policy above unchanged.
 3. **Inspect** — read status, diff, and recent log; verify the intended file
    set.
 4. **Stage** — add named files only. Never stage the whole tree. Keep transient
-   `.cheese/` reports unstaged; include tracked wiki/docs writes.
+   `.cheese/` reports unstaged; include tracked wiki/docs writes. When the repo
+   has a hallouminate wiki, sweep `git status` for uncommitted
+   `.hallouminate/wiki/` paths — including writes from earlier in the session —
+   and stage them unless gitignored. Wiki updates ship with this publication,
+   never after it.
 5. **Commit** — use a Conventional Commit message focused on why. Do not amend
    unless explicitly requested and do not bypass hooks.
 6. **Verify** — inspect status and the committed file set.
@@ -185,6 +189,10 @@ type(scope): short description
 
 Optional body when the rationale needs it.
 ```
+
+Write the message BLUF and newscaster-flat: the subject states the change up
+front, the optional body carries only the facts a reviewer needs, and nothing
+else — short, concise, no narrative prose, tone, or slang.
 
 Allowed types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`,
 `style`. If a hook fails, fix it, re-run the writing and quality gates when

--- a/skills/plate/references/durable-writes.md
+++ b/skills/plate/references/durable-writes.md
@@ -10,6 +10,11 @@ files, ADR/domain-model decisions, release notes, and implementation-time
 architecture, convention, protocol, or gotcha knowledge. Classify each item as
 required or optional and tracked or transient.
 
+When the repository has a hallouminate wiki, also sweep `git status` for
+uncommitted `.hallouminate/wiki/` paths and add each (unless gitignored) as a
+required tracked artifact — wiki writes from earlier in the session ship with
+this publication, not after it.
+
 ## Backend cascade
 
 1. When the consumer repository exposes a hallouminate wiki, invoke the explicit


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->
## What changed

Semantics-altering change to the `/plate` skill contract:

1. **Commit contract** — messages must be BLUF and newscaster-flat: subject states the change up front, optional body carries only reviewer-relevant facts, no narrative prose, tone, or slang.
2. **Wiki sweep** — when the repo has a hallouminate wiki, staging sweeps `git status` for uncommitted `.hallouminate/wiki/` paths (including writes from earlier in the session) and the durable-writes inventory lists them as required tracked artifacts, so publication halts rather than leaving them behind.

The `plate-publication-boundary-001` ADR is updated to record the sweep.

## Why

Two recurring failure modes: verbose/slangy commit messages, and wiki updates written after plating that never reached a PR.

## How to verify

Read the three-file diff. Check that:

- the staging step, durable-writes inventory, and ADR describe the same sweep behavior (no contradiction between SKILL.md and references);
- the sweep is conditional on a hallouminate wiki and excludes gitignored paths;
- the commit-style wording sits inside the existing Conventional Commit contract without changing allowed types.

`just check` on this branch: all lint/validators pass; `tests/python/test_red_gate_validator.py::test_probe_replays_native_context_in_both_safe_modes` (8 cases) fails identically at HEAD with the diff stashed — local Homebrew Python binary-path resolution, unrelated to this docs-only change.

## Risk / rollout notes

None beyond agent-behavior change: plate runs will now stage pending wiki edits it previously ignored. Installed copy at `~/.claude/skills/plate` synced manually.

## Checklist

- [x] Conventional Commits PR title (`feat:`, `fix:`, `chore:`, `docs:`, ...)
- [x] Tests added or updated (or N/A — docs-only skill contract change)
- [x] Documentation updated (or N/A)
- [x] No secrets or credentials added
