### PR TITLE
feat(runtime): add bundle closure resolver

### DIFF
--- a/src/easy_cheese/shared/bundles.py
+++ b/src/easy_cheese/shared/bundles.py
@@ -11,8 +11,6 @@ _PACKAGE_NAME = "easy_cheese"
 _SCHEMAS_PACKAGE_NAME = "easy_cheese_schemas"
 _SKILLS_NAMESPACE = f"{_PACKAGE_NAME}.skills"
 _SKILLS_PREFIX = f"{_SKILLS_NAMESPACE}."
-_INIT_MODULE_NAME = "__init__"
-_INIT_NAME = f"{_INIT_MODULE_NAME}.py"
 _NATIVE_SUFFIXES = {".so", ".pyd", ".dylib"}
 _ALLOWED_UNBUNDLED_EXTERNAL_ROOTS = {
     "attr",
@@ -20,6 +18,7 @@ _ALLOWED_UNBUNDLED_EXTERNAL_ROOTS = {
     "cattrs",
     "typing_extensions",
 }
+# Bare names remain while schema sources retain common.pyz fallback imports.
 _GENERATED_MODULES = {
     "_compiled_phase_registry",
     "_schema_catalog",
@@ -30,35 +29,19 @@ _INTERNAL_ROOTS = frozenset({_PACKAGE_NAME, _SCHEMAS_PACKAGE_NAME})
 _STDLIB_MODULES = sys.stdlib_module_names
 
 
-def _package_root(root: Path) -> Path:
-    candidate = root / "src" / _PACKAGE_NAME
-    return candidate if candidate.exists() else root
-
-
 def _module_name(path: Path, source_root: Path) -> str:
-    parts = path.relative_to(source_root).with_suffix("").parts
-    if parts[-1] == _INIT_MODULE_NAME:
-        parts = parts[:-1]
-    return ".".join(parts)
+    return ".".join(path.relative_to(source_root).with_suffix("").parts)
 
 
-def _modules(root: Path, shared_root: Path | None = None) -> dict[str, Path]:
-    source_root = root.parent
+def _modules(source_root: Path) -> dict[str, Path]:
     modules: dict[str, Path] = {}
-    for package in (root, source_root / _SCHEMAS_PACKAGE_NAME):
-        if not package.exists():
+    for package_name in (_PACKAGE_NAME, _SCHEMAS_PACKAGE_NAME):
+        package = source_root / package_name
+        if not package.is_dir():
             continue
         for path in package.rglob("*.py"):
-            if path.name == _INIT_NAME:
-                continue
-            modules[_module_name(path, source_root)] = path
-            if package.name == _SCHEMAS_PACKAGE_NAME and path.parent == package:
-                # Source-checkout helpers have flat fallback imports. Resolve
-                # those aliases to packaged modules instead of vendoring copies.
-                modules.setdefault(path.stem, path)
-    if shared_root is not None and shared_root.is_dir():
-        for path in shared_root.glob("*.py"):
-            modules[path.stem] = path
+            if path.name != "__init__.py":
+                modules[_module_name(path, source_root)] = path
     return modules
 
 
@@ -87,12 +70,9 @@ def _import_names(path: Path, module: str) -> tuple[str, ...]:
 
 
 class _ClosureResolver:
-    def __init__(
-        self, root: Path, skill: str, shared_root: Path | None, entrypoint: Path
-    ) -> None:
-        self._root = root
-        self._shared_root = shared_root
-        self._modules = _modules(root, shared_root)
+    def __init__(self, source_root: Path, skill: str, entrypoint: Path) -> None:
+        self._source_root = source_root
+        self._modules = _modules(source_root)
         self._pending = [entrypoint]
         self._included: set[Path] = set()
         self._owner_namespace = f"{_SKILLS_NAMESPACE}.{skill}"
@@ -104,15 +84,11 @@ class _ClosureResolver:
             if path in self._included:
                 continue
             self._included.add(path)
-            module = self._module_name(path)
+            module = _module_name(path, self._source_root)
             for name in _import_names(path, module):
                 self._classify_import(path, name)
         return tuple(sorted(self._included))
 
-    def _module_name(self, path: Path) -> str:
-        if self._shared_root is not None and path.parent == self._shared_root:
-            return path.stem
-        return _module_name(path, self._root.parent)
 
     def _classify_import(self, path: Path, name: str) -> None:
         if self._is_cross_skill_import(name):
@@ -135,8 +111,7 @@ class _ClosureResolver:
             raise ValueError(f"unresolved internal dependency: {name}")
         stem = name.rsplit(".", 1)[-1]
         if any(
-            (path.parent / f"{stem}{suffix}").exists()
-            for suffix in _NATIVE_SUFFIXES
+            (path.parent / f"{stem}{suffix}").exists() for suffix in _NATIVE_SUFFIXES
         ):
             raise ValueError(f"native ambient dependency in bundle: {name}")
         raise ValueError(f"ambient dependency in bundle: {name}")
@@ -147,17 +122,10 @@ class _ClosureResolver:
         )
 
 
-def minimal_closure(
-    skill: str, root: Path, shared_root: Path | None = None
-) -> tuple[Path, ...]:
+def _resolve_bundle_sources(skill: str, source_root: Path) -> tuple[Path, ...]:
     """Resolve one skill's reachable internal pure-Python modules."""
-    root = _package_root(root)
-    entrypoint = root / "skills" / skill / "commands.py"
+    package_root = source_root / _PACKAGE_NAME
+    entrypoint = package_root / "skills" / skill / "commands.py"
     if not entrypoint.is_file():
         raise ValueError(f"unknown Python skill: {skill}")
-    return _ClosureResolver(root, skill, shared_root, entrypoint).resolve()
-
-
-__all__ = [
-    "minimal_closure",
-]
+    return _ClosureResolver(source_root, skill, entrypoint).resolve()

--- a/src/easy_cheese/shared/bundles.py
+++ b/src/easy_cheese/shared/bundles.py
@@ -1,4 +1,4 @@
-"""Layout-derived bundle closure validation."""
+"""Find the pure-Python sources one skill archive must contain."""
 
 from __future__ import annotations
 
@@ -29,26 +29,51 @@ _INTERNAL_ROOTS = frozenset({_PACKAGE_NAME, _SCHEMAS_PACKAGE_NAME})
 _STDLIB_MODULES = sys.stdlib_module_names
 
 
-def _module_name(path: Path, source_root: Path) -> str:
-    return ".".join(path.relative_to(source_root).with_suffix("").parts)
+# Build the index only from canonical source packages; never consult sys.path.
+class _SourceModules:
+    def __init__(self, source_root: Path) -> None:
+        self._source_root = source_root
+        self._paths = self._index()
 
+    def module_name(self, path: Path) -> str:
+        return ".".join(path.relative_to(self._source_root).with_suffix("").parts)
 
-def _modules(source_root: Path) -> dict[str, Path]:
-    modules: dict[str, Path] = {}
-    for package_name in (_PACKAGE_NAME, _SCHEMAS_PACKAGE_NAME):
-        package = source_root / package_name
-        if not package.is_dir():
-            continue
-        for path in package.rglob("*.py"):
-            if path.name != "__init__.py":
-                modules[_module_name(path, source_root)] = path
-    return modules
+    def source_for(self, module: str) -> Path | None:
+        return self._paths.get(module)
+
+    def contains(self, module: str) -> bool:
+        return module in self._paths
+
+    def has_descendant(self, package: str) -> bool:
+        prefix = f"{package}."
+        return any(module.startswith(prefix) for module in self._paths)
+
+    @staticmethod
+    def has_adjacent_native(importer: Path, module: str) -> bool:
+        stem = module.rsplit(".", 1)[-1]
+        return any(
+            (importer.parent / f"{stem}{suffix}").exists()
+            for suffix in _NATIVE_SUFFIXES
+        )
+
+    def _index(self) -> dict[str, Path]:
+        paths: dict[str, Path] = {}
+        for package_name in (_PACKAGE_NAME, _SCHEMAS_PACKAGE_NAME):
+            package = self._source_root / package_name
+            if not package.is_dir():
+                continue
+            for path in package.rglob("*.py"):
+                # The archive builder stages package initializers separately.
+                if path.name != "__init__.py":
+                    paths[self.module_name(path)] = path
+        return paths
 
 
 def _import_names(path: Path, module: str) -> tuple[str, ...]:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     package = module.rpartition(".")[0]
     names: list[str] = []
+    # Walk nested scopes so deferred imports are bundled without executing the module.
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             names.extend(alias.name for alias in node.names)
@@ -69,50 +94,32 @@ def _import_names(path: Path, module: str) -> tuple[str, ...]:
     return tuple(names)
 
 
-class _ClosureResolver:
-    def __init__(self, source_root: Path, skill: str, entrypoint: Path) -> None:
-        self._source_root = source_root
-        self._modules = _modules(source_root)
-        self._pending = [entrypoint]
-        self._included: set[Path] = set()
+class _ImportPolicy:
+    def __init__(self, skill: str, sources: _SourceModules) -> None:
+        self._sources = sources
         self._owner_namespace = f"{_SKILLS_NAMESPACE}.{skill}"
         self._owner_prefix = f"{self._owner_namespace}."
 
-    def resolve(self) -> tuple[Path, ...]:
-        while self._pending:
-            path = self._pending.pop()
-            if path in self._included:
-                continue
-            self._included.add(path)
-            module = _module_name(path, self._source_root)
-            for name in _import_names(path, module):
-                self._classify_import(path, name)
-        return tuple(sorted(self._included))
-
-
-    def _classify_import(self, path: Path, name: str) -> None:
+    def dependency_source(self, importer: Path, name: str) -> Path | None:
+        # Ownership wins over lookup so another skill cannot enter this closure.
         if self._is_cross_skill_import(name):
             raise ValueError(f"cross-skill import in bundle: {name}")
-        candidate = self._modules.get(name)
-        if candidate is not None:
-            self._pending.append(candidate)
-            return
+        if candidate := self._sources.source_for(name):
+            return candidate
         parent = name.rpartition(".")[0]
-        if parent in self._modules or parent in _GENERATED_MODULES:
-            return
+        if self._sources.contains(parent) or parent in _GENERATED_MODULES:
+            return None
         root_name = name.split(".", 1)[0]
         if name in _GENERATED_MODULES or root_name in _STDLIB_MODULES:
-            return
+            return None
         if root_name in _ALLOWED_UNBUNDLED_EXTERNAL_ROOTS:
-            return
+            return None
         if root_name in _INTERNAL_ROOTS:
-            if any(module_name.startswith(name + ".") for module_name in self._modules):
-                return
+            # Package imports have descendants but no indexed initializer source.
+            if self._sources.has_descendant(name):
+                return None
             raise ValueError(f"unresolved internal dependency: {name}")
-        stem = name.rsplit(".", 1)[-1]
-        if any(
-            (path.parent / f"{stem}{suffix}").exists() for suffix in _NATIVE_SUFFIXES
-        ):
+        if self._sources.has_adjacent_native(importer, name):
             raise ValueError(f"native ambient dependency in bundle: {name}")
         raise ValueError(f"ambient dependency in bundle: {name}")
 
@@ -122,10 +129,38 @@ class _ClosureResolver:
         )
 
 
