### PR TITLE
feat(site): publish the schema catalog to Cloudflare Pages

### DIFF
--- a/.github/workflows/schemas-site.yml
+++ b/.github/workflows/schemas-site.yml
@@ -1,0 +1,82 @@
+name: schemas-site
+
+# Publishes the contract-schema catalog at https://schemas.easy-cheese.dev.
+#
+# The site is a Cloudflare Pages project, not GitHub Pages: this repository's
+# single GitHub Pages site already serves the Starlight docs, and GitHub Pages
+# cannot set a content type for the extensionless paths the schema URIs claim
+# (/curd-plan, /review-request, ...). Cloudflare Pages reads the generated
+# `_headers` file and serves them as application/schema+json.
+#
+# MANUAL PREREQUISITES (not automatable from this repo):
+#   1. Create the Cloudflare Pages project (direct upload, no build command).
+#   2. Set repository variable CLOUDFLARE_ACCOUNT_ID and repository secret
+#      CLOUDFLARE_API_TOKEN (token scope: Account > Cloudflare Pages > Edit).
+#   3. Point schemas.easy-cheese.dev at the Pages project as a custom domain.
+# Until the variable is set the deploy step is skipped and this workflow just
+# verifies the generated tree, so it is green from the moment it lands.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/easy_cheese_schemas/**'
+      - 'scripts/build_schema_site.py'
+      - 'tests/schemas/python/test_schema_site.py'
+      - '.github/workflows/schemas-site.yml'
+  pull_request:
+    paths:
+      - 'src/easy_cheese_schemas/**'
+      - 'scripts/build_schema_site.py'
+      - 'tests/schemas/python/test_schema_site.py'
+      - '.github/workflows/schemas-site.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: build and publish schema catalog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install runtime dependencies
+        run: |
+          set -euo pipefail
+          pip install --no-cache-dir pytest==9.0.3
+          pip install --no-cache-dir --require-hashes --requirement requirements/runtime.txt
+
+      # The suite pins the generated tree to tests/schemas/python/goldens, i.e.
+      # to the same bytes the published package validates against. A red run
+      # here means the deploy would have served a document that drifted.
+      - name: Verify the generated tree against the schema goldens
+        run: python3 -m pytest tests/schemas/python/test_schema_site.py -q
+
+      - name: Build the site
+        run: python3 scripts/build_schema_site.py --out dist-schemas
+
+      - name: Deploy to Cloudflare Pages
+        if: >-
+          github.repository == 'paulnsorensen/easy-cheese'
+          && github.event_name != 'pull_request'
+          && github.ref == 'refs/heads/main'
+          && vars.CLOUDFLARE_ACCOUNT_ID != ''
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist-schemas --project-name=easy-cheese-schemas --branch=main

