### PR TITLE
chore(typing): pin basedpyright config and teach the python-authoring skill

### DIFF
--- a/.agents/skills/python-authoring/SKILL.md
+++ b/.agents/skills/python-authoring/SKILL.md
@@ -17,7 +17,7 @@ This is a repository-local skill. Keep it under `.agents/skills/python-authoring
 4. Validate untrusted input once at the boundary, then work with typed trusted data.
 5. Choose the clearest succinct Python construct; do not compress code until it becomes harder to read.
 6. Remove only slop introduced by the change and code that the change orphaned.
-7. Run targeted tests, rebuild affected bundles, then run `just check`.
+7. Type-check changed files with basedpyright, run targeted tests, rebuild affected bundles, then run `just check`.
 
 ## Keep runtime code stdlib-first
 
@@ -66,6 +66,17 @@ This is a repository-local skill. Keep it under `.agents/skills/python-authoring
 - Consolidate repetitive tests by behavior; do not add shallow input-variation tests.
 - Fix the underlying lint issue instead of adding a suppression.
 
+## Type-check with basedpyright
+
+- Run `basedpyright <changed .py files>` (fall back to `uvx basedpyright` if the binary is absent) before finishing. Changed files must report zero errors and warnings.
+- Repo config lives in `[tool.basedpyright]` in `pyproject.toml`: include paths, `pythonVersion = "3.12"`, and an execution environment pinning `src/easy_cheese_schemas` to 3.11 to honor the published wheel's `requires-python >=3.11`. `typeCheckingMode` is deliberately unset — basedpyright defaults to `recommended`, which enables every rule with an error/warning split and `failOnWarnings`, so a full run fails on warnings too.
+- Scope runs to the files the change touched: the repo carries a large pre-existing backlog, so a whole-repo run is red by design. Pre-existing diagnostics in untouched files are out of scope; report them, do not fix them. If the repo adopts a baseline (`basedpyright --writebaseline` → `.basedpyright/baseline.json`), never hand-edit it — entries for fixed diagnostics are removed automatically on the next run.
+- basedpyright is stricter than stock pyright; its extra rules are binding here: assign deliberately ignored call results to `_` (`reportUnusedCallResult`), collapse implicit string concatenations, and `cast` untrusted boundary reads to their validated type.
+- Load build-only modules that are excluded from wheels with `importlib.import_module` plus `cast`-typed `getattr`, not static imports the checker cannot resolve.
+- Fix the type at its source. When a suppression is genuinely unavoidable, use rule-scoped `# pyright: ignore[ruleName]`, never a bare `# type: ignore` or a file-wide switch — `reportIgnoreCommentWithoutRule` flags unscoped ignores.
+- Use `--outputjson` when a tool needs machine-readable diagnostics. In GitHub Actions the CLI detects CI and emits inline PR annotations with no extra flags.
+- The binary is mise-managed and pinned to an exact version (upstream recommends exact pinning for reproducibility); the `pyright` and `pyright-langserver` shims resolve to basedpyright.
+
 ## Test and finish
 
 - Test observable behavior and the reason it matters; do not add assertions that can pass when the implementation is broken.
@@ -85,4 +96,5 @@ Confirm:
 - Bundle registration and generated `.pyz` files match their sources when applicable.
 - CLI and validator failures remain loud, read-only validators remain read-only, and tests are hermetic.
 - No silent failures, speculative abstractions, narration comments, unnecessary local annotations, or unrelated cleanup remain.
+- Changed Python files pass basedpyright with zero errors and warnings.
 - A fresh `just check` run passed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,18 @@ only-include = [
   "docs/easy-cheese-schemas.md",
   "LICENSE",
 ]
+# typeCheckingMode is deliberately unset: basedpyright's default "recommended"
+# tier matches the editor LSP diagnostics.
+[tool.basedpyright]
+include = ["src", "scripts", ".github/scripts", "tests"]
+pythonVersion = "3.12"
+
+# The published easy-cheese-schemas wheel declares requires-python >=3.11, so
+# its sources must not use 3.12-only features.
+[[tool.basedpyright.executionEnvironments]]
+root = "src/easy_cheese_schemas"
+pythonVersion = "3.11"
+
 [tool.vulture]
 min_confidence = 60
 paths = [


### PR DESCRIPTION
## Summary

Semantics-preserving tooling change: pins basedpyright's repository configuration and records its usage doctrine in the `python-authoring` skill. No runtime code changes.

- **`pyproject.toml`** — new `[tool.basedpyright]` section: include paths matching vulture's (`src`, `scripts`, `.github/scripts`, `tests`), `pythonVersion = "3.12"`, and an execution environment pinning `src/easy_cheese_schemas` to 3.11 so the published wheel's `requires-python >=3.11` floor is checked, not assumed. `typeCheckingMode` is deliberately unset — basedpyright's `recommended` default matches the editor LSP diagnostics.
- **`.agents/skills/python-authoring/SKILL.md`** — extends the "Type-check with basedpyright" section with the repo config rationale, scoped-run policy against the pre-existing backlog (whole-repo run is red by design: 1,961 errors / 14,881 warnings), the `--writebaseline` adoption workflow, rule-scoped suppression policy, `--outputjson`, and GitHub Actions auto-annotation behavior.

Backed by cited research in `.cheese/research/basedpyright-capabilities/` (untracked; primary sources: docs.basedpyright.com, PyPI).

## Reviewer verification

- The `[tool.basedpyright]` section changes no build/packaging behavior (hatchling ignores unknown tool tables).
- `basedpyright scripts/build_pyz.py scripts/check_bundles.py` under the new config: 0 errors, 0 warnings (matches #529's clean state).
- The 3.11 execution environment covers exactly the published package sources.

## Out of scope

- No baseline file: adopting `.basedpyright/baseline.json` to grandfather the backlog is a separate, reviewable decision.
- No basedpyright dev-dependency plumbing or CI job; the binary is machine-managed (mise pin `npm:basedpyright = 1.39.10`, see dotfiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018V6nZ6MgNn3vNPgQCRVwky