+class _ClosureResolver:
+    def __init__(
+        self,
+        sources: _SourceModules,
+        policy: _ImportPolicy,
+        entrypoint: Path,
+    ) -> None:
+        self._sources = sources
+        self._policy = policy
+        self._pending = [entrypoint]
+        self._included: set[Path] = set()
+
+    def resolve(self) -> tuple[Path, ...]:
+        while self._pending:
+            path = self._pending.pop()
+            if path in self._included:
+                continue
+            self._included.add(path)
+            module = self._sources.module_name(path)
+            for name in _import_names(path, module):
+                dependency = self._policy.dependency_source(path, name)
+                if dependency is not None:
+                    self._pending.append(dependency)
+        return tuple(sorted(self._included))
+
+
 def _resolve_bundle_sources(skill: str, source_root: Path) -> tuple[Path, ...]:
     """Resolve one skill's reachable internal pure-Python modules."""
     package_root = source_root / _PACKAGE_NAME
     entrypoint = package_root / "skills" / skill / "commands.py"
     if not entrypoint.is_file():
         raise ValueError(f"unknown Python skill: {skill}")
-    return _ClosureResolver(source_root, skill, entrypoint).resolve()
+    sources = _SourceModules(source_root)
+    policy = _ImportPolicy(skill, sources)
+    return _ClosureResolver(sources, policy, entrypoint).resolve()

