### PR TITLE
docs(pyz): establish skill bundle doctrine

### DIFF
--- a/.hallouminate/wiki/architecture/index.md
+++ b/.hallouminate/wiki/architecture/index.md
@@ -3,6 +3,7 @@
 <!-- HALLOUMINATE:INDEX-START -->
 - [age-fanout-router](./age-fanout-router.md) — Age fan-out router
 - [pyz-bundling-pipeline](./pyz-bundling-pipeline.md) — Pyz bundling pipeline
+- [skill-python-bundle-doctrine](./skill-python-bundle-doctrine.md) — Skill Python bundle doctrine
 - [ultracook-agent-topology](./ultracook-agent-topology.md) — Ultracook agent topology (now owned by /cook's fan pathway)
 - [workflow-contract-map](./workflow-contract-map.md) — Workflow contract map
 <!-- HALLOUMINATE:INDEX-END -->

--- a/.hallouminate/wiki/architecture/skill-python-bundle-doctrine.md
+++ b/.hallouminate/wiki/architecture/skill-python-bundle-doctrine.md
@@ -1,0 +1,75 @@
+# Skill Python bundle doctrine
+
+Every skill that executes Python ships at most one same-named `.pyz` and invokes Python only through that archive. Runtime source is organized as importable packages under `src/`; checked-in skill directories contain deployment artifacts, not Python source.
+
+This doctrine was approved on 2026-08-24. The repository does not yet conform fully; enforcement and migration belong to follow-up work rather than the doctrine-only change that introduced these rules.
+
+## Skill deployment contract
+
+- A skill that executes Python ships exactly `skills/<skill>/scripts/<skill>.pyz`.
+- A skill that does not execute Python ships no `.pyz`.
+- Skill instructions and references invoke only their own bundled archive. They never invoke `src/**/*.py`, repository automation, loose Python helpers, `common.pyz`, or another skill's archive.
+- Skill-root-relative paths are the portable reference form required by the Agent Skills file-reference convention.[^1]
+- Python source never lives under `skills/`. Checked-in `.pyz` files are generated deployment artifacts, never source of truth.
+- Non-executable references and assets remain ordinary skill resources; “bundle-only” applies to executable Python, not Markdown, schemas, templates, or other documentation.
+
+## Source layout
+
+Runtime Python has two import packages:
+
+```text
+src/
+├── easy_cheese/
+│   ├── shared/
+│   └── skills/
+│       └── <python_skill_name>/
+└── easy_cheese_schemas/
+```
+
+- `easy_cheese_schemas` is the independently published PyPI package.
+- `easy_cheese` is repository-internal and must be excluded from the PyPI distribution.
+- Skill slugs remain kebab-case in `skills/`; import-package segments use underscores because Python import packages should be valid identifiers.[^2]
+- Shared runtime helpers live in `src/easy_cheese/shared/`.
+- Skill-owned runtime code lives in `src/easy_cheese/skills/<python_skill_name>/`.
+- Tests remain under `tests/`.
+- Repository build, release, generation, and maintenance programs may live under `scripts/`. Runtime Python has no other source root.
+
+The `src` layout separates importable code from repository files and prevents accidental imports from the working directory.[^3]
+
+## Zip-safe runtime
+
+A skill archive may contain Python modules, bytecode, and immutable package resources. Bundled dependencies must be pure Python and zip-importable.
+
+The following are prohibited:
+
+- native extension modules such as `.so` and `.pyd`;
+- platform-specific libraries such as bundled `.dll` or `.dylib` files;
+- required external executables;
+- runtime package installation or downloads;
+- mandatory extraction before the skill can run.
+
+Python's ZIP importer supports `.py` and `.pyc` modules but explicitly rejects dynamic extension modules.[^4] Package resources may be read from ZIP archives through `importlib.resources`, so non-Python immutable data is allowed when it is part of the reachable runtime closure.[^5]
+
+## Minimal bundles
+
+Minimal means both few artifacts and narrow contents:
+
+1. At most one same-named `.pyz` per skill.
+2. Only that skill's entrypoints and transitive runtime closure.
+3. Only required shared and schema modules.
+4. Only approved pure-Python third-party dependencies.
+5. No whole-package or whole-tree inclusion without explicit justification.
+
+The build must eventually enforce dependency closure, reject native artifacts, verify bundle currency, and execute every bundled interface with repository paths, `PYTHONPATH`, and ambient site packages unavailable. Those gates are follow-up implementation work; this page establishes their target contract.
+
+## Superseded topology
+
+This doctrine supersedes the current split between `src/` and `shared/scripts/`, the multi-consumer `common.pyz`, cross-skill archive calls, and retained runtime ownership under the retired `ultracook` skill. Until migration lands, [[pyz-bundling-pipeline]] documents current behavior while this page defines the target.
+
+[^1]: https://agentskills.io/specification#file-references
+[^2]: https://packaging.python.org/en/latest/discussions/distribution-package-vs-import-package/
+[^3]: https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/
+[^4]: https://docs.python.org/3/library/zipimport.html
+[^5]: https://docs.python.org/3/library/importlib.resources.html
+
+_Source: human-approved repository doctrine · Updated: 2026-08-24 · Supersedes: split runtime roots and shared common bundle topology_

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,35 @@ Do NOT commit or push when `just check` fails. If CI fails, pull the branch loca
 
 This is a skills-only collection following the [Agent Skills spec](https://agentskills.io/specification). Every change either adds, edits, or supports a skill under `skills/<name>/`.
 
+## Skill Python bundle doctrine
+
+This is the target contract. Existing violations are migration work; do not expand
+them while enforcement is implemented separately.
+
+- A skill that executes Python ships exactly
+  `skills/<skill>/scripts/<skill>.pyz`; a skill with no Python ships no
+  `.pyz`. Skill prose invokes only its own archive—never loose source,
+  `common.pyz`, repository automation, or another skill's bundle.
+- Runtime Python lives under `src/`. Tests remain under `tests/`; repository
+  build, release, generation, and maintenance programs may live under
+  `scripts/`.
+- Published schemas live in `src/easy_cheese_schemas/`. All non-published
+  runtime code lives under `src/easy_cheese/`, split between
+  `skills/<python_skill_name>/` and `shared/`. Skill slugs remain kebab-case;
+  Python package segments use underscores.
+- Bundles may contain Python modules, bytecode, and immutable package resources.
+  Dependencies must be pure Python and zip-importable. Native extensions,
+  platform-specific libraries, required external executables, runtime
+  installation/downloads, and mandatory extraction are prohibited.
+- Each bundle contains only its entrypoints and transitive runtime closure:
+  required skill, shared, schema, and approved pure-Python dependency modules.
+  Whole-package or whole-tree inclusion requires explicit justification.
+- Checked-in `.pyz` files are generated deployment artifacts, never source of
+  truth. Python source never lives under `skills/`.
+
+The durable rationale and migration boundary live in
+[the skill Python bundle doctrine](.hallouminate/wiki/architecture/skill-python-bundle-doctrine.md).
+
 ### Workflow skills (the cheese pipeline)
 
 | Skill | Purpose |


### PR DESCRIPTION
## Summary

- establish the target one-skill/one-bundle Python doctrine in `AGENTS.md`
- record source layout, zip-safety, and minimal-closure rationale in Hallouminate
- mark current bundle topology as migration work and defer enforcement to a follow-up

## Review classification

Semantics-altering documentation: this defines the repository contract for future Python and skill-bundle changes without changing current runtime behavior.

## Verification

- `just check`

## Reviewer focus

- doctrine matches the approved same-named `.pyz`, `src/easy_cheese`, and pure-Python dependency boundaries
- current non-conformance is clearly separated from the follow-up enforcement work
