### PR TITLE
refactor(runtime): migrate pasteurize to bundle_command dispatch

### DIFF
--- a/src/easy_cheese/skills/pasteurize/commands.py
+++ b/src/easy_cheese/skills/pasteurize/commands.py
@@ -1,17 +1,32 @@
-"""Command surface for the Pasteurize application bundle."""
+"""Command surface for the pasteurize application bundle."""
 
 from __future__ import annotations
 
 import sys
 
-from easy_cheese.shared.bundle_commands import dispatch_modules
+from easy_cheese.shared import bundle_commands
+from easy_cheese.shared.fanout import pasteurize_route_cli
 
-COMMANDS = {
-    "debug-tag-sweep": "easy_cheese.skills.pasteurize.debug_tag_sweep",
-    "repro-rerun": "easy_cheese.skills.pasteurize.repro_rerun",
-    "pasteurize-route": "easy_cheese.shared.fanout.pasteurize_route_cli",
-}
+from . import debug_tag_sweep, repro_rerun
+
+
+@bundle_commands.bundle_command("debug-tag-sweep")
+def run_debug_tag_sweep(argv: list[str]) -> int:
+    """Scan the tree for instrumentation tags."""
+    return debug_tag_sweep.main(argv)
+
+
+@bundle_commands.bundle_command("pasteurize-route")
+def run_pasteurize_route(argv: list[str]) -> int:
+    """Size the pasteurize fan-out from a JSON request."""
+    return pasteurize_route_cli.main(argv)
+
+
+@bundle_commands.bundle_command("repro-rerun")
+def run_repro_rerun(argv: list[str]) -> int:
+    """Re-run a repro command N times and emit a verdict."""
+    return repro_rerun.main(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
-    return dispatch_modules(COMMANDS, sys.argv[1:] if argv is None else argv)
+    return bundle_commands.dispatch(__name__, sys.argv[1:] if argv is None else argv)

--- a/src/easy_cheese/skills/pasteurize/debug_tag_sweep.py
+++ b/src/easy_cheese/skills/pasteurize/debug_tag_sweep.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 from pathlib import Path
 
 from easy_cheese.shared import cli  # noqa: E402
@@ -105,5 +106,9 @@ def _setup(parser: argparse.ArgumentParser) -> None:
     parser.set_defaults(func=_run)
 
 
+def main(argv: list[str] | None = None) -> int:
+    return cli.run(_setup, argv=argv)
+
+
 if __name__ == "__main__":
-    raise SystemExit(cli.run(_setup))
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/easy_cheese/skills/pasteurize/repro_rerun.py
+++ b/src/easy_cheese/skills/pasteurize/repro_rerun.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import argparse
 import subprocess
+import sys
 
 from easy_cheese.shared import cli  # noqa: E402
 
@@ -67,5 +68,9 @@ def _setup(parser: argparse.ArgumentParser) -> None:
     parser.set_defaults(func=_cmd)
 
 
+def main(argv: list[str] | None = None) -> int:
+    return cli.run(_setup, argv=argv)
+
+
 if __name__ == "__main__":
-    raise SystemExit(cli.run(_setup))
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

- Migrates pasteurize from the legacy `dispatch_modules` pattern to the `@bundle_command` decorator pattern established by hard-cheese (#490) and briesearch (#488)
- Adds `main(argv)` entry points to `debug_tag_sweep` and `repro_rerun`
- Replaces string-based `runpy` dispatch with typed decorator registration

Pasteurize was the last of the three audit targets still on the legacy path. The `dispatch_modules` function uses `runpy.run_module` with string module references, bypassing `compile_bundle_commands`, `guidance_source`, and `validate_generated_region` — the full bundle infrastructure. This PR aligns it with the [skill-python-bundle-doctrine](/.hallouminate/wiki/architecture/skill-python-bundle-doctrine.md).

### What changed

| File | Change |
|------|--------|
| `commands.py` | `dispatch_modules(COMMANDS, ...)` → 3 `@bundle_command` decorators + `bundle_commands.dispatch(__name__, ...)` |
| `debug_tag_sweep.py` | Added `main(argv) -> int` wrapper around `cli.run(_setup)`, updated `__main__` guard |
| `repro_rerun.py` | Same pattern as `debug_tag_sweep` |

### Cross-package reference

`pasteurize-route` delegates to `easy_cheese.shared.fanout.pasteurize_route_cli` (shared package). Previously a string reference invisible to static analysis; now a direct import, matching how briesearch imports `artifact_path` from shared.

## Test plan

- [x] `commands.main(['--help'])` prints usage with all 3 subcommands
- [x] `compile_bundle_commands(commands.__name__)` returns the correct map
- [x] `pytest tests/pasteurize/python tests/fanout/python` — 650 passed
- [x] `pytest tests/python --ignore=tests/python/test_pyz_bundle.py` — 1147 passed
- [x] `pytest tests/shared/python` — 373 passed
- [ ] CI bundle build (rebuilds .pyz with `--update-locks`)

🧀 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoazYmFrGXtsF3oixNwLj7