### PR TITLE
feat(runtime): add shared artifact_path resolver

### DIFF
--- a/src/easy_cheese/shared/artifact_path.py
+++ b/src/easy_cheese/shared/artifact_path.py
@@ -1,0 +1,77 @@
+"""Resolve durable and transient artifact paths for packaged skills."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PHASES = frozenset({
+    "cook", "press", "age", "cure", "specs", "notes", "hard",
+    "research", "ultracook", "pasteurize",
+})
+XDG_PHASES = frozenset({"specs", "research"})
+PHASE_DIRS = {"hard": "hard-cheese"}
+KEBAB_SLUG = re.compile(r"^(?!-)(?!.*--)[a-z0-9-]{1,64}(?<!-)$")
+
+
+def _project_key() -> str:
+    override = os.environ.get("EASY_CHEESE_PROJECT", "").strip()
+    if override:
+        return re.sub(r"[^a-z0-9._-]+", "-", override.lower()).strip("-._") or "default"
+    try:
+        remote = subprocess.run(
+            ["git", "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if remote.returncode == 0 and remote.stdout.strip():
+            value = remote.stdout.strip().removesuffix(".git")
+            value = value.rsplit(":", 1)[-1].rsplit("/", 2)[-2:]
+            return re.sub(r"[^a-z0-9._-]+", "-", "-".join(value).lower()).strip("-._") or "default"
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return Path.cwd().name
+
+
+def _corpus_home() -> Path:
+    override = os.environ.get("EASY_CHEESE_HOME", "").strip()
+    if override and Path(override).is_absolute():
+        return Path(override)
+    xdg = os.environ.get("XDG_DATA_HOME", "").strip()
+    return (Path(xdg) if xdg and Path(xdg).is_absolute() else Path.home() / ".local" / "share") / "cheese"
+
+
+def project_corpus_root() -> Path:
+    return _corpus_home() / _project_key()
+
+
+def artifact_path(phase: str, slug: str) -> Path:
+    if phase not in PHASES:
+        raise ValueError(f"unknown phase {phase!r}; expected one of {sorted(PHASES)}")
+    if not isinstance(slug, str) or not KEBAB_SLUG.match(slug):
+        raise ValueError(
+            f"slug {slug!r} must be kebab-case, 1-64 chars, [a-z0-9-], "
+            "no leading/trailing hyphen, no double hyphens"
+        )
+    root = project_corpus_root() if phase in XDG_PHASES else Path(".cheese")
+    return root / PHASE_DIRS.get(phase, phase) / f"{slug}.md"
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("phase")
+    parser.add_argument("slug")
+    args = parser.parse_args(argv)
+    try:
+        resolved = project_corpus_root() if args.phase == "research" else artifact_path(args.phase, args.slug)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(resolved)
+    return 0

--- a/tests/python/test_artifact_path.py
+++ b/tests/python/test_artifact_path.py
@@ -1,0 +1,96 @@
+"""Behavioral contract for easy_cheese.shared.artifact_path.
+
+Pins path resolution, phase-directory remapping, slug validation, corpus-root
+derivation from the environment, and the CLI wrapper's exit codes. artifact_path
+never touches the filesystem, so these assert on returned/printed paths only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from easy_cheese.shared import artifact_path as ap
+
+
+def test_non_xdg_phase_resolves_under_cheese() -> None:
+    assert ap.artifact_path("cook", "my-slug") == Path(".cheese/cook/my-slug.md")
+
+
+def test_hard_phase_remaps_directory() -> None:
+    assert ap.artifact_path("hard", "my-slug") == Path(".cheese/hard-cheese/my-slug.md")
+
+
+def test_xdg_phase_resolves_under_corpus_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("EASY_CHEESE_HOME", str(tmp_path))
+    monkeypatch.setenv("EASY_CHEESE_PROJECT", "proj")
+    assert ap.artifact_path("specs", "s") == tmp_path / "proj" / "specs" / "s.md"
+
+
+def test_unknown_phase_raises() -> None:
+    with pytest.raises(ValueError, match="unknown phase"):
+        ap.artifact_path("bogus", "my-slug")
+
+
+@pytest.mark.parametrize(
+    "slug",
+    ["", "Bad", "-lead", "trail-", "dou--ble", "a" * 65, "has/slash", "has space"],
+)
+def test_invalid_slug_raises(slug: str) -> None:
+    with pytest.raises(ValueError, match="kebab-case"):
+        ap.artifact_path("cook", slug)
+
+
+@pytest.mark.parametrize("slug", ["a", "a" * 64, "a-b-c", "phase-1"])
+def test_valid_slug_accepted(slug: str) -> None:
+    assert ap.artifact_path("cook", slug) == Path(f".cheese/cook/{slug}.md")
+
+
+def test_corpus_root_uses_easy_cheese_home_verbatim(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # EASY_CHEESE_HOME is used as-is; unlike the XDG/home fallbacks it gets no
+    # trailing "cheese" component appended.
+    monkeypatch.setenv("EASY_CHEESE_HOME", str(tmp_path))
+    monkeypatch.setenv("EASY_CHEESE_PROJECT", "proj")
+    assert ap.project_corpus_root() == tmp_path / "proj"
+
+
+def test_corpus_home_falls_back_to_xdg_data_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("EASY_CHEESE_HOME", raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path))
+    monkeypatch.setenv("EASY_CHEESE_PROJECT", "proj")
+    assert ap.project_corpus_root() == tmp_path / "cheese" / "proj"
+
+
+def test_project_key_sanitizes_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("EASY_CHEESE_HOME", "/abs/home")
+    monkeypatch.setenv("EASY_CHEESE_PROJECT", "My Proj!")
+    assert ap.project_corpus_root() == Path("/abs/home/my-proj")
+
+
+def test_main_prints_resolved_path(capsys: pytest.CaptureFixture[str]) -> None:
+    assert ap.main(["cook", "my-slug"]) == 0
+    out = capsys.readouterr().out.strip()
+    assert out == str(Path(".cheese/cook/my-slug.md"))
+
+
+def test_main_reports_error_on_bad_slug(capsys: pytest.CaptureFixture[str]) -> None:
+    assert ap.main(["cook", "Bad"]) == 1
+    assert "error:" in capsys.readouterr().err
+
+
+def test_main_research_prints_corpus_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("EASY_CHEESE_HOME", str(tmp_path))
+    monkeypatch.setenv("EASY_CHEESE_PROJECT", "proj")
+    assert ap.main(["research", "ignored-slug"]) == 0
+    assert capsys.readouterr().out.strip() == str(tmp_path / "proj")


