### PR TITLE
feat(runtime): add shared bundle_commands registry

### DIFF
--- a/src/easy_cheese/shared/bundle_commands.py
+++ b/src/easy_cheese/shared/bundle_commands.py
@@ -1,0 +1,120 @@
+"""Declarative bundle command registration, dispatch, and guidance."""
+
+from __future__ import annotations
+
+import inspect
+import re
+import sys
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+_COMMAND_RE = re.compile(r"[a-z0-9][a-z0-9_-]*")
+_GUIDANCE_START = "<!-- GENERATED BUNDLE COMMANDS:START -->"
+_GUIDANCE_END = "<!-- GENERATED BUNDLE COMMANDS:END -->"
+CommandHandler = Callable[[list[str]], int]
+
+
+@dataclass(frozen=True)
+class BundleCommand:
+    name: str
+    function: CommandHandler
+    guidance: str
+
+
+_REGISTRY: dict[str, dict[str, BundleCommand]] = {}
+
+
+def bundle_command(name: str) -> Callable[[CommandHandler], CommandHandler]:
+    if not isinstance(name, str) or _COMMAND_RE.fullmatch(name) is None:
+        raise ValueError("invalid command name")
+
+    def decorate(function: CommandHandler) -> CommandHandler:
+        commands = _REGISTRY.setdefault(function.__module__, {})
+        if name in commands:
+            raise ValueError(f"duplicate bundle command: {name}")
+        commands[name] = BundleCommand(
+            name, function, inspect.getdoc(function) or ""
+        )
+        setattr(function, "__bundle_command__", name)
+        return function
+
+    return decorate
+
+
+def registered_commands(module: str) -> tuple[BundleCommand, ...]:
+    return tuple(
+        sorted(_REGISTRY.get(module, {}).values(), key=lambda command: command.name)
+    )
+
+
+def compile_bundle_commands(
+    module: str, *, referenced: set[str] | None = None
+) -> dict[str, str]:
+    commands = _REGISTRY.get(module, {})
+    if not commands:
+        raise ValueError(f"no bundle commands registered for {module}")
+    if referenced is not None:
+        unreferenced = set(commands) - referenced
+        missing = referenced - set(commands)
+        if unreferenced or missing:
+            raise ValueError(
+                f"command references differ: unreferenced={sorted(unreferenced)}, "
+                f"missing={sorted(missing)}"
+            )
+    return {
+        name: command.function.__name__
+        for name, command in sorted(commands.items())
+    }
+
+
+def dispatch(
+    module: str,
+    argv: Sequence[str],
+    *,
+    expected: dict[str, str] | None = None,
+) -> int:
+    mapping = compile_bundle_commands(module)
+    if expected is not None and mapping != expected:
+        raise RuntimeError("generated bundle command map is stale")
+    choices = "|".join(mapping)
+    if not argv or argv[0] in {"-h", "--help"}:
+        print(f"usage: <pyz> {{{choices}}} [args...]")
+        return 0 if argv else 2
+    name = argv[0]
+    command = _REGISTRY[module].get(name)
+    if command is None:
+        print(f"usage: <pyz> {{{choices}}} [args...]", file=sys.stderr)
+        return 2
+    result = command.function(list(argv[1:]))
+    if not isinstance(result, int):
+        raise TypeError(f"bundle command {name!r} did not return an integer status")
+    return result
+
+
+def guidance_source(module: str) -> str:
+    lines = [_GUIDANCE_START]
+    for command in registered_commands(module):
+        guidance = command.guidance.splitlines()[0] if command.guidance else ""
+        lines.append(f"- `{command.name}` — {guidance}")
+    lines.append(_GUIDANCE_END)
+    return "\n".join(lines)
+
+
+def validate_generated_region(text: str, module: str) -> None:
+    expected = guidance_source(module)
+    start = text.find(_GUIDANCE_START)
+    end = text.find(_GUIDANCE_END, start + len(_GUIDANCE_START))
+    actual = "" if start < 0 or end < 0 else text[start : end + len(_GUIDANCE_END)]
+    if actual != expected:
+        raise ValueError("generated command guidance drift")
+
+
+__all__ = [
+    "BundleCommand",
+    "bundle_command",
+    "compile_bundle_commands",
+    "dispatch",
+    "guidance_source",
+    "registered_commands",
+    "validate_generated_region",
+]

