### PR TITLE
feat(runtime): scaffold src/easy_cheese runtime package skeleton

### DIFF
--- a/src/easy_cheese/__init__.py
+++ b/src/easy_cheese/__init__.py
@@ -1,0 +1,1 @@
+"""Doctrine-compliant runtime package."""

--- a/src/easy_cheese/shared/__init__.py
+++ b/src/easy_cheese/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime modules owned by individual skill bundles and shared contracts."""

--- a/src/easy_cheese/skills/__init__.py
+++ b/src/easy_cheese/skills/__init__.py
@@ -1,0 +1,1 @@
+"""Skill-owned runtime modules."""

--- a/src/easy_cheese/skills/cook/__init__.py
+++ b/src/easy_cheese/skills/cook/__init__.py
@@ -1,0 +1,1 @@
+"""Cook canonical consumer."""

--- a/src/easy_cheese/skills/mold/__init__.py
+++ b/src/easy_cheese/skills/mold/__init__.py
@@ -1,0 +1,1 @@
+"""Mold canonical producer."""


### PR DESCRIPTION
## Summary

First minimum-viable slice extracted from the enforceable skill-boundary work (#476 plan / #478 full implementation). Establishes the new `src/easy_cheese/` runtime package layout so later slices land modules into an existing structure instead of introducing structure and behavior in one large change.

Packages created (docstring-only `__init__.py`):

- `src/easy_cheese/` — runtime package root
- `src/easy_cheese/shared/` — shared contracts + bundle-owned modules
- `src/easy_cheese/skills/` — skill-owned runtime modules
- `src/easy_cheese/skills/cook/` — canonical consumer
- `src/easy_cheese/skills/mold/` — canonical producer

Distinct from the existing `src/easy_cheese_schemas/` package.

## Scope

Structure only. No implementation, schema, build, or bundle wiring — the new package is not yet added to the wheel or `.pyz` build. Those follow in subsequent slices from #478.

## Verification

- `uvx ruff check src/easy_cheese` — clean
- `python3 -m pytest tests/python -q` — 1246 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EY43r6yCnbPrkzrS5cBSZ4