### PR TITLE
docs(build): document skill bundle pipeline

### DIFF
--- a/.hallouminate/wiki/adr/index.md
+++ b/.hallouminate/wiki/adr/index.md
@@ -39,8 +39,8 @@
 - [post-pr-wiki-writeback-001](./post-pr-wiki-writeback-001.md) — ADR: curdle wiki writes enforced by gate node + read-back verify, not a Stop-hook
 - [post-pr-wiki-writeback-002](./post-pr-wiki-writeback-002.md) — ADR: post-PR learnings write-back reuses wiki-ingest, not the personal wiki-curator skill
 - [pyz-pipeline-contracts-001](./pyz-pipeline-contracts-001.md) — ADR: Bundle builds verify the staged import closure, including function-body imports
-- [pyz-pipeline-contracts-002](./pyz-pipeline-contracts-002.md) — ADR: Bundle currency is enforced locally by just check and a scoped prek hook
-- [pyz-pipeline-contracts-003](./pyz-pipeline-contracts-003.md) — ADR: Script locations are published as a generated, gated map plus per-source banners
+- [pyz-pipeline-contracts-002](./pyz-pipeline-contracts-002.md) — ADR: Bundle currency remains a dedicated build gate
+- [pyz-pipeline-contracts-003](./pyz-pipeline-contracts-003.md) — ADR: Runtime source locations follow the package layout
 - [pyz-pipeline-contracts-004](./pyz-pipeline-contracts-004.md) — ADR: The subcommand registry is pruned to the prose-referenced set with strict two-way equality
 - [pyz-pipeline-contracts-005](./pyz-pipeline-contracts-005.md) — ADR: cook joins COMMON_CONSUMERS so its documented common.pyz fallback ships
 - [pyz-pipeline-contracts-006](./pyz-pipeline-contracts-006.md) — ADR: The Astro site source moves out of src/ to website/, leaving src/ purely Python

--- a/.hallouminate/wiki/adr/pyz-pipeline-contracts-002.md
+++ b/.hallouminate/wiki/adr/pyz-pipeline-contracts-002.md
@@ -1,17 +1,28 @@
-# ADR: Bundle currency is enforced locally by just check and a scoped prek hook
+# ADR: Bundle currency remains a dedicated build gate
 
-Status: accepted (2026-08-18)
+Status: superseded (2026-08-28)
 
 Spec: pyz-pipeline-contracts (durable specs corpus).
 
-## Context
+This ADR records an unimplemented local-gate proposal. The implemented Shiv pipeline keeps archive rebuilding and currency comparison in the dedicated bundle workflow rather than adding them to `just check`.[^1]
 