### PR DESCRIPTION
## Summary

Second slice extracted from the enforceable skill-boundary work (#476 plan / #478 full implementation). **Stacked on #479** (the package skeleton) — targets `feat/easy-cheese-runtime-package-skeleton`, not `main`.

Adds the stdlib-only leaf module that resolves durable and transient artifact paths for packaged skills. It's the foundation the later `cook`/`mold` command layers call.

- `src/easy_cheese/shared/artifact_path.py` — **byte-for-byte from #478** (blob `f6b6aee2`). Phase validation, kebab-case slug validation, `.cheese` vs XDG corpus routing, `hard`→`hard-cheese` directory remap, and a CLI `main()`.
- `tests/python/test_artifact_path.py` — **new** focused unit test. 478 covers this module only indirectly (through `test_bundle_commands.py`, which needs the whole command layer); this pins the leaf's own behavior: resolution, remapping, slug validation (valid + invalid boundary cases), corpus-root derivation from `EASY_CHEESE_HOME`/`XDG_DATA_HOME`/`EASY_CHEESE_PROJECT`, and CLI exit codes. Placed under `tests/python/` so the existing `pytest tests/python` gate runs it with no justfile change.

## Scope

One leaf module + its test. No schema, build, or bundle wiring; the module is not yet imported by any shipping code (that arrives with the command-layer slice) and is not yet added to the wheel/`.pyz` build.

## Verification

- `uvx ruff check src/easy_cheese/shared/artifact_path.py tests/python/test_artifact_path.py` — clean
- `python3 -m pytest tests/python/test_artifact_path.py -q` — 22 passed
- `python3 -m pytest tests/python -q` — 1268 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EY43r6yCnbPrkzrS5cBSZ4