### PR TITLE
fix(build): enforce local bundle currency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: local
+    hooks:
+      - id: bundle-currency
+        name: bundle-currency
+        entry: python3 scripts/precommit_bundle_currency.py
+        language: system
+        always_run: true
+        files: >-
+          (?x)^(
+            src/|
+            skills/[^/]+/(phase-contract\.yaml|scripts/[^/]+\.pyz)$|
+            scripts/(build_pyz|check_bundles|check_bundles_local|precommit_bundle_currency)\.py$|
+            \.github/workflows/build-pyz\.yml$|
+            pyproject\.toml$|
+            requirements/(runtime\.txt|bundles/[^/]+\.txt)$|
+            requirements-build\.txt
+          )
+        pass_filenames: false

--- a/justfile
+++ b/justfile
@@ -38,6 +38,14 @@ test-skill-overlap:
 bundle:
     python3 scripts/build_pyz.py
 
+# Verify current worktree sources against current bundle artifacts
+check-bundles:
+    python3 scripts/check_bundles_local.py
+
+# CI alias keeps the HEAD comparison explicit
+check-bundles-ci:
+    python3 scripts/check_bundles.py --against head
+
 # Preview the exact tree a release ships (skills + .pyz only, no sources)
 release-preview:
     python3 scripts/stage_release.py --out .release-preview
@@ -72,10 +80,10 @@ update-skill-budgets:
     python3 .github/scripts/validate_skills.py --write-budgets
 
 # Full local check with autofixes
-check: lint-md-fix lint-yaml-fix lint-yaml lint-py-fix lint-sh test docs-build
+check: lint-md-fix lint-yaml-fix lint-yaml lint-py-fix lint-sh test check-bundles docs-build
 
 # CI-mode verification (no autofixes)
-ci: lint-md lint-yaml lint-sh test docs-build
+ci: lint-md lint-yaml lint-sh test bundle check-bundles-ci docs-build
 
 # Install docs build dependencies
 docs-install:

--- a/scripts/check_bundles.py
+++ b/scripts/check_bundles.py
@@ -14,12 +14,14 @@ Every .pyz must carry Shiv's runtime markers; other zipapp formats are rejected.
 
 from __future__ import annotations
 
+import argparse
 import io
 import hashlib
 import json
 import re
 import subprocess
 import sys
+import tempfile
 import zipfile
 from pathlib import Path
 
@@ -147,6 +149,38 @@ def _committed(path: Path) -> bytes | None:
     return result.stdout if result.returncode == 0 else None
 
 
