### PR TITLE
ci: park skill-overlap ratchet (manual-only)

### DIFF
--- a/.github/workflows/skill-overlap.yml
+++ b/.github/workflows/skill-overlap.yml
@@ -1,5 +1,8 @@
 name: skill-overlap
 
+# Disabled for now: automatic schedule and pull_request triggers are parked
+# while we decide whether to salvage the ratchet. Manual runs still work via
+# workflow_dispatch. See https://github.com/paulnsorensen/easy-cheese/issues/511.
 on:
   workflow_dispatch:
     inputs:
@@ -9,15 +12,6 @@ on:
         default: calibrate
         type: choice
         options: [calibrate, report, check]
-  schedule:
-    - cron: "17 6 * * 1"
-  pull_request:
-    paths:
-      - 'skills/**/*.md'
-      - '.claude-plugin/plugin.json'
-      - 'tools/skill-overlap/**'
-      - '.github/skill-overlap-*.yml'
-      - '.github/workflows/skill-overlap.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Disables the skill-overlap ratchet for now by removing the `schedule` and `pull_request` auto-triggers from `.github/workflows/skill-overlap.yml`, leaving only manual `workflow_dispatch`.

**Why:** calibration and baseline are both still `status: draft`, so the job only ever ran advisory `calibrate` mode on PRs — never enforcing — while paying a full Rust build + model fetch + parity check per PR touching `skills/**/*.md`.

Nothing else in the workflow or `tools/skill-overlap/` was touched. Re-enabling is just restoring the two `on:` triggers.

Salvage-or-retire decision tracked in #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)