### PR TITLE
docs(release): record the v0.14 release decisions and #477 suggestions

### DIFF
--- a/.cheese/issues/477-suggestions.md
+++ b/.cheese/issues/477-suggestions.md
@@ -1,0 +1,181 @@
+# #477 — Enforceable skill boundaries and doctrine-compliant bundles
+
+Status: **suggested**. Base `bab83ce4` (main, cut-free).
+
+## Why this is not a single fix
+
+The design is settled — #477 links an approved Mold spec, ADRs
+`skill-boundary-protocol-001`, `skill-boundary-normalization-002`,
+`skill-bundle-authority-003`, `legacy-adapter-lifecycle-004`, and canonical
+`PlannerResult` / `CurdPlan` artifacts. What blocks it is ordering and other
+people's open PRs: the stated wave 1 requires restacking #433, and waves 2-7
+depend on ride-along dispositions for #429, #430, #455, #459, #460. Those are
+user calls on live branches, not code this pass can write.
+
+The waves below are re-cut so that **wave A has no open-PR dependency** and can
+start immediately.
+
+## What already exists on main (do not rebuild)
+
+- `src/easy_cheese/skills/<skill>/` + `src/easy_cheese/shared/` layout is in
+  place; `src/easy_cheese_schemas/` is the published schema package.
+- `scripts/build_pyz.py` builds one Shiv archive per registered skill;
+  `scripts/check_bundles.py` compares canonical member content.
+- `tests/python/test_pyz_bundle.py` already asserts several doctrine
+  properties: `test_bundle_carries_only_its_own_skill_package`,
+  `test_briesearch_bundle_uses_internal_distributions`,
+  `test_plate_bundle_validates_publication_without_source_imports`.
+- `@document_contract` / `@contract` decorators and the generated projections
+  (`_document_rules.py`, `_compiled_phase_registry.py`, `_schema_catalog.py`)
+  are the working precedent for "declare once, compile into the bundle".
+
+So the gap is not the mechanism. It is that the doctrine has no *derivation*
+(ownership is a hand-maintained registry) and no *rejection* (nothing fails a
+build when a skill reaches outside its archive).
+
+---
+
+## Wave A — layout-derived bundle ownership and rejection (no dependencies)
+
+Start here. This is the wave the release-decisions plan recommends for 0.15.
+
+### A1. Derive the skill registry from `src/easy_cheese/skills/`
+
+`scripts/build_pyz.py` currently carries an explicit registry of skills to
+build (the "13-skill registry" #562 had to hand-edit when `/cut` was removed —
+that hand-edit is the bug this item prevents). Replace it with a directory
+scan of `src/easy_cheese/skills/*/` mapped to `skills/<kebab-slug>/scripts/<slug>.pyz`,
+with the underscore→kebab conversion in one shared helper.
+
+Regression test (`tests/python/test_pyz_bundle.py`): create a temporary
+skill package under a staged source tree and assert the default batch builds
+exactly one archive for it — asserting the derived path, not that "a file
+exists". Assert the inverse too: a `skills/<name>/` directory with no
+corresponding `src/easy_cheese/skills/<name>/` package must build no `.pyz`,
+and an orphan `.pyz` with no source package must fail `check_bundles.py`.
+
+### A2. Reject cross-skill imports at build time
+
+Add an import-closure check to `scripts/build_pyz.py` (this is the work #460
+prototyped; port the AST logic rather than re-deriving it). For each built
+archive, walk the staged tree's ASTs and fail the build on any
+`import easy_cheese.skills.<other>` where `<other>` is not the owning skill.
+`easy_cheese.shared` and `easy_cheese_schemas` stay permitted.
+
+Regression test: stage a skill package that imports another skill's module and
+assert `build_pyz.py` exits non-zero with the offending module and symbol in
+the message. Assert a `shared` import in the same position still builds.
+
+### A3. Reject non-pure-Python and ambient dependencies
+
+Doctrine forbids native extensions, platform-specific libraries, required
+external executables, runtime installation, and caller-managed extraction. Add
+to the same pass: fail on any `.so` / `.pyd` / `.dylib` member in a built
+archive, and on any staged distribution whose wheel tag is not `py3-none-any`.
+
+Regression test: build with a deliberately impure wheel staged in a temp
+requirements file and assert the specific rejection message.
+
+### A4. Reject repository-path and `PYTHONPATH` escapes in skill prose
+
+`.github/scripts/validate_skills.py` already parses every `SKILL.md`. Extend it
+to fail when a skill's prose or references invoke anything other than its own
+archive: another skill's `.pyz`, a `scripts/` path, `common.pyz`, or a bare
+`python3 src/...`. Today `skills/mold/references/curdle.md` still documents a
+`python3 shared/scripts/artifact_path.py` fallback — that is the pattern to
+catch.
+
+Regression test in `.github/scripts/test_validate_skills.py`: a fixture skill
+invoking a sibling archive must fail with the offending line quoted; the same
+skill invoking `skills/<self>/scripts/<self>.pyz` must pass.
+
+**Wave A exit criterion:** `just check` green, and removing a skill's source
+package makes the build fail loudly instead of leaving a stale archive.
+
+---
+
+## Wave B — `@bundle_command` declarations (depends on A1 only)
+
+Each skill's `commands.py` (`src/easy_cheese/skills/<skill>/commands.py`)
+hand-maintains its subcommand map. Introduce a `@bundle_command("<verb>")`
+decorator in `src/easy_cheese/shared/` following the exact pattern of
+`@contract` in `src/easy_cheese_schemas/contracts.py` (module-scan +
+marker attribute + deterministic ordering), and compile the declarations into
+a generated per-skill command map staged into that skill's archive — the same
+build-time projection pattern as `src/easy_cheese/shared/document_rules.py`.
+
+This removes the drift class where a decorator exists but the dispatcher does
+not list it, and it is the prerequisite for generated per-skill command
+guidance in `SKILL.md`.
+
+Regression test: extend the existing
+`test_kebab_commands_and_legacy_aliases_dispatch_from_committed_bundles` to
+assert the generated map is byte-identical to a fresh compile (a stale
+projection must fail the build), and that an undeclared verb exits 2.
+
+---
+
+## Wave C — pointer-last Mold producer / pointer-only Cook consumer
+
+This is the vertical boundary the issue actually names, and it is the wave that
+should wait: it touches `PlannerResult` publication order and Cook's ingress,
+both of which the ride-along PRs (#429, #430) still hold work for.
+
+Shape, when it starts:
+
+1. `HandoffPointer` contract in `src/easy_cheese_schemas/` (a new
+   `@contract("handoff-pointer")` class next to the `CurdPlan` declaration),
+   carrying `schema_uri`, `contract_version`, payload path, and payload digest.
+2. Mold's curdle path writes payload → optional `NormalizationReceipt` →
+   *then* the pointer. The pointer's appearance is the commit signal; an
+   interrupted publication leaves no pointer and is therefore re-runnable.
+   Seam: `src/easy_cheese/skills/mold/` curdle writer.
+3. Cook's ingress (`src/easy_cheese/skills/cook/`, the merged CLI from #470)
+   accepts *only* a pointer, resolves it, and re-validates the payload digest
+   before use. Reject inline payloads with a typed error, not a fallback.
+
+Regression test at the real seam: write a payload and pointer to a tmp tree,
+then assert Cook's ingress (a) accepts the pointer, (b) rejects the payload
+passed directly, and (c) rejects a pointer whose digest no longer matches the
+payload on disk.
+
+**Dependency note:** #430 carries projection/reference work. Land the pointer
+contract in exactly one place — do not create a second schema authority. If
+#430 lands first, extend its projection rather than adding a parallel one.
+
+---
+
+## Wave D — index/HEAD bundle currency
+
+Port #459's currency enforcement after waves A and B: `check_bundles.py`
+should fail when a committed `.pyz` does not match the *staged index*
+content of its source, not merely the working tree. This is what turns "the
+bundle is stale" from a merge-time surprise into a commit-time one.
+
+Pair it with the CI fix in
+[`../plans/release-0-14-decisions.md`](../plans/release-0-14-decisions.md) § (c):
+currency enforcement is worthless while `build-pyz` is not a required check on
+`main`.
+
+---
+
+## Sequencing summary
+
+| Wave | Scope | Blocked on |
+|---|---|---|
+| A | Derived ownership, cross-skill/native/path rejection | nothing |
+| B | `@bundle_command` compilation | A1 |
+| C | Pointer-last Mold → pointer-only Cook | #429/#430 disposition |
+| D | Index/HEAD bundle currency | A, B, and required checks on `main` |
+
+Waves A and B are ordinary implementation work with clean outer seams and no
+open-PR entanglement. Wave C is the one that genuinely needs the ride-along
+decisions the triage note flagged. Do not open wave C before those are settled.
+
+## Explicitly out of scope
+
+The 0.14 release should ship the doctrine as documentation with the
+"skill boundaries are documented, not enforced" caveat drafted in
+`../plans/release-0-14-decisions.md` § (d). Partial enforcement is worse than
+none: a check that catches three of five violation classes reads as a
+guarantee it does not provide.

--- a/.cheese/plans/release-0-14-decisions.md
+++ b/.cheese/plans/release-0-14-decisions.md
@@ -1,0 +1,343 @@
+# Release 0.14 — open decisions
+
+Base: `bab83ce4` (main, cut-free, basedpyright 0/0). Prior tag: `v0.13.0`.
+Scope: five decisions the release owner must land or consciously defer before
+tagging 0.14. Each carries one recommendation, not a menu.
+
+---
+
+## (a) Spec-format fork from #466 — v0.13-era specs fail `validate-spec` unconditionally
+
+### What is actually true
+
+`git ls-tree v0.13.0 --name-only src/` returns
+`affinage age assets briesearch components content.config.ts content fanout
+hard-cheese melt mold pasteurize styles` — **there is no
+`src/easy_cheese_schemas` at v0.13.0**. The whole schemas package landed after
+the tag (#380 published it to PyPI; #466 added the document-contract layer).
+The v0.13 spec shape was never schema-declared; it was prose in
+`skills/mold/references/curdle.md` § Spec template.
+
+Reproduced against a spec built verbatim from the v0.13.0 template
+(`git show v0.13.0:skills/mold/references/curdle.md`), run through
+`skills/mold/scripts/mold.pyz validate-spec`:
+
+```text
+ERROR: missing-required-section 'Test Contracts' section not found in <spec>
+ERROR: gate-applicability-required frontmatter gate_applicability is missing or unparseable in <spec>
+
+FAIL: 2 error(s) in <spec>
+EXIT=1
+```
+
+Both failures are structural and unconditional: the v0.13 template has no
+`## Test Contracts` section and no `gate_applicability` frontmatter key, and
+neither can be absent under
+`src/easy_cheese/shared/document_rules.py` (`sections[].optional = False` for
+Test Contracts) or `src/easy_cheese/skills/mold/validate_spec.py:322-327`.
+`validate-spec` blocks curdle through the `spec-format-valid` gate node
+(`tests/python/test_gate_graph.py:637-684`), so this is a hard stop, not a
+warning.
+
+### Options weighed
+
+**Option 1 — ship as a documented breaking change.**
+Cost: any spec authored under v0.13 must be re-run through `/mold`, or
+hand-patched with a `gate_applicability` block and a `## Test Contracts` table.
+
+**Option 2 — legacy-accept path in the schemas package.**
+Cost: a permanent legacy branch in `validate_spec.py`, a second rule set in the
+`_document_rules` projection, a sunset timer, and its own test matrix.
+
+The decisive fact is that Option 2 **cannot be built as an adapter**. A v0.13
+spec contains no source for any of the seven Test Contracts columns
+(`Acceptance ID`, `Interface referent`, `Outermost stable seam`,
+`Expected failure`, `Mode`, `Interface version`, `Matrix rows`) nor for
+`work_class` / `ui_surface`. Its Acceptance section is EARS prose bullets with
+no `AC-<n>:` identifiers, so even `ac-coverage-exactly-once` has nothing to
+bind. A legacy path would have to *synthesise* those semantics — i.e. guess a
+seam and a witness — and then issue a passing verdict on the guess. That is
+precisely what ADR `legacy-adapter-lifecycle-004` forbids: migration happens
+"only through exact schema/version adapters with declared sunsets", and no
+exact adapter exists from an unversioned prose template to a semantic contract.
+
+This is also the failure mode #401 already reported from the other direction
+(Mold-produced specs rejected by Cut's contract inference). Adding a lenient
+accept path re-opens that class rather than closing it.
+
+### Recommendation — Option 1: ship as a documented breaking change
+
+Blast radius is bounded and non-durable: specs live in per-project `.cheese/`
+scratch, which is gitignored, not in a published artifact surface. The migration
+is two additive edits to a document a human already owns.
+
+Do:
+
+1. Add a **"v0.13 → v0.14 spec migration"** subsection to
+   `skills/mold/references/curdle.md`, immediately after § Spec template,
+   listing exactly the two required additions and pointing at
+   `tests/python/fixtures/spec_format/valid_spec.md` as the worked example.
+2. Ship the release-notes caveat drafted in (d).
+3. Do **not** add a `--legacy` or `--lenient` flag. `validate-spec` already
+   separates syntax repair from semantic rejection; a bypass flag would erode
+   the only thing the gate buys.
+
+Do not do in 0.14: `gate_applicability.disposition` still carries the enum
+value `red-required` (`src/easy_cheese/shared/document_rules.py`) on a tree
+where the RED gate was removed by #560. The field itself is still load-bearing
+— `src/easy_cheese/skills/mold/curd_count.py` and
+`src/easy_cheese/shared/taste_test.py` both consume it — so keep it. Renaming
+the enum value now would be a *second* spec-format break in one release.
+Track the rename as post-0.14 work and land it with a real adapter.
+
+---
+
+## (b) #470 strict contract-version equality — compat window before the first post-0.14 minor bump
+
+### Where it stands
+
+#470 deleted `_decimal_greater`, `_migrate_payload`, `_MIGRATION_REGISTRY`, and
+`MigrationStep`. Acceptance is now exact equality in two places:
+
+- `src/easy_cheese_schemas/schema_runtime.py:738` (`validate_contract`)
+- `src/easy_cheese_schemas/schema_runtime.py:679`
+  (`_validate_curd_plan_against`)
+
+The ADR (`writer-view-boundary-simplification-001`) justifies this on evidence:
+the migration registry was empty, and producer and consumer ship in the same
+commit. That reasoning holds **only while there is no independently versioned
+client** — which stops being true the moment `easy-cheese-schemas` (PyPI, now
+1.1.0) is consumed at a different version than the skill bundle that produced
+the payload.
+
+### The blocking precondition nobody has written down
+
+There is currently **no per-contract version declaration at all**.
+`schema_runtime.py:74-77` hardcodes every registered contract to 1.0:
+
+```python
+ContractVersion(schema_uri=schema_uri, major="1", minor="0")
+if "contract_version" in attrs.fields_dict(contract)
+else None
+```
+
+`contracts.py`'s `@contract(slug)` decorator records only a slug. So the first
+minor bump is not a one-line change — it needs a declaration seam first. A
+compat window that does not exist before that bump lands cannot be
+retrofitted afterwards without a second break.
+
+### Recommended mechanism — mirror `compat.py`, do not resurrect the registry
+
+`src/easy_cheese_schemas/compat.py` already ships the right shape for this
+repo: a `SCHEMA_VERSION` / `MIN_READABLE` pair with documented N-1 tolerance and
+a `classify_stamp` → `Provenance` (`CURRENT` / `PRIOR` / `STALE` / `FUTURE` /
+`UNSTAMPED`) verdict. It reports provenance rather than repairing payloads,
+which is exactly the property #470's ADR wanted to preserve.
+
+Land these five, in order:
+
+1. **Declaration seam.** Extend `contracts.py` `@contract(slug)` to
+   `@contract(slug, version="1.0", min_readable_minor="0")`, defaulting to
+   today's values so the change is inert. Consume it in
+   `contract_models.registered_contracts()` and in the `_RegisteredContract`
+   construction at `schema_runtime.py:70-80`, replacing the hardcoded literal.
+2. **Window check.** Replace both equality comparisons with: `schema_uri` must
+   match exactly; `major` must match exactly; `min_readable_minor <=
+   source.minor <= supported.minor`. Keep a *distinct* error message for a
+   future minor ("written by a newer producer") versus a too-old minor, so a
+   version skew is diagnosable from the message alone.
+3. **Additive-only constraint, in place of migration code.** A minor bump may
+   only add optional fields. That single rule is what makes a read window safe
+   without `_migrate_payload`, and it is the clause that replaces the
+   superseded minor-forward-migration text in
+   `workflow-contract-milknado-seam-002`. Enforce it with a test that diffs the
+   required-field set of the current contract against the previous minor's
+   frozen conformance fixture.
+4. **Widen the emitted JSON Schema with it.** `_contract_version_definition`
+   (`schema_runtime.py:216-231`) pins `"const": version.minor`. If runtime
+   widens and the published schema does not, a payload the library accepts is
+   rejected by the schema shipped to external consumers — a silent
+   producer/consumer fork in the PyPI package. Change `minor` to
+   `{"enum": [<accepted minors>], "type": "string"}`; leave `major` and
+   `schema_uri` as `const`.
+5. **Conformance coverage.**
+   `src/easy_cheese_schemas/conformance/v1/contract-cases.json` needs a
+   prior-minor accept case and a below-window reject case, plus the matching
+   assertions in `tests/schemas/python/test_schema_runtime.py`.
+
+### Recommended timing
+
+**Ship 0.14 with strict equality as-is.** Every contract is at 1.0, so the
+window would be a no-op and would only add untested code to a release.
+
+Make the window a **merge-blocking prerequisite on the PR that first bumps any
+contract minor** — steps 1-5 land in that PR or before it, never after. Record
+the constraint in the release notes as a known limitation (text in (d)) and in
+the ADR so the next author does not discover it at bump time.
+
+---
+
+## (c) CI gap behind #562 — bundle regressions surface after merge
+
+### Root cause, verified
+
+Three independent holes, in descending order of blame:
+
+1. **`main` has no required status checks.**
+   `gh api repos/paulnsorensen/easy-cheese/branches/main/protection` →
+   `404 Branch not protected`. PR #560's `build-pyz` job **did** run and
+   **did** fail on both matrix legs (run `33334026483`, jobs `99317581430`
+   and `99317581515`) — and the PR merged anyway. Nothing about paths filters
+   or local skips would have mattered; the red check simply did not block.
+   This is the cause of #562.
+
+2. **The bundle suite silently skips locally.**
+   `tests/python/test_pyz_bundle.py:27` skips the whole module when `build`,
+   `pip`, or `shiv` is missing. `just check` runs it under the justfile's
+   interpreter (`justfile:2`):
+   `uv run --no-project --with-requirements requirements/runtime.txt --with
+   pip==26.2.1 --with pytest==9.0.3 --with pyyaml==6.0.2 python3` — no `build`,
+   no `shiv`. `requirements-build.txt` (`build`, `hatchling`, `shiv`) is never
+   installed for `check`. So the author sees green locally, and the *only*
+   thing that runs the suite is the one job that is not required.
+   `validate.yml`'s `pytest tests/python -q` has the same gap: its env installs
+   only `pytest`, `pyyaml`, and `requirements/runtime.txt`.
+
+3. **`build-pyz.yml` paths filter excludes `tests/`.** Both the
+   `pull_request` and `push` filters list `src/**`, `scripts/build_pyz.py`,
+   `scripts/check_bundles.py`, `skills/*/scripts/*.pyz`, `pyproject.toml`,
+   `requirements-build.txt`, `requirements/**/*.txt` — and nothing under
+   `tests/`. A PR that only edits the bundle suite (which is exactly what
+   #562 was) does not run the only job that executes it.
+
+### Recommended fix, in landing order
+
+**1. Require the checks (highest value, smallest diff).** Add a repository
+ruleset on `main` requiring, at minimum:
+
+- `check .pyz bundles are current`
+- `check .pyz bundles are current (Python 3.14)`
+- `test melt + shared + fan-out scripts`
+- `validate skills`
+- `lint markdown, yaml, python`
+- `type-check python`
+
+`/gh-bootstrap` already owns this ceremony. Until it is in place, every other
+item here is advisory.
+
+**2. Make the skip impossible where it must not happen.** Replace the bare
+`pytestmark = pytest.mark.skipif(...)` in `tests/python/test_pyz_bundle.py`
+with a guard that *fails* rather than skips when
+`EASY_CHEESE_REQUIRE_BUNDLE_TESTS=1`, and set that variable in
+`build-pyz.yml`'s "Test bundle build and isolation contracts" step. Five lines,
+and it converts "build tooling missing → silently green" into a hard error in
+the one job that is supposed to prove the bundles. Do this even if item 1 lands
+— it closes the class, not just the instance.
+
+**3. Add the test paths to the workflow filter.** In both `on.pull_request.paths`
+and `on.push.paths` of `.github/workflows/build-pyz.yml`, add:
+
+```yaml
+      - 'tests/python/test_pyz_bundle.py'
+      - 'tests/python/test_build_pyz_tree_staging.py'
+      - 'tests/python/fixtures/**'
+```
+
+Path-list rather than a blanket `tests/**`, so unrelated test edits do not pay
+the ~3-minute bundle build twice per matrix leg.
+
+**4. (Optional) Run the suite locally.** Add a `bundle-python` interpreter var
+to the justfile that appends `--with-requirements requirements-build.txt`, plus
+a `test-bundles` recipe running `tests/python/test_pyz_bundle.py` and
+`tests/python/test_build_pyz_tree_staging.py` under it, wired into `check` and
+`ci`. This is genuinely useful but costs a real shiv build in every local
+`just check`. Recommend deferring it behind items 1-3 and, if adopted, putting
+it in `check` only — never make `ci` depend on a recipe that item 1 already
+covers in a dedicated job.
+
+---
+
+## (d) Release-notes caveat queue
+
+Verification performed for this section:
+
+- **#304 — verified fixed on main; close it.** All three acceptance criteria
+  are implemented. Opt-in concurrent dispatch, isolated worktree, and the
+  resume link are specified in `skills/cook/references/quality-gates.md`
+  § Repair pathway (steps 1-5: dedupe / consent / worktree / dispatch /
+  record) with a § Merge-time topology section; the
+  `baseline.repair_dispatch: {slug, branch, pr}` block is declared in
+  § Baseline block shape; and it is enforced by
+  `tests/python/test_baseline_policy_coherence.py` and
+  `tests/fanout/python/test_validate_manifest.py`. Close as completed,
+  citing the repair-pathway section — not as stale.
+- **#492, #493, #393** — open, unimplemented, correctly stated as known gaps.
+- **#542, #457, #425, #401, #546** — all describe `/cut` and RED-gate
+  behaviour, which #560 removed from main. Retag each to the `next` channel
+  (label `channel/next`, or move to the next-channel milestone) so 0.14
+  triage does not keep surfacing issues about code that is not on this branch.
+  #401 in particular is *not* reproducible on main: `cut.pyz` no longer ships.
+
+### Draft caveat text (paste into the 0.14 release notes)
+
+> #### Known limitations
+>
+> **Skill boundaries are documented, not enforced.** The one-skill / one-bundle
+> doctrine in `AGENTS.md` § Skill Python bundle doctrine is the target
+> contract, and existing violations are migration work. Nothing in this release
+> mechanically prevents a skill from invoking another skill's archive, loose
+> source, or repository automation. Typed, enforced boundaries between skills
+> are tracked in #477 and are not part of 0.14 — treat the doctrine as a
+> review checklist, not a guarantee.
+>
+> **Spec format is a breaking change.** `/mold` now validates spec documents at
+> curdle time (`mold.pyz validate-spec`), and the gate blocks curdle. Specs
+> authored under v0.13 fail unconditionally: they lack the `## Test Contracts`
+> section and the `gate_applicability` frontmatter block, both of which are
+> required. Re-run `/mold` on the spec, or add the two sections by hand —
+> `skills/mold/references/curdle.md` § Spec template shows the shape and
+> `tests/python/fixtures/spec_format/valid_spec.md` is a passing example.
+> There is no legacy-accept mode: a v0.13 spec carries no source for the
+> acceptance IDs, seams, and witnesses the validator checks, so accepting one
+> would mean certifying a guess.
+>
+> **Contract versions are matched exactly.** `easy-cheese-schemas` accepts a
+> payload only when its `contract_version` equals the version the host was
+> built against. Every contract is at 1.0 today and producers ship with their
+> consumers, so this is invisible in 0.14 — but there is no compatibility
+> window yet. If you pin `easy-cheese-schemas` independently of the skill
+> bundles, keep the two in lockstep. A read window (N-1 minor tolerance,
+> additive-only minors) must land before the first contract minor bump.
+>
+> **Open gaps carried into 0.14.**
+> - `/briesearch` `artifact-path` returns the research root; there is no
+>   slug-aware `research-layout --json` command yet (#492).
+> - `ground-check` validates report structure and local evidence only. Cited
+>   remote URLs are not fetched or verified; that remains the selected
+>   provider's responsibility (#493).
+> - `/plate` does not use GitHub's documented `GET /repos/{owner}/{repo}/stacks`
+>   preflight for Stacked PRs enablement; it still discovers the requirement
+>   from an exit-4 on the first mutating operation (#393).
+>
+> **`/cut` is not in this release.** The RED-gate subsystem was removed from
+> the main channel. Issues #542, #457, #425, #401, and #546 describe its
+> behaviour and are tracked on the `next` soak channel, not here.
+
+---
+
+## (e) #477 — enforceable skill boundaries
+
+Design is settled (approved Mold spec, four ADRs, canonical `PlannerResult` and
+`CurdPlan` artifacts); execution ordering is not. Triage already marked it
+`deferred` for that reason, and the ride-along dispositions for #429, #430,
+#455, #459, and #460 are user calls about other people's open PRs — not
+something to decide unilaterally inside a release-decisions pass.
+
+Concrete implementation suggestions, with file paths and a wave order that does
+not depend on restacking #433 first, are in
+[`.cheese/issues/477-suggestions.md`](../issues/477-suggestions.md).
+
+**Recommendation for 0.14:** do not attempt any part of #477 in this release.
+Ship the doctrine as documentation with the caveat above, and start with
+wave A of the suggestions document (bundle-ownership enforcement) in the first
+0.15 cycle — it is the only wave with no open-PR dependency.


### PR DESCRIPTION
Adds .cheese/plans/release-0-14-decisions.md (channel model, legacy-accept, contract-version, pre-tag scope decisions) and .cheese/issues/477-suggestions.md. Docs only; refs #477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018V6nZ6MgNn3vNPgQCRVwky