--- a/src/easy_cheese/shared/bundles.py
+++ b/src/easy_cheese/shared/bundles.py
@@ -1,0 +1,138 @@
+"""Layout-derived bundle closure validation."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+_NATIVE_SUFFIXES = {".so", ".pyd", ".dylib"}
+_PURE_EXTERNALS = {"attr", "attrs", "cattrs", "typing_extensions"}
+_GENERATED_MODULES = {
+    "_compiled_phase_registry",
+    "_schema_catalog",
+    "easy_cheese_schemas._compiled_phase_registry",
+    "easy_cheese_schemas._schema_catalog",
+}
+
+
+def _package_root(root: Path) -> Path:
+    candidate = root / "src" / "easy_cheese"
+    return candidate if candidate.exists() else root
+
+
+def bundle_name(skill: str) -> str:
+    if not skill or "/" in skill or "\\" in skill:
+        raise ValueError("invalid skill name")
+    return f"{skill}.pyz"
+
+
+def _module_name(path: Path, source_root: Path) -> str:
+    parts = path.relative_to(source_root).with_suffix("").parts
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _modules(root: Path, shared_root: Path | None = None) -> dict[str, Path]:
+    source_root = root.parent
+    modules: dict[str, Path] = {}
+    for package in (root, source_root / "easy_cheese_schemas"):
+        if not package.exists():
+            continue
+        for path in package.rglob("*.py"):
+            if path.name == "__init__.py":
+                continue
+            modules[_module_name(path, source_root)] = path
+            if package.name == "easy_cheese_schemas" and path.parent == package:
+                # Source-checkout helpers have flat fallback imports. Resolve
+                # those aliases to packaged modules instead of vendoring copies.
+                modules.setdefault(path.stem, path)
+    if shared_root is not None and shared_root.is_dir():
+        for path in shared_root.glob("*.py"):
+            modules[path.stem] = path
+    return modules
+
+
+def _import_names(tree: ast.AST, module: str) -> tuple[str, ...]:
+    package = module.rpartition(".")[0]
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+            continue
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if node.level:
+            target = "." * node.level + (node.module or "")
+            try:
+                imported = importlib.util.resolve_name(target, package)
+            except (ImportError, ValueError) as exc:
+                raise ValueError(f"invalid relative import in {module}") from exc
+        else:
+            imported = node.module or ""
+        if imported:
+            names.append(imported)
+            names.extend(f"{imported}.{alias.name}" for alias in node.names)
+    return tuple(names)
+
+
+def minimal_closure(
+    skill: str, root: Path, shared_root: Path | None = None
+) -> tuple[Path, ...]:
+    """Resolve one skill's reachable internal pure-Python modules."""
+    root = _package_root(root)
+    entrypoint = root / "skills" / skill / "commands.py"
+    if not entrypoint.is_file():
+        raise ValueError(f"unknown Python skill: {skill}")
+    modules = _modules(root, shared_root)
+    pending = [entrypoint]
+    included: set[Path] = set()
+    while pending:
+        path = pending.pop()
+        if path in included:
+            continue
+        if path.suffix in _NATIVE_SUFFIXES:
+            raise ValueError(f"native module in bundle: {path.name}")
+        included.add(path)
+        if shared_root is not None and path.parent == shared_root:
+            module = path.stem
+        else:
+            module = _module_name(path, root.parent)
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for name in _import_names(tree, module):
+            if name.startswith("easy_cheese.skills.") and not name.startswith(
+                f"easy_cheese.skills.{skill}"
+            ):
+                raise ValueError(f"cross-skill import in bundle: {name}")
+            candidate = modules.get(name)
+            if candidate is not None:
+                pending.append(candidate)
+                continue
+            parent = name.rpartition(".")[0]
+            if parent in modules or parent in _GENERATED_MODULES:
+                continue
+            root_name = name.split(".", 1)[0]
+            if name in _GENERATED_MODULES or root_name in sys.stdlib_module_names:
+                continue
+            if root_name in _PURE_EXTERNALS:
+                continue
+            if root_name in {"easy_cheese", "easy_cheese_schemas"}:
+                if any(module_name.startswith(name + ".") for module_name in modules):
+                    continue
+                raise ValueError(f"unresolved internal dependency: {name}")
+            stem = name.rsplit(".", 1)[-1]
+            if any(
+                (path.parent / f"{stem}{suffix}").exists()
+                for suffix in _NATIVE_SUFFIXES
+            ):
+                raise ValueError(f"native ambient dependency in bundle: {name}")
+            raise ValueError(f"ambient dependency in bundle: {name}")
+    return tuple(sorted(included))
+
+
+__all__ = [
+    "bundle_name",
+    "minimal_closure",
+]