--- a/tests/python/test_bundle_commands.py
+++ b/tests/python/test_bundle_commands.py
@@ -1,0 +1,174 @@
+"""Behavioral contract for easy_cheese.shared.bundle_commands.
+
+Covers the declarative command registry in isolation: registration and its
+validation, sorted introspection, reference-checked compilation, dispatch exit
+codes and argument forwarding, and generated-guidance rendering plus drift
+detection. The registry is module-global mutable state, so every test runs
+against a snapshot restored on teardown and registers handlers under an
+explicit module key.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from easy_cheese.shared import bundle_commands as bc
+
+MODULE = "test_module"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry() -> Iterator[None]:
+    snapshot = {key: dict(value) for key, value in bc._REGISTRY.items()}
+    try:
+        yield
+    finally:
+        bc._REGISTRY.clear()
+        bc._REGISTRY.update(snapshot)
+
+
+def register(name: str, *, module: str = MODULE, ret: int | str = 0, doc: str | None = None):
+    calls: list[list[str]] = []
+
+    def handler(argv: list[str]):
+        calls.append(argv)
+        return ret
+
+    handler.__module__ = module
+    handler.__name__ = f"{name}_impl"
+    handler.__doc__ = doc
+    handler.calls = calls  # type: ignore[attr-defined]
+    return bc.bundle_command(name)(handler)
+
+
+def test_decorator_registers_and_marks_function() -> None:
+    handler = register("go")
+    assert handler.__bundle_command__ == "go"  # type: ignore[attr-defined]
+    assert [c.name for c in bc.registered_commands(MODULE)] == ["go"]
+
+
+@pytest.mark.parametrize("name", ["Bad", "", "-x", "_x", "a b", "camelCase"])
+def test_invalid_command_name_rejected(name: str) -> None:
+    with pytest.raises(ValueError, match="invalid command name"):
+        bc.bundle_command(name)
+
+
+def test_duplicate_command_rejected() -> None:
+    register("go")
+    with pytest.raises(ValueError, match="duplicate bundle command"):
+        register("go")
+
+
+def test_registered_commands_sorted_by_name() -> None:
+    register("beta")
+    register("alpha")
+    assert [c.name for c in bc.registered_commands(MODULE)] == ["alpha", "beta"]
+
+
+def test_compile_requires_registered_commands() -> None:
+    with pytest.raises(ValueError, match="no bundle commands registered"):
+        bc.compile_bundle_commands("no-such-module")
+
+
+def test_compile_maps_name_to_function_name() -> None:
+    register("a")
+    register("b")
+    assert bc.compile_bundle_commands(MODULE) == {"a": "a_impl", "b": "b_impl"}
+
+
+def test_compile_flags_unreferenced_and_missing() -> None:
+    register("a")
+    register("b")
+    with pytest.raises(ValueError, match=r"unreferenced=\['b'\], missing=\['c'\]"):
+        bc.compile_bundle_commands(MODULE, referenced={"a", "c"})
+
+
+def test_compile_accepts_exact_reference_set() -> None:
+    register("a")
+    register("b")
+    assert bc.compile_bundle_commands(MODULE, referenced={"a", "b"}) == {
+        "a": "a_impl",
+        "b": "b_impl",
+    }
+
+
+def test_dispatch_invokes_handler_and_forwards_args() -> None:
+    handler = register("go", ret=7)
+    assert bc.dispatch(MODULE, ["go", "x", "y"]) == 7
+    assert handler.calls == [["x", "y"]]  # type: ignore[attr-defined]
+
+
+def test_dispatch_empty_argv_prints_usage_and_returns_2(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    register("go")
+    assert bc.dispatch(MODULE, []) == 2
+    assert "usage: <pyz> {go}" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("flag", ["-h", "--help"])
+def test_dispatch_help_returns_0(flag: str, capsys: pytest.CaptureFixture[str]) -> None:
+    register("go")
+    assert bc.dispatch(MODULE, [flag]) == 0
+    assert "usage:" in capsys.readouterr().out
+
+
+def test_dispatch_unknown_command_returns_2_to_stderr(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    register("go")
+    assert bc.dispatch(MODULE, ["nope"]) == 2
+    assert "usage:" in capsys.readouterr().err
+
+
+def test_dispatch_detects_stale_expected_map() -> None:
+    register("go")
+    with pytest.raises(RuntimeError, match="stale"):
+        bc.dispatch(MODULE, ["go"], expected={"go": "wrong_impl"})
+
+
+def test_dispatch_accepts_matching_expected_map() -> None:
+    register("go", ret=0)
+    assert bc.dispatch(MODULE, ["go"], expected={"go": "go_impl"}) == 0
+
+
+def test_dispatch_rejects_non_integer_status() -> None:
+    register("go", ret="oops")
+    with pytest.raises(TypeError, match="did not return an integer status"):
+        bc.dispatch(MODULE, ["go"])
+
+
+def test_guidance_source_renders_first_docline_sorted() -> None:
+    register("beta", doc="Second command.\nignored detail.")
+    register("alpha", doc="First command.")
+    assert bc.guidance_source(MODULE) == (
+        "<!-- GENERATED BUNDLE COMMANDS:START -->\n"
+        "- `alpha` — First command.\n"
+        "- `beta` — Second command.\n"
+        "<!-- GENERATED BUNDLE COMMANDS:END -->"
+    )
+
+
+def test_validate_generated_region_accepts_current_block() -> None:
+    register("go", doc="Do the thing.")
+    text = f"prefix\n{bc.guidance_source(MODULE)}\nsuffix"
+    bc.validate_generated_region(text, MODULE)
+
+
+def test_validate_generated_region_flags_drift() -> None:
+    register("go", doc="Do the thing.")
+    stale = (
+        "<!-- GENERATED BUNDLE COMMANDS:START -->\n"
+        "- `go` — Stale description.\n"
+        "<!-- GENERATED BUNDLE COMMANDS:END -->"
+    )
+    with pytest.raises(ValueError, match="generated command guidance drift"):
+        bc.validate_generated_region(stale, MODULE)
+
+
+def test_validate_generated_region_flags_missing_block() -> None:
+    register("go", doc="Do the thing.")
+    with pytest.raises(ValueError, match="generated command guidance drift"):
+        bc.validate_generated_region("no markers here", MODULE)


### PR DESCRIPTION
## Summary

Third slice extracted from the enforceable skill-boundary work (#476 plan / #478 full implementation). **Stacked on #483** (artifact_path) — targets `feat/easy-cheese-artifact-path`, not `main`.

Adds the stdlib-only declarative bundle-command registry that the later `cook`/`mold` command layers register against and dispatch through.

- `src/easy_cheese/shared/bundle_commands.py` — **byte-for-byte from #478** (blob `89c0dba7`). The `@bundle_command` decorator + name validation, sorted introspection, reference-checked `compile_bundle_commands`, `dispatch` with its exit-code contract and argv forwarding, and `guidance_source`/`validate_generated_region` for the generated command-guidance region.
- `tests/python/test_bundle_commands.py` — **new** focused unit test (25 cases). 478's `test_bundle_commands.py` exercises this module only through the cook/mold command modules; this pins the registry directly, isolating the module-global `_REGISTRY` per test via a snapshot/restore fixture. Under `tests/python/` so the existing `pytest tests/python` gate runs it with no justfile change.

## Scope

One leaf module + its test. No schema, build, or bundle wiring; nothing imports the module yet (the command layer does, in a later slice) and it is not yet added to the wheel/`.pyz` build.

## Verification

- `uvx ruff check src/easy_cheese/shared/bundle_commands.py tests/python/test_bundle_commands.py` — clean
- `python3 -m pytest tests/python/test_bundle_commands.py -q` — 25 passed
- `python3 -m pytest tests/python -q` — 1293 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EY43r6yCnbPrkzrS5cBSZ4