-The CRC currency check ran only in CI (build-pyz.yml), so PRs recurrently failed 'check .pyz bundles are current' (e.g. PR #424) after src/ edits without just bundle.
+## Historical context
 
-## Decision
+The CRC currency check ran only in CI, so pull requests could fail after runtime source changed without a corresponding archive rebuild.
 
-check_bundles.py joins the just check dependency chain, and a prek bundle-currency hook fires on commits touching src/, shared/, or skills/*/phase-contract.yaml. Rejected: CI auto-commit (bot pushes, rebase noise).
+## Historical decision
 
-## Consequences
+The proposal added `check_bundles.py` to the `just check` dependency chain and added a scoped prek hook for runtime changes.
 
-Staleness fails at the gate or the commit, not a CI round-trip later.
+## Supersession
+
+The current `just check` recipe runs linting, tests, and the documentation build. It does not rebuild archives or run `scripts/check_bundles.py`.[^2] Running the checker without first rebuilding the archives would compare the working-tree archives with their committed versions, not with changed runtime source. The dedicated `build-pyz.yml` workflow installs the pinned build tools, rebuilds the archives, compares canonical archive content with `HEAD`, and runs bundle isolation tests.[^3]
+
+Contributors must run `just bundle` after changes to runtime source, build inputs, phase contracts, locks, or committed archives. Do not describe archive currency as part of `just check` unless the gate first performs an authoritative rebuild.[^4]
+
+[^1]: .hallouminate/wiki/architecture/pyz-bundling-pipeline.md
+[^2]: justfile:14-39,74-78
+[^3]: .github/workflows/build-pyz.yml:39-78; scripts/check_bundles.py:1-196
+[^4]: README.md; CONTRIBUTING.md
+
+_Source: implemented repository behavior · Updated: 2026-08-28 · Supersedes: the unimplemented local `just check` and prek proposal accepted 2026-08-18_

--- a/.hallouminate/wiki/adr/pyz-pipeline-contracts-003.md
+++ b/.hallouminate/wiki/adr/pyz-pipeline-contracts-003.md
@@ -1,17 +1,28 @@
-# ADR: Script locations are published as a generated, gated map plus per-source banners
+# ADR: Runtime source locations follow the package layout
 
-Status: accepted (2026-08-18)
+Status: superseded (2026-08-28)
 
 Spec: pyz-pipeline-contracts (durable specs corpus).
 
-## Context
+This ADR records an unimplemented generated-source-map proposal. The implemented Shiv migration uses the package layout and the bundle architecture pages as the source-location contract; it does not generate `src/PYTHON_SCRIPTS.md`, `src/README.md`, or per-source banners.[^1]
 
-src/ mixed Astro site and Python sources with no artifact mapping subcommands to source files; the only explainer lived in .agents/skills/python-authoring/SKILL.md.
+## Historical context
 
-## Decision
+The earlier runtime layout mixed documentation-site source and Python source under `src/`. The repository had no generated map from bundle subcommands to source files.
 
-build_pyz compiles src/PYTHON_SCRIPTS.md (bundle, subcommand, source path) from its registries with a byte-match staleness gate mirroring the schema catalog; every registered source opens with a one-line ships-as banner asserted by test; a thin hand-written src/README.md explains and points at the map. Rejected: hand-written docs alone (rot silently).
+## Historical decision
 
-## Consequences
+The proposal required `build_pyz.py` to generate and gate `src/PYTHON_SCRIPTS.md`, add a short `src/README.md`, and add a one-line deployment banner to every registered source file.
 
-Where-does-this-live is answered by a generated artifact that cannot drift, at both the directory and the file.
+## Supersession
+
+Runtime Python now lives under two explicit packages: application and shared code under `src/easy_cheese/`, and published schemas under `src/easy_cheese_schemas/`.[^2] `scripts/build_pyz.py` discovers Python-backed skills from `src/easy_cheese/skills/*/commands.py`; package metadata defines the runtime closure.[^3] The public README and contributor guide describe how source becomes a same-named skill archive, while the wiki's bundle doctrine and pipeline pages document the full distribution graph.[^4]
+
+Do not add the proposed generated map or source banners without new demonstrated navigation pressure. Keep the package layout and existing architecture pages accurate instead.
+
+[^1]: specs/pyz-pipeline-contracts.md:68-72,149-151
+[^2]: AGENTS.md; .hallouminate/wiki/architecture/skill-python-bundle-doctrine.md
+[^3]: scripts/build_pyz.py:23-41,181-196
+[^4]: README.md; CONTRIBUTING.md; .hallouminate/wiki/architecture/pyz-bundling-pipeline.md
+
+_Source: implemented repository architecture · Updated: 2026-08-28 · Supersedes: the unimplemented generated source-map and source-banner proposal accepted 2026-08-18_

--- a/.hallouminate/wiki/architecture/pyz-bundling-pipeline.md
+++ b/.hallouminate/wiki/architecture/pyz-bundling-pipeline.md
@@ -6,6 +6,8 @@ The repository builds every Python-backed skill as a hash-locked Shiv applicatio
 
 `scripts/build_pyz.py` discovers applications from `src/easy_cheese/skills/*/commands.py`. Each discovered package becomes one `easy-cheese-<skill>` wheel with a same-named console script.[^2]
 
+Each `commands.py` declares the application's public subcommands as an immutable tuple of `Command(name, "module:callable")` values. Dispatch validates unique command names, imports only the selected target, passes it a command-local `list[str]`, and requires an integer status return. Command targets write result text to stdout or diagnostics to stderr; dispatch does not mutate `sys.argv`, execute modules through `runpy`, or use decorator registration.[^12]
+
 A build creates three distribution layers:
 
 1. `easy-cheese-schemas` from the root Hatchling project;
@@ -53,7 +55,7 @@ Before building wheels, the builder recompiles the phase registry, schema catalo
 
 `.github/workflows/build-pyz.yml` runs the bundle build, freshness comparison, and isolation tests under both Python 3.12 and 3.14. This keeps 3.12 as the runtime baseline while proving that newer build interpreters produce the same locks and canonical bundle content. Regular validation installs no Shiv.[^8]
 
-`scripts/check_bundles.py` compares member names, CRCs, and uncompressed sizes rather than raw ZIP bytes. It ignores Shiv bootstrap metadata, console wrappers, and RECORD files whose bytes can vary with the host toolchain while retaining source-staleness detection.[^9]
+`scripts/check_bundles.py` validates the required Shiv bootstrap members, then compares canonical member content rather than raw ZIP bytes. It removes the host timestamp from `environment.json`, derives a portable build ID, normalizes only the Python interpreter token in console-wrapper shebangs, and excludes `.dist-info/RECORD` files from the canonical comparison. The checker still includes RECORD content in its raw build-ID integrity check.[^9]
 
 The release workflow installs the same build-only requirements and runs `scripts/stage_release.py`. The staged tree contains skill files and one same-named archive per Python skill, with no loose Python source.[^10]
 
@@ -86,3 +88,6 @@ just bundle                                # when current locks already match
 [^9]: scripts/check_bundles.py
 [^10]: .github/workflows/release.yml; scripts/stage_release.py
 [^11]: justfile; .github/workflows/build-pyz.yml
+[^12]: src/easy_cheese/shared/bundle_commands.py; src/easy_cheese/skills/*/commands.py; tests/python/test_bundle_commands.py
+
+_Source: implemented repository architecture · Updated: 2026-08-28 · Supersedes: inaccurate bundle-comparison wording and implicit command registration_

--- a/.hallouminate/wiki/log.md
+++ b/.hallouminate/wiki/log.md
@@ -55,3 +55,10 @@
 - 2026-08-23 · 95363c78068f772a · skipped-near-duplicate · — · omitted duplicate, superseded, unresolved, and transient handoff/environment material from the tracked July checkpoint.
 
 - 2026-08-24 · mold:enforceable-skill-boundaries · approved · specs/enforceable-skill-boundaries.md, adr/skill-boundary-protocol-001.md, adr/skill-boundary-normalization-002.md, adr/skill-bundle-authority-003.md, adr/legacy-adapter-lifecycle-004.md, domain-model.md, architecture/workflow-contract-map.md · recorded the nine-curd Mold → Cook boundary plan, pointer-last publication, BAML-informed generous writer ingress, strict canonical acceptance, layout-derived one-skill bundles, and exact sunset-bound legacy adapters.
+
+
+- 2026-08-28 · cd6ee3e392a91bbd · merged · adr/pyz-pipeline-contracts-002.md · marked the unimplemented `just check` and prek bundle-currency proposal superseded; dedicated bundle rebuild and comparison remain authoritative.
+- 2026-08-28 · cd6ee3e392a91bbd · merged · adr/pyz-pipeline-contracts-003.md · marked the unimplemented generated source-map and source-banner proposal superseded by the package layout and architecture documentation.
+- 2026-08-28 · cd6ee3e392a91bbd · merged · architecture/pyz-bundling-pipeline.md · corrected canonical archive comparison: validate bootstrap members, canonicalize environment and wrapper shebangs, and exclude RECORD only from canonical comparison.
+- 2026-08-28 · cd6ee3e392a91bbd · merged · wiki-conventions.md · adopted the Google developer documentation style guide after repository-specific guidance and recorded its core editorial conventions.
+- 2026-08-28 · 21598ff6fb766b9f · merged · architecture/pyz-bundling-pipeline.md · incorporated PR #501's static `Command` manifests, lazy direct dispatch, command-local argument contract, stdout/stderr channels, and integer status returns.

--- a/.hallouminate/wiki/wiki-conventions.md
+++ b/.hallouminate/wiki/wiki-conventions.md
@@ -134,9 +134,19 @@ index and ancestor `index.md` link lists stay in sync.
 
 ## Style
 
+Follow repository-specific terminology and voice first. For editorial questions that the repository does not answer, follow the Google developer documentation style guide.[^1]
+
 - Lead with the conclusion. Don't bury the point under preamble.
+- Address the reader directly, prefer active voice, and put conditions before instructions.
+- Use sentence case for headings.
+- Format filenames, commands, symbols, and other code-related text with backticks.
+- Use descriptive link text instead of generic phrases such as "click here."
 - Cite files and line ranges by path: `skills/mold/references/handshake.md:1-3`.
 - Cite commits by SHA when behavior depends on history.
 - Prefer concrete examples to abstract description.
 - Keep entries short — ~50–150 lines is the right band. A wiki page is
   not a tutorial.
+
+[^1]: https://developers.google.com/style/
+
+_Source: repository documentation convention · Updated: 2026-08-28 · Supersedes: uncodified editorial fallback guidance_

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,55 @@ brew install just uv bats-core shellcheck yamllint yamlfmt markdownlint-cli2
 just check
 ```
 
-`just check` resolves test tools ephemerally through `uv`. To rebuild checked-in
-skill archives, install `requirements-build.txt` and run `just bundle`; Shiv is
-a build dependency and is not required to run the archives.
+`just check` resolves test tools ephemerally through `uv`. It does not install
+Shiv or rebuild the checked-in skill archives.
+
+## Rebuild skill archives
+
+Each Python-backed skill ships one same-named Shiv archive at
+`skills/<skill>/scripts/<skill>.pyz`. You need the build dependencies only when
+you rebuild these archives; users run them with Python alone.
+
+If you change runtime source under `src/easy_cheese/`, a phase contract, build
+configuration, a bundle lock, or a committed archive, install the pinned build
+tools and rebuild every archive:
+
+```sh
+python3 -m pip install --requirement requirements-build.txt
+just bundle
+```
+
+`just bundle` resolves each application from PEP 517 wheels in a private
+wheelhouse. It compares the resolved closure with the corresponding hash-locked
+file under `requirements/bundles/`.
+
+Each Python skill declares its public subcommands in `commands.py` as an
+immutable tuple of `Command(name, "module:callable")` values. When you add or
+change a command, make its target accept `list[str]`, write result text to
+stdout or diagnostics to stderr, and return an integer process status. Do not
+mutate `sys.argv`, execute the target through `runpy`, or add a decorator-based
+registry.
+
+If you intend to change the resolved dependency closure, update the locks
+explicitly:
+
+```sh
+python3 scripts/build_pyz.py --update-locks
+```
+
+Commit the changed lock files and `skills/*/scripts/*.pyz` archives with the
+source change. CI rebuilds the archives and compares their canonical member
+content with the committed artifacts.
+
+## Documentation style
+
+For project terminology and established cheese flavor, follow the repository's
+project-specific guidance first. For other editorial decisions, follow the
+[Google developer documentation style guide](https://developers.google.com/style/).
+Write directly to the reader, prefer active voice, use sentence case for
+headings, format code-related names in backticks, and use descriptive link text.
+Edit root documents such as `README.md` and `CONTRIBUTING.md`; the documentation
+build generates their copies under `src/content/docs/`.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 > _"The cheese must flow."_
 
-A portable, harness-agnostic Agent Skills toolkit — self-contained `SKILL.md` files any [Agent Skills](https://agentskills.io/specification)-compatible harness can load. No agents, no compiled bundles, no repo-wide MCP requirement. The vocabulary (mold, culture, cook, press, age, cure) reads as a workflow you can dip into anywhere.
+A portable, harness-agnostic Agent Skills toolkit for any [Agent Skills](https://agentskills.io/specification)-compatible harness. Each skill uses `SKILL.md` as its instruction surface. Python-backed skills also ship a self-contained runtime archive. The toolkit requires no custom agents or repo-wide MCP server. The vocabulary (mold, culture, cook, press, age, cure) describes a workflow that you can use in whole or in part.
 
 ## Contents
 
@@ -24,6 +24,7 @@ A portable, harness-agnostic Agent Skills toolkit — self-contained `SKILL.md` 
 - [Skills](#skills)
 - [Scope](#scope)
 - [Python package](#python-package)
+- [Build skill archives](#build-skill-archives)
 - [Optional tools](#optional-tools)
 - [Install](#install)
 - [Validate](#validate)
@@ -45,13 +46,15 @@ skills/
 └── <skill-name>/
     ├── SKILL.md          # required: name + description + body
     ├── references/       # optional: detail pulled in on demand
-    ├── scripts/          # optional: executable helpers
+    ├── scripts/          # optional: same-named Python runtime archive
     └── assets/           # optional: templates / static resources
 ```
 
 Each `SKILL.md` is self-contained markdown with YAML frontmatter. There are no nested sub-skills; deeper material lives in `references/<topic>.md` so the harness can load it progressively.
 
-Content shared _across_ skills lives in the `cheese` skill's `references/` directory (e.g. `skills/cheese/references/handoff-gate.md`). Full installs include `cheese`; when installing one workflow skill, install `cheese` alongside it. Skills reference shared material by sibling-relative path (`../cheese/references/<file>.md` from a `SKILL.md`, `../../cheese/references/<file>.md` from a `references/*.md`) so links resolve identically in the repo tree and any installed skills directory.
+Content shared _across_ skills lives in the `cheese` skill's `references/` directory (for example, `skills/cheese/references/handoff-gate.md`). Full installs include `cheese`. When you install one workflow skill, install `cheese` with it. Skills reference shared material by sibling-relative path (`../cheese/references/<file>.md` from a `SKILL.md`, `../../cheese/references/<file>.md` from a `references/*.md`) so links resolve in both the repository and an installed skills directory.
+
+A Python-backed skill ships exactly one executable archive at `skills/<skill>/scripts/<skill>.pyz`. Runtime source lives under `src/easy_cheese/`; Python source does not live under `skills/`. A skill that does not execute Python ships no archive.
 
 ## Skills
 
@@ -120,7 +123,7 @@ before review.
 
 Easy-cheese is intentionally a small surface. What that means in practice:
 
-- **Skills only.** No agents, commands, eta templates, or compiled harness bundles. Each capability is a single `SKILL.md`.
+- **Skills only.** The repository publishes no custom agents, commands, eta templates, or harness-specific bundles. `SKILL.md` defines each capability, and Python-backed skills include a portable `.pyz` runtime archive.
 - **No repo-wide MCP requirement.** Workflow skills suggest tools (tilth, Context7, Tavily) but have host-native fallbacks. Source-code work follows the shared routing contract: prefer tilth when present, use equivalent native AST/LSP/anchored-edit backends when available, and report any precision loss from bounded fallbacks.
 - **One orchestrator skill, narrowly scoped.** `/cook` is the single implementation orchestrator: focused specs use its single-coder path, while approved file-disjoint curds use its fresh-context fan pathway. `/ultracook` is only a compatibility redirect to `/cook`. Harvest and `/plate` remain parent-owned; parallel curds use sequential same-worktree phase spawns and a terminal reviewer pass before publication.
 - **No automatic re-age loop in `/cure`.** The skill describes the protocol; the human runs the next `/age` when ready.
@@ -133,7 +136,32 @@ The artifact contracts the skills read and write — run manifests, decompositio
 pip install easy-cheese-schemas
 ```
 
-Stability policy, the `schema_version` contract, and the strictness tiers: [docs/easy-cheese-schemas.md](https://github.com/paulnsorensen/easy-cheese/blob/main/docs/easy-cheese-schemas.md).
+For the stability policy, `schema_version` contract, and strictness tiers, see [Easy-cheese schemas](https://github.com/paulnsorensen/easy-cheese/blob/main/docs/easy-cheese-schemas.md).
+
+## Build skill archives
+
+You don't need Shiv or pip to run a checked-in skill archive. Run an archive with Python:
+
+```sh
+python3 skills/<skill>/scripts/<skill>.pyz <subcommand>
+```
+
+If you change runtime source, build inputs, a phase contract, a bundle lock, or a committed archive, install the pinned build tools and rebuild every archive:
+
+```sh
+python3 -m pip install --requirement requirements-build.txt
+just bundle
+```
+
+`just bundle` builds each application from PEP 517 wheels in a private wheelhouse and verifies the checked-in per-skill lock in `requirements/bundles/`. Each application's `commands.py` declares its public subcommands as an immutable tuple of `Command(name, "module:callable")` values. The bundle resolves a selected target lazily and calls it with only that command's arguments.
+
+If you intentionally change a resolved dependency closure, update the locks before you rebuild:
+
+```sh
+python3 scripts/build_pyz.py --update-locks
+```
+
+Commit the changed lock files and `skills/*/scripts/*.pyz` archives with the source change. `just check` validates the repository but does not rebuild the archives. For implementation details, see the [contributor workflow](./CONTRIBUTING.md).
 
 ## Optional tools
 


### PR DESCRIPTION
## Summary

This is a documentation-only, semantics-preserving follow-up to #501. Review that the public, contributor, and durable architecture documentation matches the implemented Shiv archive and static command-manifest contracts.

- explain the one-archive-per-Python-skill build and lock workflow
- document PR #501's immutable `Command(name, "module:callable")` manifests and direct dispatch contract
- adopt the Google developer documentation style guide after project-specific guidance
- supersede stale wiki claims about local bundle currency and generated source maps
- correct the canonical Shiv archive comparison description

## Verification

- `just check`
- generated Starlight README and contributor pages inspected after `scripts/gen_docs.py`

## Durable artifacts

- `.hallouminate/wiki/architecture/pyz-bundling-pipeline.md` — updated and verified through Hallouminate
- `.hallouminate/wiki/adr/pyz-pipeline-contracts-002.md` — superseded stale local-gate claim
- `.hallouminate/wiki/adr/pyz-pipeline-contracts-003.md` — superseded unimplemented source-map proposal
- `.hallouminate/wiki/wiki-conventions.md` — added editorial style hierarchy
- `.hallouminate/wiki/log.md` — recorded ingest decisions

## Stack relationship

- Base PR: #501
- This PR documents the bundle architecture and command contract introduced there.

## Risks

No runtime behavior changes. The PR depends on #501 and should merge after it.