--- a/src/easy_cheese/shared/bundles.py
+++ b/src/easy_cheese/shared/bundles.py
@@ -7,30 +7,37 @@ import importlib.util
 import sys
 from pathlib import Path
 
+_PACKAGE_NAME = "easy_cheese"
+_SCHEMAS_PACKAGE_NAME = "easy_cheese_schemas"
+_SKILLS_NAMESPACE = f"{_PACKAGE_NAME}.skills"
+_SKILLS_PREFIX = f"{_SKILLS_NAMESPACE}."
+_INIT_MODULE_NAME = "__init__"
+_INIT_NAME = f"{_INIT_MODULE_NAME}.py"
 _NATIVE_SUFFIXES = {".so", ".pyd", ".dylib"}
-_PURE_EXTERNALS = {"attr", "attrs", "cattrs", "typing_extensions"}
+_ALLOWED_UNBUNDLED_EXTERNAL_ROOTS = {
+    "attr",
+    "attrs",
+    "cattrs",
+    "typing_extensions",
+}
 _GENERATED_MODULES = {
     "_compiled_phase_registry",
     "_schema_catalog",
-    "easy_cheese_schemas._compiled_phase_registry",
-    "easy_cheese_schemas._schema_catalog",
+    f"{_SCHEMAS_PACKAGE_NAME}._compiled_phase_registry",
+    f"{_SCHEMAS_PACKAGE_NAME}._schema_catalog",
 }
+_INTERNAL_ROOTS = frozenset({_PACKAGE_NAME, _SCHEMAS_PACKAGE_NAME})
+_STDLIB_MODULES = sys.stdlib_module_names
 
 
 def _package_root(root: Path) -> Path:
-    candidate = root / "src" / "easy_cheese"
+    candidate = root / "src" / _PACKAGE_NAME
     return candidate if candidate.exists() else root
-
-
-def bundle_name(skill: str) -> str:
-    if not skill or "/" in skill or "\\" in skill:
-        raise ValueError("invalid skill name")
-    return f"{skill}.pyz"
 
 
 def _module_name(path: Path, source_root: Path) -> str:
     parts = path.relative_to(source_root).with_suffix("").parts
-    if parts[-1] == "__init__":
+    if parts[-1] == _INIT_MODULE_NAME:
         parts = parts[:-1]
     return ".".join(parts)
 
@@ -38,14 +45,14 @@ def _module_name(path: Path, source_root: Path) -> str:
 def _modules(root: Path, shared_root: Path | None = None) -> dict[str, Path]:
     source_root = root.parent
     modules: dict[str, Path] = {}
-    for package in (root, source_root / "easy_cheese_schemas"):
+    for package in (root, source_root / _SCHEMAS_PACKAGE_NAME):
         if not package.exists():
             continue
         for path in package.rglob("*.py"):
-            if path.name == "__init__.py":
+            if path.name == _INIT_NAME:
                 continue
             modules[_module_name(path, source_root)] = path
-            if package.name == "easy_cheese_schemas" and path.parent == package:
+            if package.name == _SCHEMAS_PACKAGE_NAME and path.parent == package:
                 # Source-checkout helpers have flat fallback imports. Resolve
                 # those aliases to packaged modules instead of vendoring copies.
                 modules.setdefault(path.stem, path)
@@ -55,7 +62,8 @@ def _modules(root: Path, shared_root: Path | None = None) -> dict[str, Path]:
     return modules
 
 
