### PR TITLE
docs: document the next vs main release-channel model

### DIFF
--- a/.hallouminate/wiki/analytics/index.md
+++ b/.hallouminate/wiki/analytics/index.md
@@ -1,0 +1,5 @@
+# analytics
+
+<!-- HALLOUMINATE:INDEX-START -->
+- [skill-adherence-2026-08-30](./skill-adherence-2026-08-30.md) — Skill adherence analysis — 2026-08-30
+<!-- HALLOUMINATE:INDEX-END -->

--- a/.hallouminate/wiki/analytics/skill-adherence-2026-08-30.md
+++ b/.hallouminate/wiki/analytics/skill-adherence-2026-08-30.md
@@ -1,0 +1,37 @@
+# Skill adherence analysis — 2026-08-30
+
+Cross-harness session-analytics pass over 1,017 Claude + 385 Codex sessions (Jul 29 – Aug 30 Claude; May 30 – Aug 30 Codex). Filed as #542–#553 comments, #552 (age inline-fix), #553 (umbrella: suggestions → gates). This page records the durable findings and the measurement gotchas so the next pass does not rederive them.
+
+## Core finding
+
+Claude follows skill instructions written as rules and skips instructions written as numbered steps with a degrade clause. Measured adherence to hedged steps is ~1%: 8 `ground` calls in ~350 skill runs; 0 `tilth_deps` in cook/cut/cure/mold/culture; 2 of 62 cooks preceded by a cut; `/age` → `/cure` invoked 9 of 151 times (110 `coder` spawns inside age spans instead). Rules phrased imperatively (mold full ceremony, user-owned forks, press → age) are followed every run. Fix shape is a precondition on the next artifact, not prose (#553).
+
+Codex, reading the same SKILL.md files, grounds (26 calls / 32 mold runs) and delegates (46 spawns) — it re-reads SKILL.md 1–2× per run, Claude gets it injected once.
+
+## Per-skill numbers (Claude, span = invocation → next Skill invocation, idle capped at 10 min)
+
+| skill | n | med active min (p90) | note |
+|---|---|---|---|
+| cut | 6 | 47 (83) | 3× cook; all red-gate rejections environmental (coverage outputs, virtualenv symlink, digest drift) |
+| mold | 20 | 42 (52) | ~10 AskUserQuestions/run, 19-min median wait each → 249 min session wall; 28 Bash/run vs 1 explorer |
+| cook | 21 | 15 (27) | healthy |
+| cure | 10 | 16 (34) | healthy; budget overruns live in age (88) not cure (9) |
+| age | 151 | 9 (46) | 7+-agent runs: 73 min, 32 writes — cure work wearing age's name |
+| plate | 37 | 7 (68) | errors are tool call-shape under a 306+493-line prompt |
+| press | 6 | 4 (8) | clean on both harnesses |
+| wheypoint | 19 | 4 (18) | 35% `commit` rejection since 08-16 — delta schema undocumented (#423) |
+| briesearch | 50 | 3 (36) | dedup target is reads/fetches (69/79 tilth_read, 28/30 WebFetch repeats), not searches (9/254) |
+| culture | 3 | 12 (20) | short; skipped grounding/deps (#462) |
+
+Codex runs every phase skill 2–4× cheaper (mold 10, cook 5, age 2, cut 21 min).
+
+Artifact I/O confirms write-only types: `.cheese/press` 10 writes / 2 reads, `cure` 24/3, `affinage` 20/3, `cut` 22/5; only `age` (28/96) and `notes` (186/96) are read-heavy.
+
+## Measurement gotchas (session-analytics DB)
+
+- **Codex skill attribution** = `tool_uses.input LIKE '%skills/<x>/SKILL.md%'` (tilth_read / exec_command reads), deduped within 10 min. There is no Skill tool; `$skill` text regex finds nothing because codex user prompts are not ingested at all (all 8,528 codex `user` rows are tool_results).
+- **Codex `exec` inputs are encrypted** (`{raw: gAAAA…}`); only `exec_command` (~2.1k calls) is cleartext. 35–81% of codex tool calls per skill are opaque.
+- **`exec_command` results do not join** to their `tool_use_id` (output arrives via later `wait`/`write_stdin`), so codex CLI outcomes (red-gate, wheypoint commit) are not attributable.
+- `tool_results.is_error_explicit` is documented in canonical-schema.md but absent from the live DB.
+- Session wall time is useless for skill cost — use spans and cap idle gaps. Sidechain entries overlap in time, so summing capped gaps at session level overcounts.
+- The Bash `.env` guard matches the literal substring in heredoc bodies (including `.venv`); write "virtualenv"/"dotenv" in issue text. `c` is a shell alias — don't name a function `c`.

--- a/.hallouminate/wiki/architecture/index.md
+++ b/.hallouminate/wiki/architecture/index.md
@@ -4,6 +4,7 @@
 - [age-fanout-router](./age-fanout-router.md) — Age fan-out router
 - [plate-runtime-contract](./plate-runtime-contract.md) — Plate runtime contract
 - [pyz-bundling-pipeline](./pyz-bundling-pipeline.md) — Pyz bundling pipeline
+- [release-channels](./release-channels.md) — Release channels: next soak branch and stable main
 - [schema-similarity-and-consolidation-audit](./schema-similarity-and-consolidation-audit.md) — Schema similarity and consolidation audit
 - [skill-python-bundle-doctrine](./skill-python-bundle-doctrine.md) — Skill Python bundle doctrine
 - [ultracook-agent-topology](./ultracook-agent-topology.md) — Ultracook agent topology (now owned by /cook's fan pathway)

--- a/.hallouminate/wiki/architecture/release-channels.md
+++ b/.hallouminate/wiki/architecture/release-channels.md
@@ -1,0 +1,48 @@
+# Release channels: next soak branch and stable main
+
+## Decision (2026-08-29, PR #540)
+
+The repo runs two branches:
+
+- **`next`** — integration/soak channel. Every PR targets `next`
+  (`gh pr create --base next`) and squash-merges there. Dependabot
+  targets `next`. Push CI (`validate`, `build-pyz`), CodeQL, and
+  dependency review all cover `next`.
+- **`main`** — stable channel and GitHub default branch. Advances
+  **only** by fast-forward promotion (`just promote`), which verifies
+  FF-ability and a green `validate` run on `next` before pushing
+  `origin/next:refs/heads/main`. Releases keep tagging `main`, so
+  `release.yml`'s ancestry gate (tag must be an ancestor of `main`)
+  is unchanged — tag after promoting, never on `next`.
+
+## Why this design, not that one
+
+- **Problem**: the maintainer's install floats the default branch via
+  the dotfiles skill sync, so dogfooding a risky change (e.g. `cut`'s
+  RED gates) previously required merging to `main` — every channel got
+  it instantly, and the next tag shipped it unsoaked.
+- **Rejected: lagging `release` branch off `main`.** Consumers already
+  track `main` (npx skills add resolves the default branch); demoting
+  `main` would migrate every install. Inverting to a `next` soak branch
+  keeps every external channel untouched.
+- **Rejected: promotion via PR.** A squash-merge to `main` rewrites the
+  promoted SHAs and permanently breaks fast-forward parity between the
+  branches. Promotion is always a direct FF push (admin bypass on the
+  `main-protection` ruleset covers the PR-requirement rule; the
+  `non_fast_forward` rule is satisfied by construction).
+
+## Gotchas
+
+- **Nothing lands on `main` directly.** Any direct squash to `main`
+  diverges the channels and forces a `next` rebase.
+- `next-protection` ruleset (id 21836182) mirrors `main-protection`:
+  deletion + non-FF blocked, PRs required, admin always-bypass.
+- Docs deploy, OpenSSF Scorecard, and `publish-pypi` stay main-only by
+  design — publishing from an unsoaked branch would defeat the model.
+- The maintainer's machine tracks `next` via `pin: next` in the
+  dotfiles `skills/_registry.yaml`; the sync's
+  `_cz_vendor_external_skills` refreshes branch pins on every sync
+  (fixed alongside this change — previously a pin froze at clone time).
+
+Channel rules for contributors live in CONTRIBUTING.md ("Release
+channels") and AGENTS.md ("Release channels: PRs target `next`").

--- a/.hallouminate/wiki/index.md
+++ b/.hallouminate/wiki/index.md
@@ -14,6 +14,7 @@ git-tracking axis (`skills/cheese/references/formatting.md:103`).
 
 <!-- HALLOUMINATE:INDEX-START -->
 - [adr/](./adr/index.md) — adr
+- [analytics/](./analytics/index.md)
 - [architecture/](./architecture/index.md) — architecture
 - [gotchas/](./gotchas/index.md) — gotchas
 - [specs/](./specs/index.md) — specs

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A portable, harness-agnostic Agent Skills toolkit for any [Agent Skills](https:/
 - [Skill layout](#skill-layout)
 - [Skills](#skills)
 - [Scope](#scope)
+- [Release channels](#release-channels)
 - [Python package](#python-package)
 - [Build skill archives](#build-skill-archives)
 - [Optional tools](#optional-tools)
@@ -127,6 +128,10 @@ Easy-cheese is intentionally a small surface. What that means in practice:
 - **No repo-wide MCP requirement.** Workflow skills suggest tools (tilth, Context7, Tavily) but have host-native fallbacks. Source-code work follows the shared routing contract: prefer tilth when present, use equivalent native AST/LSP/anchored-edit backends when available, and report any precision loss from bounded fallbacks.
 - **One orchestrator skill, narrowly scoped.** `/cook` is the single implementation orchestrator: focused specs use its single-coder path, while approved file-disjoint curds use its fresh-context fan pathway. `/ultracook` is only a compatibility redirect to `/cook`. Harvest and `/plate` remain parent-owned; parallel curds use sequential same-worktree phase spawns and a terminal reviewer pass before publication.
 - **No automatic re-age loop in `/cure`.** The skill describes the protocol; the human runs the next `/age` when ready.
+
+## Release channels
+
+Every pull request targets `next` (`gh pr create --base next`), the integration/soak channel. `main` is the stable channel and default branch; it advances only by fast-forward promotion (`just promote`) after `next` is green, and releases tag `main` after promotion — published tags only ever contain soaked changes. Never open a promotion PR: a squash-merge to `main` would rewrite the promoted SHAs and break fast-forward parity. See [CONTRIBUTING.md](CONTRIBUTING.md#release-channels) for the full contributor workflow.
 
 ## Python package
 


### PR DESCRIPTION
## Summary

- Adds a concise "Release channels" section to README.md (with TOC entry) summarizing the `next`/`main` soak model and pointing to CONTRIBUTING.md for details
- Creates the full decision record at `architecture/release-channels.md` in the hallouminate wiki — covers the decision, rejected alternatives, and gotchas
- Updates the wiki architecture index with the new page link

## Test plan

- [ ] Verify README TOC link resolves to the new section
- [ ] Verify wiki page content matches the PR #540 decision
- [ ] Confirm wiki index alphabetization is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)