--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,8 @@ src/content/docs/**
 # `just release-preview` staging output (hidden so validate_skills.py skips it)
 .release-preview/
 
+# `scripts/build_schema_site.py --out` output (schemas.easy-cheese.dev tree)
+/dist-schemas/
+
 # `just vendor` output — extracted wheel trees rebuilt from requirements-vendor.txt
 /vendor/

--- a/scripts/build_schema_site.py
+++ b/scripts/build_schema_site.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Render the static site served at https://schemas.easy-cheese.dev.
+
+Every URI in ``REGISTERED_CONTRACT_SCHEMA_URIS`` is namespaced under
+``SCHEMA_ROOT``; the bytes behind each one are produced in-process by
+``schema_bytes()``. This script projects that catalogue onto disk at the
+extensionless paths the URIs already claim (``/curd-plan``,
+``/review-request``, ...), so the published document at a URI is the same
+document the installed ``easy-cheese-schemas`` package validates against.
+Nothing here is hand-maintained: adding a contract to the catalogue adds a
+served path on the next deploy.
+
+Emits, under ``--out``:
+
+* one file per registered URI, holding exactly ``schema_bytes(uri)``;
+* ``_headers``, giving each of those extensionless paths the
+  ``application/schema+json`` content type (plus open CORS, so browser-based
+  JSON Schema tooling can dereference them);
+* ``index.html``, listing the catalogue and the package version it came from.
+
+``_headers`` is a Cloudflare Pages convention. GitHub Pages cannot set a
+content type for extensionless files, and this repository's one GitHub Pages
+site already serves the Starlight docs, so the schema host is a separate
+Cloudflare Pages project (see ``.github/workflows/schemas-site.yml``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import sys
+from pathlib import Path
+from typing import cast
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+for _extra in (REPO_ROOT / "vendor", REPO_ROOT / "src"):
+    _path = str(_extra)
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
+
+from easy_cheese_schemas import REGISTERED_CONTRACT_SCHEMA_URIS, __version__  # noqa: E402
+from easy_cheese_schemas.schema_runtime import schema_bytes  # noqa: E402
+
+SCHEMA_CONTENT_TYPE = "application/schema+json; charset=utf-8"
+HEADERS_FILENAME = "_headers"
+INDEX_FILENAME = "index.html"
+
+
+def schema_paths() -> dict[str, str]:
+    """Map each registered schema URI to the site-relative path it is served at."""
+    paths: dict[str, str] = {}
+    for uri in sorted(REGISTERED_CONTRACT_SCHEMA_URIS):
+        slug = uri.rsplit("/", 1)[-1]
+        if not slug or slug in {HEADERS_FILENAME, INDEX_FILENAME}:
+            raise SystemExit(f"build_schema_site: unusable served path for {uri}")
+        paths[uri] = slug
+    return paths
+
+
+def render_headers(paths: dict[str, str]) -> str:
+    """Render the Cloudflare Pages ``_headers`` rules for the served schemas."""
+    rules = "\n".join(
+        f"/{slug}\n  Content-Type: {SCHEMA_CONTENT_TYPE}\n  Access-Control-Allow-Origin: *"
+        for slug in sorted(paths.values())
+    )
+    return f"{rules}\n"
+
+
+def render_index(paths: dict[str, str]) -> str:
+    """Render the ``/`` landing page listing the catalogue and its version."""
+    rows = "\n".join(
+        f'      <li><a href="/{slug}"><code>{html.escape(uri)}</code></a></li>'
+        for uri, slug in sorted(paths.items())
+    )
+    return f"""<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>easy-cheese contract schemas</title>
+    <style>
+      body {{ font-family: system-ui, sans-serif; margin: 0 auto; max-width: 46rem;
+             padding: 2rem 1rem; line-height: 1.6; }}
+      code {{ font-size: 0.95rem; }}
+      ul {{ padding-left: 1.2rem; }}
+    </style>
+  </head>
+  <body>
+    <h1>🧀 easy-cheese contract schemas</h1>
+    <p>
+      JSON Schema (draft 2020-12) documents for the easy-cheese workflow
+      contracts, generated from
+      <a href="https://pypi.org/project/easy-cheese-schemas/">easy-cheese-schemas</a>
+      <code>{html.escape(__version__)}</code>. Each URI below dereferences to the
+      exact bytes that release validates against.
+    </p>
+    <ul>
+{rows}
+    </ul>
+    <p>
+      Source:
+      <a href="https://github.com/paulnsorensen/easy-cheese">github.com/paulnsorensen/easy-cheese</a>
+    </p>
+  </body>
+</html>
+"""
+
+
+def build(out: Path) -> Path:
+    """Write the deployable site tree into ``out``. Returns ``out``."""
+    paths = schema_paths()
+    out.mkdir(parents=True, exist_ok=True)
+
+    for uri, slug in paths.items():
+        _ = (out / slug).write_bytes(schema_bytes(uri))
+    _ = (out / HEADERS_FILENAME).write_text(render_headers(paths), encoding="utf-8")
+    _ = (out / INDEX_FILENAME).write_text(render_index(paths), encoding="utf-8")
+    return out
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description="Build the schemas.easy-cheese.dev site.")
+    _ = parser.add_argument("--out", type=Path, required=True, help="Output directory.")
+    args = parser.parse_args(argv[1:])
+    out = build(cast(Path, args.out))
+    print(f"built {len(REGISTERED_CONTRACT_SCHEMA_URIS)} schema documents at {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/schemas/python/test_schema_site.py
+++ b/tests/schemas/python/test_schema_site.py
@@ -1,0 +1,95 @@
+"""The deployed schemas.easy-cheese.dev tree is the catalogue, byte for byte.
+
+`REGISTERED_CONTRACT_SCHEMA_URIS` is baked into published PyPI releases, so a
+served document that drifts from `schema_bytes()` silently breaks every
+consumer that dereferences the URI. These tests pin the deploy to the same
+goldens the runtime is pinned to, and pin the served path of each URI to the
+path the URI itself claims.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import build_schema_site  # noqa: E402
+
+from easy_cheese_schemas import (  # noqa: E402
+    REGISTERED_CONTRACT_SCHEMA_URIS,
+    SCHEMA_ROOT,
+    __version__,
+)
+from easy_cheese_schemas.schema_runtime import schema_bytes  # noqa: E402
+
+GOLDENS = Path(__file__).with_name("goldens")
+
+
+@pytest.fixture(scope="module")
+def site(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return build_schema_site.build(tmp_path_factory.mktemp("schema-site") / "dist")
+
+
+def _headers(site: Path) -> dict[str, dict[str, str]]:
+    rules: dict[str, dict[str, str]] = {}
+    current = ""
+    for line in (site / "_headers").read_text(encoding="utf-8").splitlines():
+        if line.startswith("/"):
+            current = line
+            rules[current] = {}
+        else:
+            name, _, value = line.strip().partition(": ")
+            rules[current][name] = value
+    return rules
+
+
+def test_served_path_of_every_uri_is_the_path_the_uri_claims() -> None:
+    for uri, slug in build_schema_site.schema_paths().items():
+        assert uri == f"{SCHEMA_ROOT}/{slug}"
+
+
+def test_site_holds_exactly_the_catalogue_plus_index_and_headers(site: Path) -> None:
+    slugs = set(build_schema_site.schema_paths().values())
+
+    assert {path.name for path in site.iterdir()} == slugs | {"_headers", "index.html"}
+
+
+@pytest.mark.parametrize("schema_uri", sorted(REGISTERED_CONTRACT_SCHEMA_URIS))
+def test_served_document_is_the_golden_schema(site: Path, schema_uri: str) -> None:
+    slug = schema_uri.rsplit("/", 1)[-1]
+    served = (site / slug).read_bytes()
+
+    assert served == schema_bytes(schema_uri)
+    assert served == (GOLDENS / f"{slug}.json").read_bytes()
+
+
+def test_headers_type_every_schema_path_as_schema_json(site: Path) -> None:
+    slugs = sorted(build_schema_site.schema_paths().values())
+
+    assert _headers(site) == {
+        f"/{slug}": {
+            "Content-Type": "application/schema+json; charset=utf-8",
+            "Access-Control-Allow-Origin": "*",
+        }
+        for slug in slugs
+    }
+
+
+def test_index_page_lists_every_uri_and_the_package_version(site: Path) -> None:
+    index = (site / "index.html").read_text(encoding="utf-8")
+
+    assert f"<code>{__version__}</code>" in index
+    for uri, slug in build_schema_site.schema_paths().items():
+        assert f'<a href="/{slug}"><code>{uri}</code></a>' in index
+
+
+def test_rebuilding_over_an_existing_deploy_is_byte_identical(site: Path) -> None:
+    before = {path.name: path.read_bytes() for path in site.iterdir()}
+
+    _ = build_schema_site.build(site)
+
+    assert {path.name: path.read_bytes() for path in site.iterdir()} == before


### PR DESCRIPTION
Adds scripts/build_schema_site.py and .github/workflows/schemas-site.yml; deploy is gated on the CLOUDFLARE_ACCOUNT_ID repo variable so the workflow is inert until the Cloudflare/DNS steps are done. Refs #434 (user-side steps remain: Pages project, API token secret, account-id variable, CNAME).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018V6nZ6MgNn3vNPgQCRVwky