-def _import_names(tree: ast.AST, module: str) -> tuple[str, ...]:
+def _import_names(path: Path, module: str) -> tuple[str, ...]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     package = module.rpartition(".")[0]
     names: list[str] = []
     for node in ast.walk(tree):
@@ -78,6 +86,67 @@ def _import_names(tree: ast.AST, module: str) -> tuple[str, ...]:
     return tuple(names)
 
 
+class _ClosureResolver:
+    def __init__(
+        self, root: Path, skill: str, shared_root: Path | None, entrypoint: Path
+    ) -> None:
+        self._root = root
+        self._shared_root = shared_root
+        self._modules = _modules(root, shared_root)
+        self._pending = [entrypoint]
+        self._included: set[Path] = set()
+        self._owner_namespace = f"{_SKILLS_NAMESPACE}.{skill}"
+        self._owner_prefix = f"{self._owner_namespace}."
+
+    def resolve(self) -> tuple[Path, ...]:
+        while self._pending:
+            path = self._pending.pop()
+            if path in self._included:
+                continue
+            self._included.add(path)
+            module = self._module_name(path)
+            for name in _import_names(path, module):
+                self._classify_import(path, name)
+        return tuple(sorted(self._included))
+
+    def _module_name(self, path: Path) -> str:
+        if self._shared_root is not None and path.parent == self._shared_root:
+            return path.stem
+        return _module_name(path, self._root.parent)
+
+    def _classify_import(self, path: Path, name: str) -> None:
+        if self._is_cross_skill_import(name):
+            raise ValueError(f"cross-skill import in bundle: {name}")
+        candidate = self._modules.get(name)
+        if candidate is not None:
+            self._pending.append(candidate)
+            return
+        parent = name.rpartition(".")[0]
+        if parent in self._modules or parent in _GENERATED_MODULES:
+            return
+        root_name = name.split(".", 1)[0]
+        if name in _GENERATED_MODULES or root_name in _STDLIB_MODULES:
+            return
+        if root_name in _ALLOWED_UNBUNDLED_EXTERNAL_ROOTS:
+            return
+        if root_name in _INTERNAL_ROOTS:
+            if any(module_name.startswith(name + ".") for module_name in self._modules):
+                return
+            raise ValueError(f"unresolved internal dependency: {name}")
+        stem = name.rsplit(".", 1)[-1]
+        if any(
+            (path.parent / f"{stem}{suffix}").exists()
+            for suffix in _NATIVE_SUFFIXES
+        ):
+            raise ValueError(f"native ambient dependency in bundle: {name}")
+        raise ValueError(f"ambient dependency in bundle: {name}")
+
+    def _is_cross_skill_import(self, name: str) -> bool:
+        return name.startswith(_SKILLS_PREFIX) and not (
+            name == self._owner_namespace or name.startswith(self._owner_prefix)
+        )
+
+
 def minimal_closure(
     skill: str, root: Path, shared_root: Path | None = None
 ) -> tuple[Path, ...]:
@@ -86,53 +155,9 @@ def minimal_closure(
     entrypoint = root / "skills" / skill / "commands.py"
     if not entrypoint.is_file():
         raise ValueError(f"unknown Python skill: {skill}")
-    modules = _modules(root, shared_root)
-    pending = [entrypoint]
-    included: set[Path] = set()
-    while pending:
-        path = pending.pop()
-        if path in included:
-            continue
-        if path.suffix in _NATIVE_SUFFIXES:
-            raise ValueError(f"native module in bundle: {path.name}")
-        included.add(path)
-        if shared_root is not None and path.parent == shared_root:
-            module = path.stem
-        else:
-            module = _module_name(path, root.parent)
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-        for name in _import_names(tree, module):
-            if name.startswith("easy_cheese.skills.") and not name.startswith(
-                f"easy_cheese.skills.{skill}"
-            ):
-                raise ValueError(f"cross-skill import in bundle: {name}")
-            candidate = modules.get(name)
-            if candidate is not None:
-                pending.append(candidate)
-                continue
-            parent = name.rpartition(".")[0]
-            if parent in modules or parent in _GENERATED_MODULES:
-                continue
-            root_name = name.split(".", 1)[0]
-            if name in _GENERATED_MODULES or root_name in sys.stdlib_module_names:
-                continue
-            if root_name in _PURE_EXTERNALS:
-                continue
-            if root_name in {"easy_cheese", "easy_cheese_schemas"}:
-                if any(module_name.startswith(name + ".") for module_name in modules):
-                    continue
-                raise ValueError(f"unresolved internal dependency: {name}")
-            stem = name.rsplit(".", 1)[-1]
-            if any(
-                (path.parent / f"{stem}{suffix}").exists()
-                for suffix in _NATIVE_SUFFIXES
-            ):
-                raise ValueError(f"native ambient dependency in bundle: {name}")
-            raise ValueError(f"ambient dependency in bundle: {name}")
-    return tuple(sorted(included))
+    return _ClosureResolver(root, skill, shared_root, entrypoint).resolve()
 
 
 __all__ = [
-    "bundle_name",
     "minimal_closure",
 ]

--- a/tests/python/test_bundles.py
+++ b/tests/python/test_bundles.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from easy_cheese.shared.bundles import bundle_name, minimal_closure
+from easy_cheese.shared.bundles import minimal_closure
 
 
 def _package(tmp_path: Path, commands: str, *, helper: str | None = None) -> Path:
@@ -17,13 +17,6 @@ def _package(tmp_path: Path, commands: str, *, helper: str | None = None) -> Pat
     if helper is not None:
         (skill / "helper.py").write_text(helper, encoding="utf-8")
     return root
-
-
-def test_bundle_name_is_owned_by_one_skill() -> None:
-    assert bundle_name("mold") == "mold.pyz"
-    for invalid in ("", "mold/cook", "mold\\cook"):
-        with pytest.raises(ValueError, match="invalid skill name"):
-            bundle_name(invalid)
 
 
 def test_minimal_closure_includes_deferred_same_skill_import(tmp_path: Path) -> None:
@@ -52,6 +45,17 @@ def test_minimal_closure_includes_flat_shared_import(tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.parametrize("module", ("json", "attrs", "_schema_catalog"))
+def test_minimal_closure_allows_unbundled_dependencies(
+    tmp_path: Path, module: str
+) -> None:
+    root = _package(tmp_path, f"import {module}\n")
+
+    assert minimal_closure("mold", root) == (
+        root / "skills" / "mold" / "commands.py",
+    )
+
+
 def test_minimal_closure_rejects_cross_skill_import(tmp_path: Path) -> None:
     root = _package(tmp_path, "from easy_cheese.skills.cook import commands\n")
     cook = root / "skills" / "cook"
@@ -59,6 +63,33 @@ def test_minimal_closure_rejects_cross_skill_import(tmp_path: Path) -> None:
     (cook / "commands.py").write_text("", encoding="utf-8")
 
     with pytest.raises(ValueError, match="cross-skill import"):
+        minimal_closure("mold", root)
+
+
+def test_minimal_closure_rejects_skill_name_prefix_collision(
+    tmp_path: Path,
+) -> None:
+    root = _package(
+        tmp_path,
+        "from easy_cheese.skills.moldy import commands\n",
+    )
+    sibling = root / "skills" / "moldy"
+    sibling.mkdir()
+    (sibling / "commands.py").write_text("", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="cross-skill import"):
+        minimal_closure("mold", root)
+
+
+def test_minimal_closure_rejects_unresolved_internal_dependency(
+    tmp_path: Path,
+) -> None:
+    root = _package(tmp_path, "import easy_cheese.missing\n")
+
+    with pytest.raises(
+        ValueError,
+        match=r"unresolved internal dependency: easy_cheese\.missing",
+    ):
         minimal_closure("mold", root)
 
 

--- a/tests/python/test_bundles.py
+++ b/tests/python/test_bundles.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from easy_cheese.shared.bundles import bundle_name, minimal_closure
+
+
+def _package(tmp_path: Path, commands: str, *, helper: str | None = None) -> Path:
+    root = tmp_path / "src" / "easy_cheese"
+    skill = root / "skills" / "mold"
+    skill.mkdir(parents=True)
+    for package in (root, root / "skills", skill):
+        (package / "__init__.py").write_text("", encoding="utf-8")
+    (skill / "commands.py").write_text(commands, encoding="utf-8")
+    if helper is not None:
+        (skill / "helper.py").write_text(helper, encoding="utf-8")
+    return root
+
+
+def test_bundle_name_is_owned_by_one_skill() -> None:
+    assert bundle_name("mold") == "mold.pyz"
+    for invalid in ("", "mold/cook", "mold\\cook"):
+        with pytest.raises(ValueError, match="invalid skill name"):
+            bundle_name(invalid)
+
+
+def test_minimal_closure_includes_deferred_same_skill_import(tmp_path: Path) -> None:
+    root = _package(
+        tmp_path,
+        "def run():\n    from easy_cheese.skills.mold import helper\n    return helper.VALUE\n",
+        helper="VALUE = 1\n",
+    )
+
+    assert minimal_closure("mold", root) == (
+        root / "skills" / "mold" / "commands.py",
+        root / "skills" / "mold" / "helper.py",
+    )
+
+
+def test_minimal_closure_includes_flat_shared_import(tmp_path: Path) -> None:
+    root = _package(tmp_path, "import paths\n")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    helper = shared / "paths.py"
+    helper.write_text("VALUE = 1\n", encoding="utf-8")
+
+    assert minimal_closure("mold", root, shared) == (
+        helper,
+        root / "skills" / "mold" / "commands.py",
+    )
+
+
+def test_minimal_closure_rejects_cross_skill_import(tmp_path: Path) -> None:
+    root = _package(tmp_path, "from easy_cheese.skills.cook import commands\n")
+    cook = root / "skills" / "cook"
+    cook.mkdir()
+    (cook / "commands.py").write_text("", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="cross-skill import"):
+        minimal_closure("mold", root)
+
+
+def test_minimal_closure_rejects_ambient_and_native_dependencies(
+    tmp_path: Path,
+) -> None:
+    root = _package(tmp_path, "import requests\n")
+    with pytest.raises(ValueError, match="ambient dependency"):
+        minimal_closure("mold", root)
+
+    commands = root / "skills" / "mold" / "commands.py"
+    commands.write_text("import native\n", encoding="utf-8")
+    commands.with_name("native.so").write_bytes(b"native")
+    with pytest.raises(ValueError, match="native ambient dependency"):
+        minimal_closure("mold", root)

--- a/tests/python/test_bundles.py
+++ b/tests/python/test_bundles.py
@@ -4,104 +4,148 @@ from pathlib import Path
 
 import pytest
 
-from easy_cheese.shared.bundles import minimal_closure
+from easy_cheese.shared.bundles import _resolve_bundle_sources
 
 
-def _package(tmp_path: Path, commands: str, *, helper: str | None = None) -> Path:
-    root = tmp_path / "src" / "easy_cheese"
-    skill = root / "skills" / "mold"
+def _source_tree(tmp_path: Path, commands: str, *, helper: str | None = None) -> Path:
+    source_root = tmp_path / "src"
+    package_root = source_root / "easy_cheese"
+    skill = package_root / "skills" / "mold"
     skill.mkdir(parents=True)
-    for package in (root, root / "skills", skill):
+    for package in (package_root, package_root / "skills", skill):
         (package / "__init__.py").write_text("", encoding="utf-8")
     (skill / "commands.py").write_text(commands, encoding="utf-8")
     if helper is not None:
         (skill / "helper.py").write_text(helper, encoding="utf-8")
-    return root
+    return source_root
 
 
-def test_minimal_closure_includes_deferred_same_skill_import(tmp_path: Path) -> None:
-    root = _package(
+def test_resolve_bundle_sources_includes_deferred_same_skill_import(
+    tmp_path: Path,
+) -> None:
+    source_root = _source_tree(
         tmp_path,
         "def run():\n    from easy_cheese.skills.mold import helper\n    return helper.VALUE\n",
         helper="VALUE = 1\n",
     )
+    package_root = source_root / "easy_cheese"
 
-    assert minimal_closure("mold", root) == (
-        root / "skills" / "mold" / "commands.py",
-        root / "skills" / "mold" / "helper.py",
+    assert _resolve_bundle_sources("mold", source_root) == (
+        package_root / "skills" / "mold" / "commands.py",
+        package_root / "skills" / "mold" / "helper.py",
     )
 
 
-def test_minimal_closure_includes_flat_shared_import(tmp_path: Path) -> None:
-    root = _package(tmp_path, "import paths\n")
-    shared = tmp_path / "shared"
+def test_resolve_bundle_sources_includes_canonical_shared_import(
+    tmp_path: Path,
+) -> None:
+    source_root = _source_tree(tmp_path, "from easy_cheese.shared import paths\n")
+    package_root = source_root / "easy_cheese"
+    shared = package_root / "shared"
     shared.mkdir()
+    (shared / "__init__.py").write_text("", encoding="utf-8")
     helper = shared / "paths.py"
     helper.write_text("VALUE = 1\n", encoding="utf-8")
 
-    assert minimal_closure("mold", root, shared) == (
+    assert _resolve_bundle_sources("mold", source_root) == (
         helper,
-        root / "skills" / "mold" / "commands.py",
+        package_root / "skills" / "mold" / "commands.py",
     )
 
 
-@pytest.mark.parametrize("module", ("json", "attrs", "_schema_catalog"))
-def test_minimal_closure_allows_unbundled_dependencies(
+@pytest.mark.parametrize(
+    "module", ("json", "attrs", "easy_cheese_schemas._schema_catalog")
+)
+def test_resolve_bundle_sources_allows_unbundled_dependencies(
     tmp_path: Path, module: str
 ) -> None:
-    root = _package(tmp_path, f"import {module}\n")
+    source_root = _source_tree(tmp_path, f"import {module}\n")
 
-    assert minimal_closure("mold", root) == (
-        root / "skills" / "mold" / "commands.py",
+    assert _resolve_bundle_sources("mold", source_root) == (
+        source_root / "easy_cheese" / "skills" / "mold" / "commands.py",
     )
 
 
-def test_minimal_closure_rejects_cross_skill_import(tmp_path: Path) -> None:
-    root = _package(tmp_path, "from easy_cheese.skills.cook import commands\n")
-    cook = root / "skills" / "cook"
+def test_resolve_bundle_sources_rejects_cross_skill_import(tmp_path: Path) -> None:
+    source_root = _source_tree(
+        tmp_path, "from easy_cheese.skills.cook import commands\n"
+    )
+    cook = source_root / "easy_cheese" / "skills" / "cook"
     cook.mkdir()
     (cook / "commands.py").write_text("", encoding="utf-8")
 
     with pytest.raises(ValueError, match="cross-skill import"):
-        minimal_closure("mold", root)
+        _resolve_bundle_sources("mold", source_root)
 
 
-def test_minimal_closure_rejects_skill_name_prefix_collision(
+def test_resolve_bundle_sources_rejects_skill_name_prefix_collision(
     tmp_path: Path,
 ) -> None:
-    root = _package(
+    source_root = _source_tree(
         tmp_path,
         "from easy_cheese.skills.moldy import commands\n",
     )
-    sibling = root / "skills" / "moldy"
+    sibling = source_root / "easy_cheese" / "skills" / "moldy"
     sibling.mkdir()
     (sibling / "commands.py").write_text("", encoding="utf-8")
 
     with pytest.raises(ValueError, match="cross-skill import"):
-        minimal_closure("mold", root)
+        _resolve_bundle_sources("mold", source_root)
 
 
-def test_minimal_closure_rejects_unresolved_internal_dependency(
+def test_resolve_bundle_sources_rejects_unresolved_internal_dependency(
     tmp_path: Path,
 ) -> None:
-    root = _package(tmp_path, "import easy_cheese.missing\n")
+    source_root = _source_tree(tmp_path, "import easy_cheese.missing\n")
 
     with pytest.raises(
         ValueError,
         match=r"unresolved internal dependency: easy_cheese\.missing",
     ):
-        minimal_closure("mold", root)
+        _resolve_bundle_sources("mold", source_root)
 
 
-def test_minimal_closure_rejects_ambient_and_native_dependencies(
+def test_resolve_bundle_sources_rejects_legacy_flat_shared_import(
     tmp_path: Path,
 ) -> None:
-    root = _package(tmp_path, "import requests\n")
-    with pytest.raises(ValueError, match="ambient dependency"):
-        minimal_closure("mold", root)
+    source_root = _source_tree(tmp_path, "import paths\n")
+    shared = tmp_path / "shared" / "scripts"
+    shared.mkdir(parents=True)
+    (shared / "paths.py").write_text("VALUE = 1\n", encoding="utf-8")
 
-    commands = root / "skills" / "mold" / "commands.py"
+    with pytest.raises(ValueError, match=r"ambient dependency in bundle: paths"):
+        _resolve_bundle_sources("mold", source_root)
+
+
+def test_resolve_bundle_sources_rejects_legacy_flat_schema_import(
+    tmp_path: Path,
+) -> None:
+    source_root = _source_tree(tmp_path, "import contracts\n")
+    schemas = source_root / "easy_cheese_schemas"
+    schemas.mkdir()
+    (schemas / "__init__.py").write_text("", encoding="utf-8")
+    (schemas / "contracts.py").write_text("", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"ambient dependency in bundle: contracts"):
+        _resolve_bundle_sources("mold", source_root)
+
+
+def test_resolve_bundle_sources_requires_source_root(tmp_path: Path) -> None:
+    source_root = _source_tree(tmp_path, "")
+
+    with pytest.raises(ValueError, match="unknown Python skill: mold"):
+        _resolve_bundle_sources("mold", source_root / "easy_cheese")
+
+
+def test_resolve_bundle_sources_rejects_ambient_and_native_dependencies(
+    tmp_path: Path,
+) -> None:
+    source_root = _source_tree(tmp_path, "import requests\n")
+    with pytest.raises(ValueError, match="ambient dependency"):
+        _resolve_bundle_sources("mold", source_root)
+
+    commands = source_root / "easy_cheese" / "skills" / "mold" / "commands.py"
     commands.write_text("import native\n", encoding="utf-8")
     commands.with_name("native.so").write_bytes(b"native")
     with pytest.raises(ValueError, match="native ambient dependency"):
-        minimal_closure("mold", root)
+        _resolve_bundle_sources("mold", source_root)


### PR DESCRIPTION
## What changed

Adds a private, target-layout bundle source resolver extracted from #478. The implementation separates three stateful phases: `_SourceModules` indexes canonical sources without consulting `sys.path`; `_ImportPolicy` classifies every dependency against ownership and bundling rules; `_ClosureResolver` walks the reachable graph from `src/easy_cheese/skills/<skill>/commands.py`.

The resolver includes reachable modules under `src/easy_cheese/{shared,skills}` and `src/easy_cheese_schemas`, and rejects cross-skill, unresolved-internal, ambient, and adjacent native dependencies. Comments document the non-obvious invariants: canonical-only indexing, deferred-import discovery, ownership-before-lookup, package initializer handling, and the temporary generated-schema allowance.

The resolver accepts exactly the repository `src/` root. It does not expose a public API, accept `shared/scripts` as a secondary root, normalize checkout/package roots, or alias schema source files by flat names. Exact skill-namespace checks reject prefix collisions such as `mold` versus `moldy`.

Semantics-altering: this adds fully implemented package-internal behavior, but no shipping builder or skill consumes it yet.

## Why

Fourth independently reviewable extraction slice for #477, based on current `main` rather than #478. It establishes the final two-package source boundary without preserving transitional paths from the legacy `src/<skill>/`, `shared/scripts/`, or `common.pyz` topology. The builder integration can establish its final staging-result contract when it becomes the resolver's first production caller.

## How to verify

- `uv run --no-project --python 3.12 --with pytest python3 -m pytest tests/python/test_bundles.py -q` — 12 passed
- `uv run --no-project --python 3.12 --with pytest --with pyyaml --with pip just check` — passed

## Risk / rollout notes

Review import-classification ordering and the strict `src/` root contract. Bare generated schema module names remain temporarily allowed only because current schema sources retain `common.pyz` fallback imports; no filesystem fallback or secondary source root is retained. No production callers, build wiring, package relocation, or `.pyz` changes are included.

## Checklist

- [x] Conventional Commits PR title
- [x] Tests added or updated
- [x] Documentation updated (N/A: no user-facing wiring yet)
- [x] No secrets or credentials added
