### PR TITLE
fix(build): reject non-Shiv pyz archives

### DIFF
--- a/scripts/check_bundles.py
+++ b/scripts/check_bundles.py
@@ -9,7 +9,7 @@ Shiv assembles deterministic wheel members, but ZIP metadata and interpreter
 paths can vary between toolchains. Host-specific fields are canonicalized; a
 source edit that never made it into the committed bundle still fails this gate.
 
-Committed common.pyz archives are rejected: each skill owns a same-named archive.
+Every .pyz must carry Shiv's runtime markers; other zipapp formats are rejected.
 """
 
 from __future__ import annotations
@@ -25,6 +25,26 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BUNDLE_GLOB = "skills/*/scripts/*.pyz"
+
+SHIV_RUNTIME_MEMBERS = frozenset(
+    {
+        "_bootstrap/__init__.py",
+        "_bootstrap/environment.py",
+        "_bootstrap/filelock.py",
+        "_bootstrap/interpreter.py",
+        "__main__.py",
+        "environment.json",
+    }
+)
+
+
+def _validate_shiv_archive(archive: zipfile.ZipFile) -> None:
+    names = set(archive.namelist())
+    missing = sorted(SHIV_RUNTIME_MEMBERS - names)
+    if missing:
+        raise ValueError(f"not a Shiv archive: missing {', '.join(missing)}")
+    if not any(name.startswith("site-packages/") for name in names):
+        raise ValueError("not a Shiv archive: missing site-packages/")
 
 
 def _site_packages_hash(
@@ -88,6 +108,7 @@ def _manifest(data: bytes) -> dict[str, tuple[int, int] | bytes]:
     only those host-dependent fields are canonicalized.
     """
     with zipfile.ZipFile(io.BytesIO(data)) as archive:
+        _validate_shiv_archive(archive)
         environment = json.loads(archive.read("environment.json"))
         stored_build_id = environment.get("build_id")
         raw_build_id = _site_packages_hash(
@@ -149,23 +170,24 @@ def main() -> int:
     for path in sorted(REPO_ROOT.glob(BUNDLE_GLOB)):
         relative = path.relative_to(REPO_ROOT)
         committed = _committed(relative)
-        if committed is None:
-            print(f"new bundle, nothing to compare: {relative}")
-            continue
         checked += 1
         try:
             rebuilt_manifest = _manifest(path.read_bytes())
+            if committed is None:
+                print(f"new Shiv bundle, nothing to compare: {relative}")
+                continue
             committed_manifest = _manifest(committed)
             problems = _describe(rebuilt_manifest, committed_manifest)
-        except (ValueError, KeyError, json.JSONDecodeError) as exc:
+        except (ValueError, KeyError, json.JSONDecodeError, zipfile.BadZipFile) as exc:
             problems = [f"    ! bundle metadata invalid: {exc}"]
         if problems:
             stale.append(f"  {relative}\n" + "\n".join(problems))
 
     if stale:
         print(
-            "::error::.pyz bundles are stale; run 'python3 scripts/build_pyz.py' "
-            "and commit the generated skills/*/scripts/*.pyz files."
+            "::error::.pyz bundles are invalid or stale; run "
+            "'python3 scripts/build_pyz.py' and commit the generated "
+            "skills/*/scripts/*.pyz files."
         )
         print("\n".join(stale))
         return 1

--- a/tests/python/test_check_bundles.py
+++ b/tests/python/test_check_bundles.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+from scripts import check_bundles
+
+
+def _non_shiv_zipapp() -> bytes:
+    data = BytesIO()
+    with zipfile.ZipFile(data, "w") as archive:
+        archive.writestr("__main__.py", b"print('not Shiv')\n")
+    return data.getvalue()
+
+
+def test_bundle_manifest_rejects_non_shiv_zipapp() -> None:
+    with pytest.raises(ValueError, match=r"not a Shiv archive: missing _bootstrap/"):
+        check_bundles._manifest(_non_shiv_zipapp())
+
+
+def test_bundle_checker_rejects_new_non_shiv_archive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    bundle = tmp_path / "skills" / "demo" / "scripts" / "demo.pyz"
+    bundle.parent.mkdir(parents=True)
+    bundle.write_bytes(_non_shiv_zipapp())
+    monkeypatch.setattr(check_bundles, "REPO_ROOT", tmp_path)
+
+    assert check_bundles.main() == 1
+    output = capsys.readouterr().out
+    assert ".pyz bundles are invalid or stale" in output
+    assert "not a Shiv archive" in output

--- a/tests/python/test_pyz_bundle.py
+++ b/tests/python/test_pyz_bundle.py
@@ -18,10 +18,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 BUILD = REPO_ROOT / "scripts" / "build_pyz.py"
 SPEC_FORMAT_FIXTURES = REPO_ROOT / "tests" / "python" / "fixtures" / "spec_format"
 COOK_PAYLOAD_FIXTURES = REPO_ROOT / "tests" / "python" / "fixtures" / "cook_payloads"
-
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 import build_pyz  # noqa: E402
 import check_bundles  # noqa: E402
+
 
 pytestmark = pytest.mark.skipif(
     importlib.util.find_spec("build") is None
@@ -156,6 +156,14 @@ def _zip_with_shiv_metadata(
 
     data = BytesIO()
     with zipfile.ZipFile(data, "w") as archive:
+        for member in (
+            "_bootstrap/__init__.py",
+            "_bootstrap/environment.py",
+            "_bootstrap/filelock.py",
+            "_bootstrap/interpreter.py",
+            "__main__.py",
+        ):
+            archive.writestr(member, b"")
         archive.writestr(
             "environment.json",
             json.dumps(


### PR DESCRIPTION
Semantics-altering: bundle validation now rejects any `.pyz` that lacks the pinned Shiv runtime structure, including newly added bundles with no committed counterpart.

## Summary

- require Shiv bootstrap, environment, entrypoint, and `site-packages/` members
- validate new bundles before skipping committed-content comparison
- report malformed ZIP apps as invalid rather than current
- add hermetic regression coverage for generic and first-add non-Shiv archives

## Verification

- `python3 -m pytest tests/python/test_check_bundles.py -q` — 2 passed
- `python3 scripts/check_bundles.py` — 15 current bundles
- `just check`

## Durable artifacts

None.

## Reviewer focus

Verify that the required member set matches Shiv 1.0.8 output and that a future Shiv layout change fails loudly rather than admitting a non-Shiv archive.

## Risk

The structural marker set is intentionally coupled to the pinned Shiv runtime and must be updated with any incompatible Shiv upgrade.