+def _materialize_index(destination: Path) -> None:
+    """Materialize the current Git index without reading raw object contents."""
+    destination.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "checkout-index", "--all", f"--prefix={destination}/"],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+
+
+def _check_roots(built_root: Path, baseline_root: Path, *, require_baseline: bool) -> list[str]:
+    problems: list[str] = []
+    built_paths = {path.relative_to(built_root) for path in built_root.glob(BUNDLE_GLOB)}
+    baseline_paths = {path.relative_to(baseline_root) for path in baseline_root.glob(BUNDLE_GLOB)}
+    for relative in sorted(baseline_paths - built_paths):
+        problems.append(f"  {relative} (expected bundle missing from build)")
+    for relative in sorted(built_paths - baseline_paths):
+        if require_baseline:
+            problems.append(f"  {relative} (built bundle is not staged)")
+    for relative in sorted(built_paths & baseline_paths):
+        try:
+            rebuilt_manifest = _manifest((built_root / relative).read_bytes())
+            baseline_manifest = _manifest((baseline_root / relative).read_bytes())
+            problems.extend(
+                f"  {relative}\n{detail}"
+                for detail in _describe(rebuilt_manifest, baseline_manifest)
+            )
+        except (ValueError, KeyError, json.JSONDecodeError, zipfile.BadZipFile) as exc:
+            problems.append(f"  {relative}\n    ! bundle metadata invalid: {exc}")
+    return problems
+
+
 def _describe(
     rebuilt: dict[str, tuple[int, int] | bytes],
     committed: dict[str, tuple[int, int] | bytes],
@@ -162,39 +196,60 @@ def _describe(
     return problems
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--against",
+        choices=("head", "index"),
+        default="head",
+        help="compare rebuilt bundles with HEAD or the materialized Git index",
+    )
+    parser.add_argument(
+        "--baseline-root",
+        type=Path,
+        help="compare against bundles materialized under this checkout",
+    )
+    args = parser.parse_args([] if argv is None else argv)
     stale: list[str] = []
-    for path in sorted(REPO_ROOT.glob("skills/*/scripts/common.pyz")):
-        stale.append(f"  {path.relative_to(REPO_ROOT)} (obsolete shared bundle)")
     checked = 0
-    for path in sorted(REPO_ROOT.glob(BUNDLE_GLOB)):
-        relative = path.relative_to(REPO_ROOT)
-        committed = _committed(relative)
-        checked += 1
-        try:
-            rebuilt_manifest = _manifest(path.read_bytes())
-            if committed is None:
-                print(f"new Shiv bundle, nothing to compare: {relative}")
-                continue
-            committed_manifest = _manifest(committed)
-            problems = _describe(rebuilt_manifest, committed_manifest)
-        except (ValueError, KeyError, json.JSONDecodeError, zipfile.BadZipFile) as exc:
-            problems = [f"    ! bundle metadata invalid: {exc}"]
-        if problems:
-            stale.append(f"  {relative}\n" + "\n".join(problems))
-
+    if args.baseline_root is not None:
+        baseline = args.baseline_root.resolve()
+        built_paths = {path.relative_to(REPO_ROOT) for path in REPO_ROOT.glob(BUNDLE_GLOB)}
+        baseline_paths = {path.relative_to(baseline) for path in baseline.glob(BUNDLE_GLOB)}
+        checked = len(baseline_paths | built_paths)
+        stale.extend(_check_roots(REPO_ROOT, baseline, require_baseline=True))
+    elif args.against == "index":
+        with tempfile.TemporaryDirectory(prefix="easy-cheese-index-") as raw:
+            baseline = Path(raw) / "baseline"
+            _materialize_index(baseline)
+            built_paths = {path.relative_to(REPO_ROOT) for path in REPO_ROOT.glob(BUNDLE_GLOB)}
+            baseline_paths = {path.relative_to(baseline) for path in baseline.glob(BUNDLE_GLOB)}
+            checked = len(baseline_paths | built_paths)
+            stale.extend(_check_roots(REPO_ROOT, baseline, require_baseline=True))
+    else:
+        for path in sorted(REPO_ROOT.glob("skills/*/scripts/common.pyz")):
+            stale.append(f"  {path.relative_to(REPO_ROOT)} (obsolete shared bundle)")
+        for path in sorted(REPO_ROOT.glob(BUNDLE_GLOB)):
+            relative = path.relative_to(REPO_ROOT)
+            committed = _committed(relative)
+            checked += 1
+            try:
+                rebuilt_manifest = _manifest(path.read_bytes())
+                if committed is None:
+                    problems = []
+                else:
+                    problems = _describe(rebuilt_manifest, _manifest(committed))
+            except (ValueError, KeyError, json.JSONDecodeError, zipfile.BadZipFile) as exc:
+                problems = [f"    ! bundle metadata invalid: {exc}"]
+            if problems:
+                stale.append(f"  {relative}\n" + "\n".join(problems))
     if stale:
-        print(
-            "::error::.pyz bundles are invalid or stale; run "
-            "'python3 scripts/build_pyz.py' and commit the generated "
-            "skills/*/scripts/*.pyz files."
-        )
+        print("::error::.pyz bundles are invalid or stale; run 'python3 scripts/build_pyz.py' and commit the generated skills/*/scripts/*.pyz files.")
         print("\n".join(stale))
         return 1
-
     print(f".pyz bundles are current ({checked} checked, by canonical member content).")
     return 0
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_bundles_local.py
+++ b/scripts/check_bundles_local.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Check current worktree sources and bundles without mutating the worktree."""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUILD_COMMAND = (
+    "uv",
+    "run",
+    "--no-project",
+    "--with-requirements",
+    "requirements-build.txt",
+    "--with-requirements",
+    "requirements/runtime.txt",
+    "python",
+    "scripts/build_pyz.py",
+)
+
+
+def _materialize_files(destination: Path) -> None:
+    output = subprocess.check_output(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+        cwd=REPO_ROOT,
+    )
+    for raw_path in output.split(b"\0"):
+        if not raw_path:
+            continue
+        relative = Path(os.fsdecode(raw_path))
+        if relative.is_absolute() or ".." in relative.parts:
+            raise RuntimeError(f"unsafe repository path: {relative}")
+        source = REPO_ROOT / relative
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_symlink():
+            target.symlink_to(os.readlink(source))
+        elif source.is_file():
+            shutil.copy2(source, target)
+        else:
+            raise RuntimeError(f"unsupported repository entry: {relative}")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="easy-cheese-local-bundles-") as raw:
+        root = Path(raw)
+        checkout = root / "checkout"
+        baseline = root / "baseline"
+        _materialize_files(checkout)
+        baseline.mkdir()
+        for bundle in checkout.glob("skills/*/scripts/*.pyz"):
+            target = baseline / bundle.relative_to(checkout)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(bundle, target)
+        result = subprocess.run(BUILD_COMMAND, cwd=checkout)
+        if result.returncode:
+            return result.returncode
+        return subprocess.run(
+            [sys.executable, "scripts/check_bundles.py", "--baseline-root", str(baseline)],
+            cwd=checkout,
+        ).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/precommit_bundle_currency.py
+++ b/scripts/precommit_bundle_currency.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Build and check bundles from the staged Git index in an isolated checkout."""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AFFECTED = re.compile(
+    r"^(src/|skills/[^/]+/(phase-contract\.yaml|scripts/[^/]+\.pyz)$|"
+    r"scripts/(build_pyz|check_bundles|check_bundles_local|precommit_bundle_currency)\.py$|"
+    r"\.github/workflows/build-pyz\.yml$|pyproject\.toml$|requirements-build\.txt$|"
+    r"requirements/(runtime\.txt|bundles/[^/]+\.txt)$)"
+)
+BUILD_COMMAND = (
+    "uv",
+    "run",
+    "--no-project",
+    "--with-requirements",
+    "requirements-build.txt",
+    "--with-requirements",
+    "requirements/runtime.txt",
+    "python",
+    "scripts/build_pyz.py",
+)
+
+
+def _staged_inputs() -> list[str]:
+    output = subprocess.check_output(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACDMRTUXB", "-z"],
+        cwd=REPO_ROOT,
+    )
+    return [
+        path
+        for raw_path in output.split(b"\0")
+        if raw_path
+        for path in [os.fsdecode(raw_path)]
+        if AFFECTED.match(path)
+    ]
+
+
+def main() -> int:
+    if not _staged_inputs():
+        return 0
+    git_env = os.environ.copy()
+    git_env["GIT_DIR"] = subprocess.check_output(
+        ["git", "rev-parse", "--path-format=absolute", "--git-dir"],
+        cwd=REPO_ROOT,
+        text=True,
+    ).strip()
+    git_env["GIT_INDEX_FILE"] = subprocess.check_output(
+        ["git", "rev-parse", "--path-format=absolute", "--git-path", "index"],
+        cwd=REPO_ROOT,
+        text=True,
+    ).strip()
+    with tempfile.TemporaryDirectory(prefix="easy-cheese-bundle-currency-") as raw:
+        checkout = Path(raw) / "checkout"
+        checkout.mkdir()
+        subprocess.run(
+            ["git", "checkout-index", "--all", f"--prefix={checkout}/"],
+            cwd=REPO_ROOT,
+            check=True,
+        )
+        for command in (
+            BUILD_COMMAND,
+            [sys.executable, "scripts/check_bundles.py", "--against", "index"],
+        ):
+            result = subprocess.run(command, cwd=checkout, env=git_env)
+            if result.returncode:
+                return result.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/python/test_bundle_currency.py
+++ b/tests/python/test_bundle_currency.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import base64
+import contextlib
+import importlib
+from typing import Any
+import io
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import textwrap
+import zipfile
+
+import yaml
+
+from scripts import check_bundles
+
+
+ROOT = Path(__file__).parents[2]
+
+
+def _roots(tmp_path: Path) -> tuple[Path, Path]:
+    built = tmp_path / "built" / "skills" / "demo" / "scripts"
+    baseline = tmp_path / "baseline" / "skills" / "demo" / "scripts"
+    built.mkdir(parents=True)
+    baseline.mkdir(parents=True)
+    (built / "demo.pyz").write_bytes(b"built")
+    (baseline / "demo.pyz").write_bytes(b"baseline")
+    return built.parents[2], baseline.parents[2]
+
+
+def test_local_pair_and_stale_bundle_are_distinguished(tmp_path, monkeypatch) -> None:
+    built, baseline = _roots(tmp_path)
+    monkeypatch.setattr(check_bundles, "_manifest", lambda data: {"payload": data})
+    assert check_bundles._check_roots(built, built, require_baseline=True) == []
+    problems = check_bundles._check_roots(built, baseline, require_baseline=True)
+    assert any("content differs" in problem for problem in problems)
+
+
+def test_index_comparison_reports_missing_and_new_expected_bundles(tmp_path) -> None:
+    built = tmp_path / "built"
+    baseline = tmp_path / "baseline"
+    (built / "skills" / "demo" / "scripts").mkdir(parents=True)
+    (baseline / "skills" / "old" / "scripts").mkdir(parents=True)
+    (built / "skills" / "demo" / "scripts" / "demo.pyz").write_bytes(b"x")
+    (baseline / "skills" / "old" / "scripts" / "old.pyz").write_bytes(b"x")
+    problems = check_bundles._check_roots(built, baseline, require_baseline=True)
+    assert any("expected bundle missing" in problem for problem in problems)
+    assert any("not staged" in problem for problem in problems)
+
+
+def test_local_check_is_not_head_based() -> None:
+    justfile = (ROOT / "justfile").read_text()
+    assert "check-bundles-local" not in justfile
+    assert "check-bundles" in justfile
+    assert "check_bundles_local.py" in justfile
+    assert " bundle " not in justfile.split("check:", 1)[1].splitlines()[0]
+
+
+def test_hook_scope_covers_bundle_inputs_and_archives() -> None:
+    config = yaml.safe_load((ROOT / ".pre-commit-config.yaml").read_text())
+    hook = config["repos"][0]["hooks"][0]
+    assert hook["always_run"] is True
+    trigger = re.compile(hook["files"])
+    for path in (
+        "src/easy_cheese/skills/demo/commands.py",
+        "skills/demo/phase-contract.yaml",
+        "skills/demo/scripts/demo.pyz",
+        "requirements/runtime.txt",
+        "requirements/bundles/demo.txt",
+        "requirements-build.txt",
+        "pyproject.toml",
+    ):
+        assert trigger.search(path), path
+
+
+
+def test_bundle_build_commands_include_runtime_requirements() -> None:
+    from scripts import check_bundles_local, precommit_bundle_currency
+
+    for command in (check_bundles_local.BUILD_COMMAND, precommit_bundle_currency.BUILD_COMMAND):
+        assert "requirements-build.txt" in command
+        assert "requirements/runtime.txt" in command
+
+
+def _bundle(marker: str) -> bytes:
+    members = {
+        "_bootstrap/__init__.py": b"",
+        "_bootstrap/environment.py": b"",
+        "_bootstrap/filelock.py": b"",
+        "_bootstrap/interpreter.py": b"",
+        "__main__.py": b"",
+        "site-packages/demo.py": marker.encode(),
+        "site-packages/demo-1.dist-info/RECORD": b"demo.py,,\\n",
+    }
+    raw = io.BytesIO()
+    with zipfile.ZipFile(raw, "w") as archive:
+        for name, data in members.items():
+            archive.writestr(name, data)
+    with zipfile.ZipFile(io.BytesIO(raw.getvalue())) as archive:
+        build_id = check_bundles._site_packages_hash(
+            archive, normalize_wrappers=False, include_record=True
+        )
+    with zipfile.ZipFile(raw, "a") as archive:
+        archive.writestr(
+            "environment.json",
+            ('{"build_id": "' + build_id + '"}').encode(),
+        )
+    return raw.getvalue()
+
+
+def _repo(tmp_path: Path, *, source: str, artifact: bytes) -> tuple[Path, dict[str, str]]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    (repo / "src").mkdir()
+    (repo / "src" / "input.py").write_text(source)
+    bundle = repo / "skills" / "demo" / "scripts"
+    bundle.mkdir(parents=True)
+    (bundle / "demo.pyz").write_bytes(artifact)
+    (repo / "scripts").mkdir()
+    for name in ("check_bundles.py", "check_bundles_local.py", "precommit_bundle_currency.py"):
+        shutil.copy2(ROOT / "scripts" / name, repo / "scripts" / name)
+    builder = repo / "fake_builder.py"
+    encoded = {key: base64.b64encode(value).decode() for key, value in {
+        "one": _bundle("one"), "two": _bundle("two")
+    }.items()}
+    builder.write_text(textwrap.dedent(f"""        import base64
+        from pathlib import Path
+        if Path("link.py").exists():
+            assert Path("link.py").is_symlink()
+        source = Path("src/input.py").read_text().strip()
+        data = base64.b64decode({encoded!r}[source])
+        target = Path("skills/demo/scripts/demo.pyz")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    """))
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "fixture"], cwd=repo, check=True)
+    return repo, os.environ.copy()
+
+
+def _run(repo: Path, script: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    module: Any = importlib.import_module(f"scripts.{script}")
+    module.REPO_ROOT = repo
+    module.BUILD_COMMAND = (sys.executable, str(repo / "fake_builder.py"))
+    previous = os.environ.get("GIT_INDEX_FILE")
+    if "GIT_INDEX_FILE" in env:
+        os.environ["GIT_INDEX_FILE"] = env["GIT_INDEX_FILE"]
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            returncode = module.main()
+    finally:
+        if previous is None:
+            os.environ.pop("GIT_INDEX_FILE", None)
+        else:
+            os.environ["GIT_INDEX_FILE"] = previous
+    return subprocess.CompletedProcess([], returncode, stdout.getvalue(), stderr.getvalue())
+
+
+def _stage(repo: Path, *paths: str, env: dict[str, str]) -> None:
+    subprocess.run(["git", "add", *paths], cwd=repo, env=env, check=True)
+
+
+def test_precommit_staged_source_and_matching_artifact_pass(tmp_path) -> None:
+    repo, env = _repo(tmp_path, source="one", artifact=_bundle("one"))
+    (repo / "src/input.py").write_text("two")
+    (repo / "skills/demo/scripts/demo.pyz").write_bytes(_bundle("two"))
+    _stage(repo, "src/input.py", "skills/demo/scripts/demo.pyz", env=env)
+    result = _run(repo, "precommit_bundle_currency", env)
+    assert result.returncode == 0, result.stderr
+
+
+def test_precommit_staged_source_without_regenerated_artifact_fails(tmp_path) -> None:
+    repo, env = _repo(tmp_path, source="one", artifact=_bundle("one"))
+    (repo / "src/input.py").write_text("two")
+    _stage(repo, "src/input.py", env=env)
+    result = _run(repo, "precommit_bundle_currency", env)
+    assert result.returncode != 0
+
+
+def test_precommit_ignores_unstaged_worktree_edits(tmp_path) -> None:
+    repo, env = _repo(tmp_path, source="one", artifact=_bundle("one"))
+    (repo / "src/input.py").write_text("two")
+    (repo / "skills/demo/scripts/demo.pyz").write_bytes(_bundle("two"))
+    _stage(repo, "src/input.py", "skills/demo/scripts/demo.pyz", env=env)
+    (repo / "src/input.py").write_text("one")
+    result = _run(repo, "precommit_bundle_currency", env)
+    assert result.returncode == 0, result.stderr
+
+
+def test_precommit_detects_staged_bundle_deletion(tmp_path) -> None:
+    repo, env = _repo(tmp_path, source="one", artifact=_bundle("one"))
+    (repo / "skills/demo/scripts/demo.pyz").unlink()
+    _stage(repo, "skills/demo/scripts/demo.pyz", env=env)
+    result = _run(repo, "precommit_bundle_currency", env)
+    assert result.returncode != 0
+
+
+def test_precommit_honors_alternate_git_index(tmp_path) -> None:
+    repo, env = _repo(tmp_path, source="one", artifact=_bundle("one"))
+    default_env = os.environ.copy()
+    (repo / "src/input.py").write_text("two")
+    _stage(repo, "src/input.py", env=default_env)
+
+    alternate = repo / "alternate-index"
+    env["GIT_INDEX_FILE"] = str(alternate)
+    subprocess.run(["git", "read-tree", "HEAD"], cwd=repo, env=env, check=True)
+    (repo / "skills/demo/scripts/demo.pyz").write_bytes(_bundle("two"))
+    _stage(repo, "src/input.py", "skills/demo/scripts/demo.pyz", env=env)
+
+    assert _run(repo, "precommit_bundle_currency", default_env).returncode != 0
+    assert _run(repo, "precommit_bundle_currency", env).returncode == 0
+
+
+def test_local_matching_and_stale_artifact(tmp_path) -> None:
+    repo, env = _repo(tmp_path, source="one", artifact=_bundle("one"))
+    result = _run(repo, "check_bundles_local", env)
+    assert result.returncode == 0, result.stderr
+    (repo / "src/input.py").write_text("two")
+    result = _run(repo, "check_bundles_local", env)
+    assert result.returncode != 0
+
+
+def test_local_materialization_preserves_symlinks(tmp_path) -> None:
+    repo, env = _repo(tmp_path, source="one", artifact=_bundle("one"))
+    (repo / "link.py").symlink_to("src/input.py")
+    _stage(repo, "link.py", env=env)
+    result = _run(repo, "check_bundles_local", env)
+    assert result.returncode == 0, result.stderr
+
+
+def test_hook_uses_staged_diff_for_deletion_paths(monkeypatch) -> None:
+    from scripts import precommit_bundle_currency
+
+    monkeypatch.setattr(precommit_bundle_currency, "REPO_ROOT", Path("."))
+    monkeypatch.setattr(
+        precommit_bundle_currency.subprocess,
+        "check_output",
+        lambda *args, **kwargs: (
+            b"skills/demo/scripts/demo.pyz"
+            + bytes((0,))
+            + b"src/name"
+            + bytes((10,))
+            + b"with-newline.py"
+            + bytes((0,))
+        ),
+    )
+    assert precommit_bundle_currency._staged_inputs() == [
+        "skills/demo/scripts/demo.pyz",
+        "src/name" + chr(10) + "with-newline.py",
+    ]


### PR DESCRIPTION
This semantics-altering change makes bundle currency an enforceable local and staged-index contract instead of a CI-only failure.

## What changed

- add a non-mutating local checker that rebuilds from the current Git-visible worktree and compares canonical Shiv member content
- add an index-pure `prek` hook that materializes and rebuilds the staged snapshot, including deletion-only changes and alternate indexes
- preserve the existing explicit HEAD comparison for CI
- include pinned build and runtime requirements in isolated rebuilds
- wire bundle currency into `just check`

## Verification

- `just check`
- `pyright scripts/check_bundles.py scripts/check_bundles_local.py scripts/precommit_bundle_currency.py tests/python/test_bundle_currency.py`
- final severity review: SHIP, no P0-P3 findings

## Reviewer focus

- confirm worktree, index, and HEAD comparisons remain isolated from one another
- confirm unusual staged paths, deletions, symlinks, missing/new bundles, and alternate indexes fail or pass at the intended boundary
- confirm the hook remains scoped to bundle-affecting inputs

## Provenance

Extracts the remaining staged-index currency contract from #459 onto the current package-derived Shiv architecture. The accepted decision already lives in `.hallouminate/wiki/adr/pyz-pipeline-contracts-002.md`; no new durable architecture decision was introduced.

## Risk

The local gate performs a full isolated bundle rebuild when relevant worktree inputs change. This is intentionally slower than a metadata-only check in exchange for validating the actual generated artifacts.
