### PR TITLE
docs(age): fold /simplify's altitude and closure-capture checks into the rubrics

### DIFF
--- a/skills/age/references/dimensions.md
+++ b/skills/age/references/dimensions.md
@@ -214,7 +214,7 @@ Recommendation shape: "Restore the X requirement" / "Confirm with the user that 
 
 ### complexity
 
-Look for: functions over budget (40 lines / 4 params / 3 nesting), files over 300 lines that grew, speculative abstractions, redundant state, parameter sprawl, stringly-typed code, explanatory-renaming comments, and the inverse failure — abstractions whose interface costs more than they hide: pass-through methods, pass-through variables, adjacent layers restating the same abstraction, wrapper types that forward every call.
+Look for: functions over budget (40 lines / 4 params / 3 nesting), files over 300 lines that grew, speculative abstractions, redundant state, parameter sprawl, stringly-typed code, explanatory-renaming comments, special cases layered on shared infrastructure when generalizing the underlying mechanism costs less (a bandaid-depth fix), and the inverse failure — abstractions whose interface costs more than they hide: pass-through methods, pass-through variables, adjacent layers restating the same abstraction, wrapper types that forward every call.
 
 | Base | Trigger |
 | --- | --- |
@@ -293,7 +293,7 @@ Recommendation shape: "Replace with `<existing-dep>.<fn>`" / "Use the stdlib `<f
 
 ### efficiency
 
-Look for: unnecessary work, missed concurrency, hot-path bloat, no-op updates, TOCTOU pre-checks, memory leaks, overly broad reads.
+Look for: unnecessary work, missed concurrency, hot-path bloat, no-op updates, TOCTOU pre-checks, memory leaks, long-lived objects built from closures that capture the enclosing scope (the capture keeps the whole scope alive — prefer a type that copies only the fields it needs), overly broad reads.
 
 | Base | Trigger |
 | --- | --- |


### PR DESCRIPTION
Closes two rubric gaps found by comparing the built-in /simplify skill against /age (analysis: cheez-wiki `engineering/simplify-vs-deslop-age.md`, paulnsorensen/cheez-wiki#15):

- **G1 — altitude:** no rubric line asked "is this change a bandaid on shared infrastructure?" Added to the complexity look-for list; the encapsulation/complexity boundary rows already route ownership cases correctly.
- **G2 — closure-capture leaks:** efficiency had "retained references after teardown" but never named the closure-capture mechanism (long-lived object keeps the whole enclosing scope alive). Added with the copy-only-needed-fields fix shape.

One line each; no severity-table or boundary-row changes. `just check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)