### PR TITLE
docs(wiki): record the release-channel model

### DIFF
--- a/.hallouminate/wiki/architecture/index.md
+++ b/.hallouminate/wiki/architecture/index.md
@@ -4,6 +4,7 @@
 - [age-fanout-router](./age-fanout-router.md) — Age fan-out router
 - [plate-runtime-contract](./plate-runtime-contract.md) — Plate runtime contract
 - [pyz-bundling-pipeline](./pyz-bundling-pipeline.md) — Pyz bundling pipeline
+- [release-channels](./release-channels.md) — Release channels: next soak branch and stable main
 - [schema-similarity-and-consolidation-audit](./schema-similarity-and-consolidation-audit.md) — Schema similarity and consolidation audit
 - [skill-python-bundle-doctrine](./skill-python-bundle-doctrine.md) — Skill Python bundle doctrine
 - [ultracook-agent-topology](./ultracook-agent-topology.md) — Ultracook agent topology (now owned by /cook's fan pathway)

--- a/.hallouminate/wiki/architecture/release-channels.md
+++ b/.hallouminate/wiki/architecture/release-channels.md
@@ -1,0 +1,48 @@
+# Release channels: next soak branch and stable main
+
+## Decision (2026-08-29, PR #540)
+
+The repo runs two branches:
+
+- **`next`** — integration/soak channel. Every PR targets `next`
+  (`gh pr create --base next`) and squash-merges there. Dependabot
+  targets `next`. Push CI (`validate`, `build-pyz`), CodeQL, and
+  dependency review all cover `next`.
+- **`main`** — stable channel and GitHub default branch. Advances
+  **only** by fast-forward promotion (`just promote`), which verifies
+  FF-ability and a green `validate` run on `next` before pushing
+  `origin/next:refs/heads/main`. Releases keep tagging `main`, so
+  `release.yml`'s ancestry gate (tag must be an ancestor of `main`)
+  is unchanged — tag after promoting, never on `next`.
+
+## Why this design, not that one
+
+- **Problem**: the maintainer's install floats the default branch via
+  the dotfiles skill sync, so dogfooding a risky change (e.g. `cut`'s
+  RED gates) previously required merging to `main` — every channel got
+  it instantly, and the next tag shipped it unsoaked.
+- **Rejected: lagging `release` branch off `main`.** Consumers already
+  track `main` (npx skills add resolves the default branch); demoting
+  `main` would migrate every install. Inverting to a `next` soak branch
+  keeps every external channel untouched.
+- **Rejected: promotion via PR.** A squash-merge to `main` rewrites the
+  promoted SHAs and permanently breaks fast-forward parity between the
+  branches. Promotion is always a direct FF push (admin bypass on the
+  `main-protection` ruleset covers the PR-requirement rule; the
+  `non_fast_forward` rule is satisfied by construction).
+
+## Gotchas
+
+- **Nothing lands on `main` directly.** Any direct squash to `main`
+  diverges the channels and forces a `next` rebase.
+- `next-protection` ruleset (id 21836182) mirrors `main-protection`:
+  deletion + non-FF blocked, PRs required, admin always-bypass.
+- Docs deploy, OpenSSF Scorecard, and `publish-pypi` stay main-only by
+  design — publishing from an unsoaked branch would defeat the model.
+- The maintainer's machine tracks `next` via `pin: next` in the
+  dotfiles `skills/_registry.yaml`; the sync's
+  `_cz_vendor_external_skills` refreshes branch pins on every sync
+  (fixed alongside this change — previously a pin froze at clone time).
+
+Channel rules for contributors live in CONTRIBUTING.md ("Release
+channels") and AGENTS.md ("Release channels: PRs target `next`").


### PR DESCRIPTION
Records the next/main channel decision, the rejected alternatives, and the promotion gotchas in the durable wiki. Also the first PR through the new `--base next` lane, exercising the channel CI end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018V6nZ6MgNn3vNPgQCRVwky