### PR TITLE
docs(cut): decision docs for the next-channel cut issues

### DIFF
--- a/.cheese/issues/401-suggestions.md
+++ b/.cheese/issues/401-suggestions.md
@@ -1,0 +1,169 @@
+# Issue #401 — suggestions
+
+`bug: Mold-produced specs can fail Cut contract inference`
+
+## Channel — and why this one is different
+
+**Not reproducible on `main`, and the premise is partly stale on `next`.**
+
+Two separate reasons this issue cannot be actioned as written:
+
+1. **`main` cannot reproduce it.** PR #560 removed `/cut`; #562 dropped cut and
+   red-gate expectations from the `.pyz` bundle suite. `main` builds no
+   `cut.pyz`, so the reproduction step
+
+   ```text
+   python3 ~/.agents/skills/cut/scripts/cut.pyz red-gate contracts <spec>
+   ```
+
+   has no command to run. Anyone reproducing it today is running a previously
+   installed bundle, not anything `main` produces.
+
+2. **`next`'s Mold already emits the shape Cut demands.** The issue describes
+   Mold producing "narrative `Goals` and `Required cases`, but no acceptance
+   IDs, `gate_applicability`, or Test Contract table". On `origin/next`, Mold's
+   own grammar requires all three:
+
+   - `skills/mold/SKILL.md:74-98` — "Every spec declares `gate_applicability`";
+     "`red-required` requires `behavior` plus a complete `## Test Contracts`
+     table".
+   - `skills/mold/references/curdle.md:45,75,86-95` — the emitted spec carries
+     a `gate_applicability` block, an `## Acceptance` section, and a
+     `## Test Contracts` table with the exact seven columns
+     `_contract_table` parses.
+   - `skills/mold/references/curdle.md:159` — rule `ac-coverage-exactly-once`,
+     mirroring `red_gate.py:625-628`.
+   - `skills/mold/references/mini-spec-mode.md:21,32,36-37` — same shape in the
+     mini-spec path.
+
+Retag to a next-channel label **and** `triage/stale` on the reproduction, then
+keep the two genuinely-live pieces below. Do not close it outright: the
+integration test it asks for was never written, and the legacy-spec path it
+exposed is still a live refusal.
+
+## What is still real
+
+### The exact failure path, for the record
+
+`_parse_spec` (`src/easy_cheese/shared/cut/red_gate.py:538`) reaches legacy
+inference at `:616-620`:
+
+```python
+elif declaration is None:
+    if criteria:
+        for acceptance_id, statement in criteria.items():
+            contracts.append(_infer_contract(acceptance_id, statement))
+    else:
+        problems.append("legacy spec has no acceptance IDs to infer")
+```
+
+`criteria` comes from `_acceptance_criteria` (`:335-364`), which needs **both**:
+
+1. a heading whose text lower-cases to exactly `acceptance` or
+   `acceptance criteria` (`:341-345`), and
+2. at least one line inside it matching `_ACCEPTANCE_ID`
+   (`red_gate.py:176`: `\bAC-[0-9]+(?:[-.][A-Za-z0-9_-]+)?\b`).
+
+A spec with `## Goals` / `## Required cases` satisfies neither. `criteria` is
+empty, the first problem fires, and then — because `disposition_value` defaults
+to `red-required` with `work_class: behavior` (`:639-646`) — `:672-673` adds
+the second: `red-required requires at least one Test Contract`. Two errors, one
+cause.
+
+### The error messages name no remedy
+
+Both strings state what is missing and nothing about what to do. For a spec the
+same skill suite produced, that is the worst possible failure mode. Cheapest
+fix in this whole issue set:
+
+```text
+legacy spec has no acceptance IDs to infer: add a `## Acceptance` section whose
+items carry AC-<n> identifiers, or declare gate_applicability explicitly (see
+skills/mold/references/curdle.md)
+```
+
+Applies to `red_gate.py:620` and `:672`.
+
+### The integration test the issue asks for was never written
+
+`tests/python/` on `next` has `test_cut_spec_format_tracers.py`,
+`test_cut_skill_contract.py`, `test_cut_pressure_eval.py`, and the fixtures
+under `tests/python/fixtures/cut_spec_format/` — but nothing that drives a
+**Mold-shaped** spec end-to-end into a canonical receipt. That gap is why a
+schema disagreement between two skills in one repo could ship at all.
+
+## Proposal
+
+### 1. Pin the handshake with a real integration test (do this one)
+
+New `tests/python/test_cut_mold_spec_handshake.py`:
+
+- Fixture `tests/python/fixtures/mold_handshake/red_required_spec.md`, written
+  to Mold's **current** emitted grammar, copied structurally from
+  `skills/mold/references/curdle.md:45-95` — `gate_applicability` frontmatter,
+  `## Acceptance` with `AC-1`/`AC-2`, and the seven-column `## Test Contracts`
+  table.
+- Assert `_parse_spec` returns `disposition == RED`, `work_class == "behavior"`,
+  `contract_source == "approved"` for every contract, and **zero problems**.
+- Drive the full path — `begin_phase` -> oracle install -> `issue_gate` -> a
+  canonical receipt on disk — proving Cook preflight can obtain one. This is
+  literally the issue's "Expected" section.
+- Second fixture `not_applicable_spec.md` (`docs-only` + reason, no table) ->
+  N/A receipt.
+- **The load-bearing part:** derive the fixtures from the Mold reference docs,
+  and add an assertion that fails if
+  `skills/mold/references/curdle.md`'s Test Contracts column list and
+  `_contract_table`'s expected headers (`red_gate.py:381`) diverge. A fixture
+  that is hand-maintained will silently drift back into exactly this bug. A
+  fixture that is checked against the grammar cannot.
+
+### 2. Improve the two error messages
+
+As above. Two string edits, covered by an assertion in the new test module on
+the legacy-spec fixture.
+
+### 3. Decide the legacy-compat question explicitly — recommend "no"
+
+The issue offers two remedies; the first ("Mold emits acceptance IDs, an
+explicit `gate_applicability` declaration, and at least one valid Test
+Contract") is **already done** on `next`. The second — teach
+`_acceptance_criteria` to recognize `Required cases` and synthesize positional
+IDs — is a live option only for specs approved under an older Mold.
+
+**Recommend rejecting it.** Reasons:
+
+- `_infer_contract` (`red_gate.py:443-456`) already stamps inferred contracts
+  `mode=GateMode.TRACER` and `contract_source="inferred"`, so nothing gets
+  promoted — but widening the *heading* vocabulary means Cut silently invents
+  contracts from arbitrary prose sections. The blast radius is every spec in
+  every consuming repo with a section named `Required cases`, whether or not
+  its author meant it as acceptance criteria.
+- The workaround for a genuinely stale spec is one paste of a
+  `gate_applicability` block, which the improved error message from item 2 now
+  tells the author to do.
+- Legacy inference already exists as an escape hatch for specs that *do* carry
+  `AC-<n>` IDs. Widening it twice is how a compat shim becomes permanent.
+
+If the release owner disagrees and wants the shim: scope it to the single
+literal heading `required cases`, keep `mode=TRACER` and
+`contract_source="inferred"`, synthesize IDs as `AC-1`… by list position, and
+emit a deprecation line on stdout naming the spec path. Add a fixture asserting
+the shim never produces `contract_source="approved"`.
+
+## Tradeoffs
+
+- **Closing this as stale loses the test.** That is the trap. If the issue is
+  closed on the "not reproducible" finding alone, the handshake stays untested
+  and the next Mold grammar change reintroduces it. Item 1 is the deliverable;
+  the staleness finding is context.
+- **Item 1 is not free.** Driving `begin_phase` -> `issue_gate` in a test needs
+  a temp project tree, a real runner, and a real oracle file — the existing cut
+  suites already do this, so copy their harness rather than inventing one.
+- **Ordering.** Independent of #542, #546, #425, and #457. If #542 lands first,
+  add a `red-gate cut` leg to the same test so the transaction path is covered
+  too.
+
+## Effort
+
+Small-to-medium. Items 2 and the grammar-drift assertion are hours; the
+full `begin` -> `issue` leg is the bulk of it.

--- a/.cheese/issues/425-suggestions.md
+++ b/.cheese/issues/425-suggestions.md
@@ -1,0 +1,148 @@
+# Issue #425 — suggestions
+
+`/cut: fold RED-oracle evidence into the existing test format, not a separate tests/cut/ folder`
+
+## Channel
+
+**This is a `next`-channel issue. Do not implement it on `main`.**
+
+PR #560 removed `/cut` from `main`; there is no `skills/cut/` and no
+`skills/cut/scripts/cut.pyz` to change there. The behavior reported in
+`sorensen-labs/football` PR #11 came from an installed `cut.pyz`, which `main`
+no longer produces. Retag to a next-channel label (see #542's suggestions for
+the label proposal).
+
+## Root cause — narrower than the issue assumes
+
+The `tests/cut/cut_*.py` layout is **not prescribed by the repository**.
+Grepping `origin/next` for `tests/cut` across `skills/`, `src/`, and `docs/`
+returns nothing. The oracle path is chosen by the agent at
+`skills/cut/SKILL.md` step 6 ("Write only the oracle"), constrained only by:
+
+- `_is_test_side_path` (`src/easy_cheese/shared/cut/red_gate.py:3040-3051`),
+  which accepts any path with a `test` / `tests` / `spec` / `specs` /
+  `__tests__` directory part, or a basename of `conftest.py`, or one starting
+  with `test_`, or matching `(_test|.test|.spec).<ext>$`.
+- `_protected_errors` (`red_gate.py:1536`), which byte-freezes whatever paths
+  the candidate declares as protected test files.
+
+Note what `_is_test_side_path` permits: `tests/cut/cut_ingest_ac1.py` is
+test-side purely because of the `tests` **directory part** — the `cut_` basename
+is irrelevant to the check. So the machinery cheerfully accepts a file that
+pytest will never collect and that ruff will always lint. That gap is the
+actual defect, and it is fixable in about twenty lines.
+
+## Proposal: the preferred direction is already reachable
+
+The issue's preferred fix ("emit the evidence as normal pytest test files …
+have the GateReceipt select them by nodeid / `pytest -k` + exit code") does not
+need new machinery. `_python_case_command` (`red_gate.py:1285-1330`) already
+supports a `python -m pytest` profile and forwards `argv[3:]` verbatim as
+selectors, and the probe reports assertion origin **in-interpreter** rather
+than by scraping stderr — so a nodeid selector satisfies the RED contract
+exactly as a loose script argv does. The frozen-witness half is likewise
+independent of file location: it is enforced by the protected-file digests,
+not by living outside `tests/`.
+
+So this is a prose-plus-validation change, not a redesign.
+
+### 1. Make the skill prose require a collected test file
+
+Rewrite `skills/cut/SKILL.md` step 6 and the matching section of
+`skills/cut/references/gate-workflow.md`:
+
+> Author each oracle as a normal test file in the project's existing test
+> layout, named so the declared runner collects it (`test_*.py` /
+> `*_test.py` for pytest). Select it in the case argv by nodeid
+> (`python -m pytest tests/test_ingest.py::test_ingest_ac1`). Declare it as a
+> protected test file so its bytes are frozen; do not create a runner-invisible
+> directory such as `tests/cut/`.
+
+### 2. Enforce it, so prose is not the only guard
+
+Add a check in `_semantic_errors` (`red_gate.py:952`) — the existing candidate
+validation seam — that rejects a protected oracle path when **both** hold:
+
+- the path is test-side only by virtue of a test **directory** part (i.e.
+  `_is_test_side_path` is true but the basename would not satisfy it alone),
+  and
+- the declared runner is a collecting runner (`pytest` or `unittest` per
+  `_python_case_runner`, `red_gate.py:1241`).
+
+Refusal text, in #542's `authoring` category:
+
+```text
+protected oracle tests/cut/cut_ingest_ac1.py is not collected by the declared
+pytest runner; name it test_*.py in the existing test root, or place it outside
+the project's test tree
+```
+
+Factor the basename half of `_is_test_side_path` into a small
+`_is_collected_basename(name, runner)` helper so both call sites share one
+definition. That is the whole implementation.
+
+### 3. Keep the fallback available, and understand what it costs
+
+The issue's fallback — oracles under `.cheese/cut/oracles/` — is *permitted* by
+this rule (no test directory part, so the collecting-runner check does not
+apply), and it does keep them off both the pytest and ruff surfaces. But note a
+consequence the issue does not:
+
+**`.cheese` is in `_EXCLUDED_SNAPSHOT_DIRS` (`red_gate.py:166-175`).** An
+oracle under `.cheese/cut/oracles/` is invisible to the production-tree
+snapshot, so it is protected *only* by its protected-file digest, not by the
+tree fingerprint's double-bracketed TOCTOU check. That is a weaker integrity
+posture than an oracle inside the snapshotted tree. Document it as the
+last-resort option the issue already calls it, and say why.
+
+## Tests
+
+New `tests/python/test_cut_oracle_placement.py`, at the real seam:
+
+- a candidate declaring protected `tests/cut/cut_ingest_ac1.py` with a
+  `python -m pytest` runner -> refused, no receipt at `--out`, message names
+  the path and the runner
+- the same path with a direct-script runner (`python tests/cut/cut_x.py`) ->
+  accepted, since nothing claims collection
+- `tests/test_ingest.py::test_ingest_ac1` under pytest -> accepted, receipt
+  issued, RED replayed at the nodeid
+- `tests/conftest.py` -> still accepted (basename satisfies collection on its
+  own; do not regress the existing rule)
+- an oracle under `.cheese/cut/oracles/` -> accepted, and assert the receipt
+  records it as protected while the phase-token snapshot contains no entry for
+  it (pins the tradeoff in item 3 rather than leaving it folklore)
+
+## Tradeoffs
+
+- **A collected oracle fails the project's suite between RED and GREEN.** This
+  is the real cost of the preferred direction, and it is acceptable only
+  because Cut -> Cook is atomic within one branch and never commits between RED
+  and GREEN. State that constraint explicitly in the prose change; if a
+  workflow ever needs to commit mid-window, this decision has to be revisited.
+- **`xfail` is not an escape hatch.** `@pytest.mark.xfail(strict=True)` makes
+  the run exit `0` and swallows the `AssertionError`, destroying the RED
+  witness. Do not suggest it.
+- **The duplicate-coverage complaint resolves itself.** The issue notes the
+  oracles "duplicate the durable contract/hardening tests the same spec
+  produces". Folding the oracle into the normal test file makes the RED oracle
+  and the durable test the *same* file — the duplication disappears rather than
+  being managed.
+- **Consuming repos still need a one-time cleanup.** Existing
+  `extend-exclude = ["tests/cut/cut_*.py"]` entries (e.g. the two
+  `pyproject.toml` files in `sorensen-labs/football`) can be dropped once their
+  oracles are renamed. Worth a note in the release entry; not this repo's work.
+- **Ordering.** Independent of #542 and #546, and cheap. This is the best
+  first-landing candidate of the five — it fixes a reproducible CI break in
+  consuming repos with a contained diff.
+
+## Acceptance mapping
+
+| Issue acceptance criterion | Satisfied by |
+|---|---|
+| "A fresh `/cut` run produces no files that require a ruff `extend-exclude`" | Items 1 + 2 — collected `test_*.py` files lint like every other test |
+| "Oracle evidence is either collected by the normal test runner or lives entirely outside `tests/`" | Item 2's check enforces exactly this disjunction, with item 3 as the documented second branch |
+
+## Effort
+
+Small. One helper + one check in `_semantic_errors`, two prose edits, one new
+test module.

--- a/.cheese/issues/457-suggestions.md
+++ b/.cheese/issues/457-suggestions.md
@@ -1,0 +1,166 @@
+# Issue #457 — suggestions
+
+`Decide: keep the Cut RED-gate as an adversary gate, an accident gate, or retire it`
+
+## Channel
+
+**This is a `next`-channel decision. It is already settled on `main`.**
+
+PR #560 removed the `/cut` skill and the RED-gate machinery from `main`, and
+#562 dropped the cut and red-gate expectations from the `.pyz` bundle suite.
+On `main`, option **C (retire)** is the shipped state — `main` has no
+`skills/cut/`, no `src/easy_cheese/shared/cut/`, and no `cut.pyz`.
+
+So the live question is narrower than the issue frames it: **what threat model
+does the gate carry on the `next` soak branch, where it still lives?** Retag to
+a next-channel label (see #542's suggestions for the label proposal).
+
+## Re-verification against current `origin/next`
+
+The issue's evidence was gathered at the `hoist/418v2` tree. Line numbers have
+shifted; the findings have not. Re-checked against `origin/next`:
+
+| Finding | Status on `next` | Current location |
+|---|---|---|
+| 1. Assertion-origin short-circuit | **Still present** | `_looks_harness_failure`, `red_gate.py:1384-1387` — `if run.assertion_origin: return False` still precedes the marker scan |
+| 2. Probe fd on argv | **Still present** | `_python_case_command` appends `str(probe_fd)` to the bootstrap prefix, `red_gate.py:1285-1316` |
+| 3. Asymmetric shadow defence | **Still present, and sharper than described** | `_stdlib_unittest` is called only from `_run_direct` (`cut_assertion_probe.py:246`, used at `:367`); `_run_pytest` (`:430`) and `_run_unittest` (`:482`) do no origin check. In the bootstrap, `import unittest` (`red_gate.py:265`) runs *inside* the trusted quarantine, but `import pytest` (`:263`) runs immediately after `sys.path[:] = target_path` (`:262`) — pytest is resolved from the target path, outside quarantine |
+| 4. Console-seam detect / `hookwrapper` | **Still present** | `pytest.hookimpl(hookwrapper=True)`, `cut_assertion_probe.py:441` |
+| 5. Snapshot walk hashes `.venv` | **Still present** | `_EXCLUDED_SNAPSHOT_DIRS` (`red_gate.py:166-175`) covers `.git`, `.cheese`, `.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `__pycache__` — no `.venv`, `node_modules`, `.tox`, `node_modules`, `dist`, `build` |
+| 6. File size | **Worse** | `red_gate.py` is now 3,468 lines (was 3,239) |
+
+## Recommendation: option B+ — an honestly-scoped accident gate, hardened
+
+Not A, not C. Reasoning:
+
+- **Against A (adversary gate).** The forgery hole is not fixable by a nonce.
+  A per-run token passed on argv is readable by the same test code that reads
+  `/proc/self/fd` — it raises the exploit's cost from three lines to five. A
+  genuine adversary gate needs the probe channel to be unreachable from user
+  code, which means the fd must be closed in the child before the test body
+  runs, with the probe holding the only reference. That is a real redesign of
+  `_python_case_command` / `cut_assertion_probe`, and it still cannot survive a
+  test that simply `os._exit(1)`s after writing a crafted event from inside the
+  probe's own process. Paying redesign cost for a property you cannot fully
+  reach is the wrong trade.
+- **Against C (retire).** `main` already took C. `next` exists to soak the
+  gate. Retiring it on `next` too would mean deleting the branch's reason to
+  exist — that is a channel decision, not a code decision, and it should be
+  made explicitly by the release owner rather than as the outcome of this
+  issue.
+- **For B+.** The accident-gate value is the part the issue reports as proven
+  daily, and #542's data corroborates it ("the gate rejected harness-only
+  failures and witness mismatches before issuing evidence"). Findings 3-6 are
+  worth fixing under *any* option, and finding 1 is a genuine correctness bug
+  in the accident gate itself, not only in the adversary claim.
+
+## Concrete work
+
+### 1. Fix finding 1 — it is an accident-gate bug, not just an adversary hole
+
+`_looks_harness_failure` (`red_gate.py:1384-1403`): delete the
+`if run.assertion_origin: return False` short-circuit so origin and markers are
+**conjunctive**. A run is behavioral RED only when the probe reports
+`assertion_origin` *and* no harness marker appears in the output.
+
+Then in `cut_assertion_probe.py`, extend the probe event with the observed
+exception's `__cause__` / `__context__` chain type names, and reject in
+`red_gate` when the chain bottoms out in `ImportError`, `ModuleNotFoundError`,
+`FileNotFoundError`, or `SyntaxError`. This is what actually catches the
+issue's exploit 1, whose `AssertionError` is raised *from* an `ImportError`
+handler and therefore carries `__context__`.
+
+Note the ordering consequence: this makes a legitimate test that asserts on an
+import failure (rare, but real) fail the gate. That is the correct default —
+the escape hatch is an explicit harness decision, not a silent pass.
+
+### 2. Fix findings 3-5
+
+- Hoist the `_stdlib_unittest` origin check out of `_run_direct`
+  (`cut_assertion_probe.py:367`) into `_run_unittest` (`:482`) and the pytest
+  plugin path (`:430`). `_stdlib_unittest` currently has zero test references —
+  add them in the same change.
+- Move `import pytest` inside the quarantine: in the bootstrap
+  (`red_gate.py:262-263`), import pytest while `sys.path` is still
+  `[root, *trusted_path]`, or explicitly justify in a comment why the target
+  path is required and add a subprocess-level shadow test for the pytest
+  profile mirroring the existing unittest ones.
+- Add a distinct `probe seam not invoked` refusal (maps to #542's
+  `environment` category) so a future pytest that stops routing `__main__`
+  through `_console_main` produces an accurate message instead of blaming the
+  author's test.
+- Replace `hookwrapper=True` (`cut_assertion_probe.py:441`) with
+  `wrapper=True`; pluggy has deprecated the former.
+- Extend `_EXCLUDED_SNAPSHOT_DIRS` (`red_gate.py:166-175`) with `.venv`,
+  `venv`, `node_modules`, `.tox`, `.nox`, `.gradle`, `target`, `dist`,
+  `build`, `.next`, `.turbo`. The measured 34%-of-entries figure is pure
+  overhead hashed twice per validation, and its churn surfaces as a misleading
+  "production-tree file changed during validation".
+
+### 3. Fix finding 6 — split `red_gate.py`
+
+Extract, in this order (each independently landable, each shrinking the next
+diff):
+
+| New module | Moves out of `red_gate.py` |
+|---|---|
+| `src/easy_cheese/shared/cut/snapshot.py` | `_hash_file` (`:1525`) … `_receipt_changes` (`:1736`) — the snapshot/differ subsystem |
+| `src/easy_cheese/shared/cut/phase_token.py` | `_load_phase_plan` (`:2718`) … `_load_phase_token` (`:2839`) and `begin_phase` (`:2796`) |
+| `src/easy_cheese/shared/cut/press_history.py` | `_read_press_history` (`:2080`) … `consume_press_boundary` (`:2477`) |
+
+This is the same move the probe extraction already validated. It also makes
+#542's `transaction.py` a thin caller rather than another reason to grow the
+monolith.
+
+### 4. Re-scope the claim in the ADRs
+
+Amend `.hallouminate/wiki/adr/outer-tdd-gates-003.md` and `005.md` with an
+explicit **Threat model** section:
+
+> The `GateReceipt` certifies that the declared case failed via an
+> `AssertionError`-typed exception, at the declared witness, under the declared
+> runner, with an unchanged production tree. It is **not** an unforgeable
+> causal witness: a hostile test author with arbitrary code execution in the
+> test process can produce a passing receipt for behavior that does not exist.
+> The gate's job is catching *accidents* — import typos, missing fixtures,
+> harness crashes, stale witnesses — not resisting the agent it gates.
+
+Do not quietly drop the adversarial framing; state the downgrade, so a future
+reader knows the claim was narrowed deliberately.
+
+### 5. Tests
+
+`tests/python/test_cut_red_gate_adversarial.py`, exercising the real
+subprocess seam:
+
+- **Exploit 1 (laundering)** — the exact three-line `try/except ImportError:
+  raise AssertionError(WITNESS)` case from the issue. Assert: no receipt
+  written, refusal names the `ImportError` in the exception chain. This test
+  **fails today**; it is the regression fence for item 1.
+- **Exploit 2 (forgery)** — a case that locates the probe fd via
+  `/proc/self/fd`, writes a well-formed event, and `os._exit(1)`s. Assert the
+  *documented* behavior. Under B+ that is **accepted**, and the test's docstring
+  must say so, citing the ADR threat model. A test that pins a known limitation
+  as intended behavior is more honest than no test, and it will fail loudly if
+  someone later claims the hole is closed.
+- Shadow tests for the pytest profile mirroring the existing unittest ones
+  (finding 3).
+- A snapshot test asserting a `.venv/` directory contributes zero entries
+  (finding 5).
+
+## Tradeoffs
+
+- **B+ narrows a shipped promise.** Five accepted ADRs (`outer-tdd-gates-001`
+  … `005`) and #396 describe a stronger property than the code delivers.
+  Narrowing the ADR is the honest move; the alternative is leaving accepted
+  design docs describing a property with two verified counterexamples.
+- **Item 1 will produce new refusals during soak.** That is the point, but it
+  will look like a regression in `next`'s receipt-issuance rate. Ship it with
+  #542's refusal categories so the new refusals are attributable rather than
+  mysterious.
+- **Item 3 is churn with no behavior change.** Sequence it after items 1-2 so
+  the security fixes land in reviewable diffs against the file everyone knows,
+  not against three fresh modules.
+- **If the release owner decides `next` is not soaking toward a merge**, then C
+  applies to `next` too and items 1-3 are wasted effort. Get that decision
+  before starting.

--- a/.cheese/issues/542-suggestions.md
+++ b/.cheese/issues/542-suggestions.md
@@ -1,0 +1,188 @@
+# Issue #542 — suggestions
+
+`perf(cut): collapse RED-gate authoring choreography behind one host-owned transaction`
+
+## Channel
+
+**This is a `next`-channel issue. Do not implement it on `main`.**
+
+PR #560 removed the `/cut` skill and the RED-gate enforcement machinery from
+`main`; `main` ships no `skills/cut/`, no `skills/cut/scripts/cut.pyz`, and no
+`src/easy_cheese/shared/cut/`. Every file this proposal touches exists only on
+the `next` soak branch. Retag to a next-channel label (see
+[Retagging](#retagging-all-five)).
+
+All line numbers below are against `origin/next` as of `bab83ce4`'s fetch.
+
+## What the machinery actually looks like today
+
+The agent-facing surface is four subcommands dispatched from
+`red_gate.main` (`src/easy_cheese/shared/cut/red_gate.py:3419-3466`):
+
+| Command | Host function |
+|---|---|
+| `red-gate contracts <spec>` | `_parse_spec` (`red_gate.py:538`) |
+| `red-gate begin <plan> --out <token>` | `begin_phase` (`red_gate.py:2796`) |
+| `red-gate issue <candidate> --token <t> --out <r>` | `issue_gate` (`red_gate.py:3220`) |
+| `red-gate validate <receipt> --state red\|green` | `validate_gate` (`red_gate.py:1941`) |
+
+`skills/cut/SKILL.md` steps 3-8 are the choreography the issue is measuring.
+Steps 5 ("copy the token's exact baseline command identities into the
+candidate"), 6 ("write only the oracle"), and 8 ("build the candidate under
+`.cheese/cut/candidates/` with the frozen pre-Cut `baseline_checks`, phase token
+ref and digest, protected test digests, and zero initial guards") are the three
+that are entirely host-computable and are currently agent-authored.
+
+## Proposal
+
+### 1. One new module, not a bigger `red_gate.py`
+
+Add `src/easy_cheese/shared/cut/transaction.py`. Do **not** grow
+`red_gate.py` — it is already 3,468 lines and #457 finding 6 asks for the
+opposite direction. The transaction is a *caller* of the existing host
+functions, never a second receipt writer:
+
+```text
+_parse_spec  ->  synthesize _PhasePlan  ->  begin_phase  ->  install oracle drafts
+             ->  _run_case replay       ->  build candidate  ->  issue_gate
+```
+
+`issue_gate` (`red_gate.py:3220`) stays the only code path that writes a
+`GateReceipt`. This is the invariant that keeps acceptance criterion
+"production mutation, harness failures, unsupported assertion origins, and
+witness mismatches still issue no receipt" free.
+
+### 2. New subcommand, old ones retained
+
+In `red_gate.main` (`red_gate.py:3419`) add:
+
+```text
+red-gate cut <semantic-input.json> --out .cheese/cut/<slug>.json
+```
+
+Keep `contracts` / `begin` / `issue` / `validate` registered and documented as
+diagnostics only (issue's proposed change 6). Nothing in Cook's preflight
+(`skills/cook/SKILL.md:38-45`) needs to change: it still consumes the same
+phase-neutral receipt at the same path.
+
+### 3. Semantic-input schema — the only public surface
+
+`<semantic-input.json>` carries agent judgment and nothing else:
+
+| Field | Why it is judgment, not mechanics |
+|---|---|
+| `spec` | The approved spec path |
+| `production_paths` | The roots Cook may change — a scoping decision |
+| `runner`, `cwd`, `selectors` | Which existing project runner and seam |
+| `oracle_drafts` | Path + content for each test-only oracle file |
+| `adopted_reproduction` | Set instead of `oracle_drafts` when adopting a Pasteurize repro |
+| `harness_decision` | The explicit halt/proceed when no supported runner profile exists |
+
+Everything the SKILL.md currently asks for and this schema omits —
+`schema_version`, `producer`, `work_id`, `project_key`, baseline identities,
+`phase_token_ref`, `phase_token_sha256`, protected-file digests, `guards: []`,
+receipt-level mode — is derived by `transaction.py`. That is the whole
+performance claim.
+
+Reject `oracle_drafts` entries whose path is not test-side per
+`_is_test_side_path` (`red_gate.py:3040`) *before* calling `begin_phase`, so a
+production-targeting draft costs one refusal instead of a full begin/replay
+cycle. See #425 for the placement rule those paths should also satisfy.
+
+### 4. N/A fast path
+
+When `_parse_spec` returns `GateDisposition.NOT_APPLICABLE`, skip
+`begin_phase`, oracle install, and replay entirely; build a candidate with no
+`baseline_checks`, no cases, no protected files, no guards, and no
+receipt-level mode, and call `issue_gate` directly. The validation that keeps
+this honest already exists (`red_gate.py:668-688`: "not-applicable receipts
+cannot carry Test Contracts", "not-applicable requires a non-empty reason").
+
+### 5. Typed refusal categories
+
+Today every failure funnels through `GateValidationError` and
+`_print_problems` (`red_gate.py:3414`), which prints prose. Add a `category`
+field to `GateValidationError` and have `red-gate cut` emit
+`{"ok": false, "category": ..., "problems": [...]}` on stdout with the five
+categories the issue names:
+
+| Category | Source |
+|---|---|
+| `semantic` | witness mismatch, wrong assertion origin, contract/AC mismatch |
+| `harness` | `_looks_harness_failure` (`red_gate.py:1384`) true |
+| `environment` | `run.error`, exit 127, unresolvable runner, unsafe argv (`_validate_argv`, `:882`) |
+| `integrity` | stale token/digest, production-tree change, `_protected_errors` (`:1536`), receipt drift |
+| `authoring` | malformed semantic input, non-test-side oracle draft, missing `gate_applicability` |
+
+This is what makes the issue's "retries need cause classification" finding
+measurable, and it is the cheapest item on the list — wire it first.
+
+### 6. Telemetry
+
+Append one JSON line per invocation to `.cheese/cut/telemetry.jsonl`:
+`{work_id, disposition, wall_ms, host_command_count, refusal_category,
+oracle_origin: "generated"|"adopted", receipt_issued}`. `.cheese` is already in
+`_EXCLUDED_SNAPSHOT_DIRS` (`red_gate.py:166-175`), so writing there cannot
+perturb the production-tree fingerprint. This is what the issue's "reassess
+after at least 20 top-level invocations" criterion needs.
+
+### 7. Prose
+
+Collapse `skills/cut/SKILL.md` steps 3-8 into one transaction step; move the
+current step-by-step into `skills/cut/references/gate-workflow.md` as the
+diagnostic appendix (it already carries the detailed event order per
+`SKILL.md:110`).
+
+## Tests
+
+New `tests/python/test_cut_red_gate_transaction.py`, driving the real
+subprocess seam (no mocks — matches the existing suites' style):
+
+- production mutation staged between `begin` and replay -> no receipt at the
+  `--out` path, category `integrity`
+- an `ImportError`-only oracle draft -> no receipt, category `harness`
+- an oracle whose failure text does not match the declared witness -> no
+  receipt, category `semantic`
+- N/A spec -> receipt exists with empty `baseline_checks`, `cases`,
+  `protected_files`, `guards`, and no receipt-level mode
+- baseline capture ordering: assert the recorded baseline exits are `0` and
+  that the snapshot digest in the phase token predates the oracle file's
+  existence (this is acceptance criterion "GREEN is captured before the oracle
+  is installed" and it is the one that is easy to silently break)
+
+The existing oracle-sensitivity suites (`tests/python/test_cut_skill_contract.py`,
+`test_cut_assertion_probe.py`, `test_cut_spec_format_tracers.py`) must stay
+green unchanged — that is the regression fence for "existing oracle-sensitivity
+tests continue rejecting ...".
+
+## Tradeoffs and risks
+
+- **Auditability vs. ergonomics.** Hiding token and digest plumbing makes the
+  integrity boundary less visible at the agent surface. Given #457's two
+  *verified* exploits, land #457's fixes first or concurrently — otherwise this
+  issue ships a smoother path to a gate whose adversarial claim is known-broken.
+- **`transaction.py` becomes a trust boundary.** It assembles the candidate
+  that `issue_gate` then validates. Keep it dumb: it may only copy values that
+  `begin_phase` printed and digests it computed from files on disk. Any
+  "helpful" normalization inside it is a new forgery surface.
+- **Sequencing with #546.** Cook's bundled preflight (#546) should call
+  `red-gate cut`, not re-implement it. Land #542 first; #546's "Cut is invoked
+  at most once" criterion is trivial once Cut is one command.
+- **YAGNI check on the diagnostics commands.** Four low-level commands plus one
+  transaction is five entrypoints for one workflow. If the diagnostics
+  commands see no use during soak, delete them rather than maintaining both.
+
+## Effort
+
+Medium. ~400-600 lines of new module + tests, no change to the validated
+invariants. The refusal-category work (item 5) is independently shippable in
+well under a day and unblocks the measurement the issue's own acceptance
+criteria depend on.
+
+## Retagging all five
+
+#542, #546, #457, #425, and #401 all describe machinery that exists only on
+`next`. The repo has no channel label today (`gh label list` shows only
+`triage/*`, `bug`, `enhancement`, and routine-artifact labels). Create one —
+`channel/next`, "Applies only to the next soak branch, not main" — and apply it
+to all five, so `main` triage sweeps stop surfacing them as actionable.

--- a/.cheese/issues/546-suggestions.md
+++ b/.cheese/issues/546-suggestions.md
@@ -1,0 +1,164 @@
+# Issue #546 — suggestions
+
+`perf(cook): collapse GateReceipt preflight and make oracle-change routing explicit`
+
+## Channel
+
+**This is a `next`-channel issue. Do not implement it on `main`.**
+
+PR #560 removed RED-gate enforcement from `main`. `main`'s `/cook` has no
+GateReceipt preflight at all — `skills/cook/SKILL.md` on `main` carries no
+`red-gate` invocation, and `src/easy_cheese/skills/cook/commands.py` on `main`
+packages no `red-gate` command. The preflight this issue optimizes exists only
+on `next`. Retag to a next-channel label (see #542's suggestions for the
+label proposal).
+
+## What the preflight actually is today
+
+On `next`, Cook resolves `red-gate` through its own bundle
+(`skills/cook/SKILL.md:34-36`: `python3 skills/cook/scripts/cook.pyz red-gate
+...`), and the preflight is prose-driven across
+`skills/cook/SKILL.md:38-45` and `:73-83`:
+
+1. Load the canonical receipt at `.cheese/cut/<slug>.json`.
+2. If absent, invoke Cut once.
+3. Classify RED vs. closed N/A.
+4. `red-gate validate <receipt> --state red` (`validate_gate`,
+   `src/easy_cheese/shared/cut/red_gate.py:1941`).
+5. No production path may run before that returns ok.
+
+Every one of those five is deterministic. None requires agent judgment. That
+is the issue's finding, and it is correct.
+
+## Proposal
+
+### 1. One bundled preflight command
+
+Add `src/easy_cheese/skills/cook/gate_preflight.py` and register it in
+`src/easy_cheese/skills/cook/commands.py` alongside the existing
+`Command(...)` tuple entries:
+
+```python
+Command("gate-preflight", "easy_cheese.skills.cook.gate_preflight:main"),
+```
+
+```text
+cook.pyz gate-preflight --spec <spec> --slug <slug> [--production-paths ...]
+```
+
+Typed stdout result, one of:
+
+| `status` | Meaning | Cook's next move |
+|---|---|---|
+| `red` | Valid RED receipt, replayed | Implement against the named cases |
+| `not-applicable` | Closed N/A receipt | Implement; no RED to satisfy |
+| `oracle-overlap` | Intended change targets a protected oracle | Halt once, actionably |
+| `failed` | Terminal | Halt; do not mutate production |
+
+`failed` carries the same refusal categories #542 proposes
+(`semantic` / `harness` / `environment` / `integrity` / `authoring`) so both
+skills classify identically. Wire #542's categories first; this issue consumes
+them rather than defining a parallel vocabulary.
+
+### 2. Internal ownership, exactly-once Cut
+
+`gate_preflight.main` owns: canonical-receipt load, the single Cut dispatch
+when absent, `validate_gate(receipt, "red")`, and error classification. Making
+Cut invocation an internal call rather than an agent step is what mechanically
+satisfies "Cut is invoked at most once" — a prose instruction cannot.
+
+Once #542 lands, that internal call is `red-gate cut <semantic-input> --out
+...`. Until then it is the four-step choreography, wrapped. **Prefer to land
+#542 first**; wrapping the four-step version means writing candidate-assembly
+logic in Cook that #542 then deletes.
+
+### 3. Oracle-overlap routing — the actually novel part
+
+This is the finding worth the most, and it needs a mechanism the codebase
+does not have yet.
+
+The invariant: `issue_gate` records protected test digests, and
+`_protected_errors` (`red_gate.py:1536`) rejects any post-receipt change to
+them. Work that legitimately targets a would-be oracle collides with that
+*after* production mutation has already begun — which is the churn the issue
+describes.
+
+Move the collision earlier. Before receipt issuance, intersect the intended
+change surface with the would-be oracle surface:
+
+- The intended surface is Cook's `production_paths` (already declared in the
+  Cut phase plan per `skills/cut/SKILL.md:53-58`), plus any test-side path
+  Cook plans to modify.
+- The oracle surface is every path `_is_test_side_path` (`red_gate.py:3040`)
+  accepts within the spec's blast radius.
+
+On a non-empty intersection, emit `status: "oracle-overlap"` with the
+colliding paths and exactly two documented resolutions:
+
+1. **Independent outside-in evidence** — the oracle moves to a seam strictly
+   outside the intended change surface. Preflight re-runs against the narrowed
+   surface.
+2. **Halt once** — typed `no-independent-oracle` result naming the paths.
+   Route to `/mold` to re-scope, not to a retry loop.
+
+Never a third option. In particular: preflight must never refresh, substitute,
+or recompute `phase_token_sha256`, protected-file digests, or the receipt
+token. Enforce that structurally — `gate_preflight` imports `validate_gate`
+and the loaders, and must not import `issue_gate`, `begin_phase`, or
+`_atomic_write` (`red_gate.py:3380`). Assert the import boundary in a test.
+
+### 4. Stage telemetry
+
+Emit one JSONL record per Cook run to `.cheese/cook/telemetry.jsonl` with
+`{slug, preflight_ms, implementation_ms, green_ms, taste_test_ms, handoff_ms,
+preflight_round_trips, refusal_category}`. `.cheese` is in
+`_EXCLUDED_SNAPSHOT_DIRS` (`red_gate.py:166-175`), so this cannot perturb the
+production-tree fingerprint that Cut's validation replays.
+
+Without this, the issue's own acceptance criterion — "after at least 20
+post-change invocations, preflight round-trips decrease without error-rate
+regression" — is unmeasurable. Its "Low" finding is really a blocker on
+proving the other two.
+
+## Tests
+
+New `tests/python/test_cook_gate_preflight.py`, at the real seam:
+
+- missing receipt -> Cut dispatched exactly once (assert via a recorded
+  invocation log, not a mock of the module under test) -> `status: "red"`
+- invalid receipt (tampered digest) -> `status: "failed"`,
+  `category: "integrity"`, and the on-disk receipt is byte-unchanged
+- closed N/A receipt -> `status: "not-applicable"`, no Cut dispatch
+- adopted-reproduction receipt -> `status: "red"`
+- baseline replay failure -> `status: "failed"`, `category: "harness"`
+- intended change surface overlapping a protected oracle path ->
+  `status: "oracle-overlap"` listing exactly the colliding paths, and **no
+  production file written**
+- import-boundary test: `gate_preflight`'s module namespace exposes no
+  `issue_gate` / `begin_phase` / `_atomic_write`
+
+Existing RED, adopted-reproduction, guard, witness, GREEN, and N/A suites must
+stay green unchanged.
+
+## Tradeoffs and risks
+
+- **Ordering dependency on #542.** Real, and worth respecting. Implementing
+  #546 first duplicates candidate assembly in Cook, then throws it away.
+- **Overlap detection can be wrong in both directions.** A false positive
+  halts legitimate work; a false negative restores today's churn. Bias to
+  false positives (halt) — the halt is one actionable message, the false
+  negative is silent corruption of the evidence chain. Say so in the docs.
+- **Scope discipline.** The issue's non-goals are sound and easy to violate:
+  do not optimize legitimate implementation test/build calls, do not let Cook
+  retry Cut implicitly, do not let Cook repair evidence. The import boundary
+  in item 3 is the cheapest enforcement of the last one.
+- **12 invocations is thin evidence.** The oracle-change failures are reported
+  operationally, not replayed. Build the fixtures in the test list above
+  first; if none of them reproduce the reported failure, the diagnosis is
+  wrong and the preflight rewrite is not the fix.
+
+## Effort
+
+Medium. Item 4 (telemetry) is a few hours and unblocks measurement. Item 3
+(overlap routing) is the design-heavy piece and deserves its own review pass.
+Items 1-2 are mostly mechanical once #542 exists.


### PR DESCRIPTION
Five decision/suggestion docs under .cheese/issues/ for #542, #546, #457, #425, #401, all re-verified against current origin/next. Recommends a channel/next label and a landing order (#425 first). No cut machinery touches main. Refs #542 #546 #457 #425 #401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018V6nZ6MgNn3vNPgQCRVwky