### PR TITLE
ci: adopt the next soak channel for pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    # All PRs land on the next soak channel; main only advances by
+    # fast-forward promotion (see CONTRIBUTING.md "Release channels").
+    target-branch: next
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -17,6 +20,7 @@ updates:
 
   - package-ecosystem: pip
     directory: /
+    target-branch: next
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -26,6 +30,7 @@ updates:
 
   - package-ecosystem: pip
     directory: /docs
+    target-branch: next
     schedule:
       interval: weekly
     open-pull-requests-limit: 5

--- a/.github/workflows/build-pyz.yml
+++ b/.github/workflows/build-pyz.yml
@@ -16,8 +16,8 @@ on:
       - 'requirements-build.txt'
       - 'requirements/**/*.txt'
   push:
-    branches: [main]
-    # Keep the check on main too so stale bundles are visible after merges.
+    branches: [main, next]
+    # Keep the check on main/next too so stale bundles are visible after merges.
     paths:
       - '.github/workflows/build-pyz.yml'
       - 'src/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,14 @@
 # CodeQL — GitHub's semantic code analysis for finding security
-# vulnerabilities and code quality issues. Runs on PRs, pushes to main,
+# vulnerabilities and code quality issues. Runs on PRs, pushes to main/next,
 # and weekly to catch newly disclosed query updates.
 # See: https://github.com/github/codeql-action
 name: codeql
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, next]
   push:
-    branches: [main]
+    branches: [main, next]
   schedule:
     - cron: "32 5 * * 1"
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,7 +6,7 @@ name: dependency review
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, next]
 
 permissions:
   contents: read

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,7 +3,7 @@ name: validate
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, next]
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,14 @@ Do NOT commit or push when `just check` fails. If CI fails, pull the branch loca
 - [`uv`](https://github.com/astral-sh/uv) — `lint-py-fix` invokes `uvx ruff` (no global ruff install needed)
 - `yamllint`, `yamlfmt`, `markdownlint-cli2`, `shellcheck`, `bats` — see README for install hints
 
+## Release channels: PRs target `next`, never `main`
+
+All pull requests use `--base next` (the integration/soak channel) and
+squash-merge there. `main` is the stable channel and advances only by
+fast-forward promotion (`just promote`). Do not open PRs against `main`
+and never squash-merge `next` into `main` — that breaks fast-forward
+parity. See CONTRIBUTING.md "Release channels".
+
 ## Skills in this repo
 
 This is a skills-only collection following the [Agent Skills spec](https://agentskills.io/specification). Every change either adds, edits, or supports a skill under `skills/<name>/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,9 +85,25 @@ bats tests/bash/test_install.bats
 
 Please run the full test suite before opening a PR.
 
+## Release channels
+
+The repo runs two branches:
+
+- **`next`** — integration/soak channel. Every pull request targets
+  `next` (`gh pr create --base next`) and is squash-merged there.
+- **`main`** — stable channel and default branch. It advances **only**
+  by fast-forward promotion from `next` (`just promote`); nothing merges
+  to `main` directly. Never open a promotion PR — a squash-merge to
+  `main` would rewrite the promoted SHAs and permanently break
+  fast-forward parity between the branches.
+
+Releases are tagged on `main` after a promotion, so published tags only
+ever contain soaked changes.
+
 ## Submitting a pull request
 
-1. Fork the repo and create a topic branch from `main`.
+1. Fork the repo and create a topic branch from `next`, and open your
+   PR against `next` (not `main`).
 2. Make your change. Keep commits focused; one concern per commit is
    easier to review than a kitchen-sink commit.
 3. Use [Conventional Commits](https://www.conventionalcommits.org)

--- a/justfile
+++ b/justfile
@@ -38,6 +38,29 @@ test-skill-overlap:
 bundle:
     python3 scripts/build_pyz.py
 
+# Fast-forward main to next once the soak channel's CI is green.
+# Never promote via a PR: a squash-merge to main rewrites SHAs and
+# permanently breaks fast-forward parity between the channels.
+promote:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    git fetch origin main next
+    if ! git merge-base --is-ancestor origin/main origin/next; then
+      echo "promote: main has commits next lacks — rebase next onto main first" >&2
+      exit 1
+    fi
+    if [ "$(git rev-parse origin/main)" = "$(git rev-parse origin/next)" ]; then
+      echo "promote: main is already at next — nothing to do"
+      exit 0
+    fi
+    conclusion=$(gh run list --branch next --workflow validate --limit 1 --json conclusion --jq '.[0].conclusion // "none"')
+    if [ "$conclusion" != "success" ]; then
+      echo "promote: latest validate run on next is '$conclusion', not success — refusing" >&2
+      exit 1
+    fi
+    git push origin origin/next:refs/heads/main
+    echo "promoted: main fast-forwarded to $(git rev-parse --short origin/next)"
+
 # Preview the exact tree a release ships (skills + .pyz only, no sources)
 release-preview:
     python3 scripts/stage_release.py --out .release-preview


### PR DESCRIPTION
## Why

Dogfooding a risky change (e.g. the `cut` RED gates) currently requires merging to `main`, where every install channel picks it up immediately. This PR introduces a two-channel model: all PRs land on a `next` integration/soak branch; `main` stays the stable channel and default branch, advancing only by fast-forward promotion (`just promote`) once the soak proves out. Releases keep tagging `main`, so published tags only ever contain soaked changes.

This is the last PR that targets `main` directly; the `next` branch and its ruleset are created from the merged tip.

## What

- `validate.yml` / `build-pyz.yml`: push CI also runs on `next`
- `codeql.yml` / `dependency-review.yml`: cover PRs into and pushes to `next`
- `dependabot.yml`: `target-branch: next` for all ecosystems
- `justfile`: `promote` recipe — verifies FF-ability and green `validate` on `next`, then fast-forwards `main`
- `CONTRIBUTING.md` / `AGENTS.md`: document the channel model and the never-promote-via-PR rule

Docs deploy, Scorecard, and publish-pypi stay main-only by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018V6nZ6MgNn3vNPgQCRVwky