### PR TITLE
ci(benchmarks): weekly contract validity budget job

### DIFF
--- a/.github/workflows/contract-benchmarks.yml
+++ b/.github/workflows/contract-benchmarks.yml
@@ -1,0 +1,39 @@
+# Weekly contract validity benchmark.
+#
+# Replays the stored writer-output corpus (benchmarks/contracts/) through the
+# real normalizer and publishes the report to the job summary, so the budget's
+# status is visible without running anything locally. The job goes red when a
+# recorded expectation flips or the captured-case budget is exceeded; ordinary
+# pull requests are never gated on the budget (see issue #406).
+name: contract-benchmarks
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: contract validity budget
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install runtime dependencies
+        run: pip install --disable-pip-version-check --no-cache-dir --require-hashes --requirement requirements/runtime.txt
+
+      - name: Replay the writer-output corpus
+        run: |-
+          set -o pipefail
+          python3 scripts/contract_benchmarks.py | tee -a "$GITHUB_STEP_SUMMARY"

--- a/benchmarks/contracts/README.md
+++ b/benchmarks/contracts/README.md
@@ -1,0 +1,44 @@
+# Writer-output corpus
+
+Each `*.json` file here is one writer view plus the host invocation it was
+produced against, replayed by `scripts/contract_benchmarks.py` through
+`normalize_agent_output`. The weekly `contract-benchmarks` workflow publishes
+the resulting report; `tests/python/test_contract_benchmark_corpus.py` replays
+the same corpus on every pull request as a backward-compat canary.
+
+## Case format
+
+```json
+{
+  "name": "review-result-clean",
+  "provenance": "captured",
+  "source": "where this payload came from, sanitized",
+  "expect_first_pass_valid": true,
+  "writer_view": {"kind": "...", "payload": {}},
+  "invocation": {},
+  "repair_view": {}
+}
+```
+
+- `name` — unique across the corpus; the report and the canary key on it.
+- `provenance` — `captured` for real agent output, `synthetic` for a payload
+  authored by hand. The <10% first-pass-invalid budget is measured over
+  captured cases only.
+- `source` — free text recording the origin (skill, run, date), sanitized of
+  anything private.
+- `expect_first_pass_valid` — the validity recorded when the case landed. A
+  replay that disagrees fails CI: a contract change flipped a stored payload.
+- `writer_view` / `invocation` — plain JSON, exactly as the boundary sees them.
+- `repair_view` — optional second attempt, replayed only after an invalid first
+  pass; rejected on a case recorded as valid, where it can never run.
+
+## Adding cases
+
+Sanitize first: strip paths, identifiers, and prose that should not be public.
+Drop the file in, run `python3 scripts/contract_benchmarks.py`, and record the
+validity it reports as `expect_first_pass_valid`.
+
+The corpus ships with four synthetic seeds derived from the representative
+benchmark in `docs/architecture/milknado-semantic-boundary-reassessment.md`.
+Until captured cases land, the budget reports as not measurable — see
+[issue #406](https://github.com/paulnsorensen/easy-cheese/issues/406).

--- a/benchmarks/contracts/planner-result-complete.json
+++ b/benchmarks/contracts/planner-result-complete.json
@@ -1,0 +1,107 @@
+{
+  "expect_first_pass_valid": true,
+  "invocation": {
+    "evidence": {
+      "evidence-1": {
+        "artifact": {
+          "artifact_id": "artifact-source",
+          "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+          "media_type": "text/markdown",
+          "role": "source",
+          "schema_uri": null,
+          "size_bytes": 1025,
+          "uri": "repo://inputs/source.md"
+        },
+        "evidence_id": "evidence-1",
+        "kind": "review",
+        "location": null,
+        "summary": "The planner dispatch boundary is under review."
+      }
+    },
+    "plan": {
+      "artifacts": {
+        "source": {
+          "artifact_id": "artifact-source",
+          "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+          "media_type": "text/markdown",
+          "role": "source",
+          "schema_uri": null,
+          "size_bytes": 1025,
+          "uri": "repo://inputs/source.md"
+        }
+      },
+      "lineages": {
+        "core": {
+          "identity_action": "new",
+          "source_curd_ids": []
+        }
+      },
+      "plan_id": "planner-benchmark-plan",
+      "versions": {
+        "https://schemas.easy-cheese.dev/curd-plan": {
+          "major": "1",
+          "minor": "0",
+          "schema_uri": "https://schemas.easy-cheese.dev/curd-plan"
+        }
+      }
+    },
+    "request_id": "planner-request-benchmark",
+    "versions": {
+      "https://schemas.easy-cheese.dev/planner-result": {
+        "major": "1",
+        "minor": "0",
+        "schema_uri": "https://schemas.easy-cheese.dev/planner-result"
+      }
+    }
+  },
+  "name": "planner-result-complete",
+  "provenance": "synthetic",
+  "source": "Synthetic seed derived from the four-case representative benchmark recorded in docs/architecture/milknado-semantic-boundary-reassessment.md; not captured agent output.",
+  "writer_view": {
+    "kind": "planner_result",
+    "payload": {
+      "disposition": "complete",
+      "plan": {
+        "context": {
+          "constraints": [
+            "Only the approved planner input is in scope."
+          ],
+          "invariants": [
+            "Host identity is never supplied by the writer."
+          ],
+          "shared_input_keys": [
+            "source"
+          ]
+        },
+        "curds": [
+          {
+            "criteria": [
+              {
+                "check": "The normalized plan has host identity.",
+                "description": "The planner result is canonical."
+              }
+            ],
+            "dependencies": [],
+            "input_keys": [
+              "source"
+            ],
+            "key": "core",
+            "outcome": "Complete the planner benchmark slice.",
+            "outputs": [
+              "The planner slice is materialized."
+            ],
+            "scope": {
+              "excluded_paths": [],
+              "paths": [
+                "src/planner.py"
+              ]
+            }
+          }
+        ],
+        "objective": "Measure planner-result normalization."
+      },
+      "reason": null,
+      "unresolved_work": []
+    }
+  }
+}

--- a/benchmarks/contracts/planner-result-partial.json
+++ b/benchmarks/contracts/planner-result-partial.json
@@ -1,0 +1,115 @@
+{
+  "expect_first_pass_valid": true,
+  "invocation": {
+    "evidence": {
+      "evidence-1": {
+        "artifact": {
+          "artifact_id": "artifact-source",
+          "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+          "media_type": "text/markdown",
+          "role": "source",
+          "schema_uri": null,
+          "size_bytes": 1025,
+          "uri": "repo://inputs/source.md"
+        },
+        "evidence_id": "evidence-1",
+        "kind": "review",
+        "location": null,
+        "summary": "The planner dispatch boundary is under review."
+      }
+    },
+    "plan": {
+      "artifacts": {
+        "source": {
+          "artifact_id": "artifact-source",
+          "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000001",
+          "media_type": "text/markdown",
+          "role": "source",
+          "schema_uri": null,
+          "size_bytes": 1025,
+          "uri": "repo://inputs/source.md"
+        }
+      },
+      "lineages": {
+        "core": {
+          "identity_action": "new",
+          "source_curd_ids": []
+        }
+      },
+      "plan_id": "planner-benchmark-plan",
+      "versions": {
+        "https://schemas.easy-cheese.dev/curd-plan": {
+          "major": "1",
+          "minor": "0",
+          "schema_uri": "https://schemas.easy-cheese.dev/curd-plan"
+        }
+      }
+    },
+    "request_id": "planner-request-benchmark",
+    "versions": {
+      "https://schemas.easy-cheese.dev/planner-result": {
+        "major": "1",
+        "minor": "0",
+        "schema_uri": "https://schemas.easy-cheese.dev/planner-result"
+      }
+    }
+  },
+  "name": "planner-result-partial",
+  "provenance": "synthetic",
+  "source": "Synthetic seed derived from the four-case representative benchmark recorded in docs/architecture/milknado-semantic-boundary-reassessment.md; not captured agent output.",
+  "writer_view": {
+    "kind": "planner_result",
+    "payload": {
+      "disposition": "partial",
+      "plan": {
+        "context": {
+          "constraints": [
+            "Only the approved planner input is in scope."
+          ],
+          "invariants": [
+            "Host identity is never supplied by the writer."
+          ],
+          "shared_input_keys": [
+            "source"
+          ]
+        },
+        "curds": [
+          {
+            "criteria": [
+              {
+                "check": "The normalized plan has host identity.",
+                "description": "The planner result is canonical."
+              }
+            ],
+            "dependencies": [],
+            "input_keys": [
+              "source"
+            ],
+            "key": "core",
+            "outcome": "Complete the planner benchmark slice.",
+            "outputs": [
+              "The planner slice is materialized."
+            ],
+            "scope": {
+              "excluded_paths": [],
+              "paths": [
+                "src/planner.py"
+              ]
+            }
+          }
+        ],
+        "objective": "Measure planner-result normalization."
+      },
+      "reason": null,
+      "unresolved_work": [
+        {
+          "description": "A later planner slice remains to be planned.",
+          "evidence_keys": [
+            "evidence-1"
+          ],
+          "scope": "omitted_work"
+        }
+      ]
+    }
+  }
+}

--- a/benchmarks/contracts/review-result-clean.json
+++ b/benchmarks/contracts/review-result-clean.json
@@ -1,0 +1,29 @@
+{
+  "expect_first_pass_valid": true,
+  "invocation": {
+    "coverage": [
+      {
+        "disposition": "covered",
+        "target": "changed-files"
+      }
+    ],
+    "review_id": "review-benchmark",
+    "versions": {
+      "https://schemas.easy-cheese.dev/review-result": {
+        "major": "1",
+        "minor": "0",
+        "schema_uri": "https://schemas.easy-cheese.dev/review-result"
+      }
+    }
+  },
+  "name": "review-result-clean",
+  "provenance": "synthetic",
+  "source": "Synthetic seed derived from the four-case representative benchmark recorded in docs/architecture/milknado-semantic-boundary-reassessment.md; not captured agent output.",
+  "writer_view": {
+    "kind": "review_result",
+    "payload": {
+      "disposition": "clean",
+      "findings": []
+    }
+  }
+}

--- a/benchmarks/contracts/review-result-host-owned-field.json
+++ b/benchmarks/contracts/review-result-host-owned-field.json
@@ -1,0 +1,37 @@
+{
+  "expect_first_pass_valid": false,
+  "invocation": {
+    "coverage": [
+      {
+        "disposition": "covered",
+        "target": "changed-files"
+      }
+    ],
+    "review_id": "review-benchmark",
+    "versions": {
+      "https://schemas.easy-cheese.dev/review-result": {
+        "major": "1",
+        "minor": "0",
+        "schema_uri": "https://schemas.easy-cheese.dev/review-result"
+      }
+    }
+  },
+  "name": "review-result-host-owned-field",
+  "provenance": "synthetic",
+  "repair_view": {
+    "kind": "review_result",
+    "payload": {
+      "disposition": "clean",
+      "findings": []
+    }
+  },
+  "source": "Synthetic seed derived from the four-case representative benchmark recorded in docs/architecture/milknado-semantic-boundary-reassessment.md; not captured agent output.",
+  "writer_view": {
+    "kind": "review_result",
+    "payload": {
+      "disposition": "clean",
+      "findings": [],
+      "host_only": "must reject"
+    }
+  }
+}

--- a/docs/architecture/milknado-semantic-boundary-reassessment.md
+++ b/docs/architecture/milknado-semantic-boundary-reassessment.md
@@ -88,6 +88,15 @@ repaired successfully) produced:
 
 These measurements are operational evidence, not release guarantees.
 
+Those four cases now live as JSON captures in `benchmarks/contracts/`, marked
+`provenance: synthetic`. `scripts/contract_benchmarks.py` replays them and
+reproduces the table above; the weekly `contract-benchmarks` workflow publishes
+its report to the run's job summary. The writer validity budget (under 10%
+first-pass invalid) is measured over `provenance: captured` cases only, so it
+reports as not measurable until real writer output is captured — that capture
+path is tracked in issue #406, and the budget is deliberately not a
+pull-request gate until real data shows it sustained under budget.
+
 ## Release blocker
 
 The package boundary is implemented locally but is not yet reproducible from the

--- a/scripts/contract_benchmarks.py
+++ b/scripts/contract_benchmarks.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Replay the committed writer-output corpus through the real normalizer.
+
+Each corpus case under ``benchmarks/contracts/`` is one writer view plus the
+host invocation it was produced against, exactly as an agent emitted it (JSON,
+sanitized). ``benchmark_contracts`` replays them through
+``normalize_agent_output``; this program turns that report into markdown and
+decides whether the contract validity budget is met.
+
+Two facts stay separate, because they answer different questions:
+
+* ``expect_first_pass_valid`` — recorded per case, replayed on every run. A
+  mismatch means a contract change flipped a payload's validity, which is the
+  cheap deterministic backward-compat canary. ``tests/python`` runs it, so it
+  gates ordinary CI.
+* ``provenance`` — ``captured`` (real agent output) or ``synthetic`` (authored
+  by hand). The <10% first-pass-invalid budget is measured over captured cases
+  only; a synthetic corpus cannot say anything about live writer behaviour.
+
+Exit status is 0 when no problem is found, 1 when a recorded expectation is
+violated or the captured-case budget is exceeded, and 2 when the corpus itself
+is malformed. The weekly workflow (``.github/workflows/contract-benchmarks.yml``)
+publishes the markdown to its job summary, so a red weekly run — not a blocked
+pull request — is how a budget breach surfaces.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+_SRC = str(REPO_ROOT / "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from easy_cheese_schemas.benchmarks import (  # noqa: E402
+    BenchmarkReport,
+    ContractBenchmarkInput,
+    benchmark_contracts,
+)
+
+CORPUS_ROOT = REPO_ROOT / "benchmarks" / "contracts"
+INVALID_BUDGET = 0.10
+CAPTURED = "captured"
+SYNTHETIC = "synthetic"
+
+_PROVENANCES = frozenset({CAPTURED, SYNTHETIC})
+_REQUIRED_KEYS = frozenset(
+    {
+        "name",
+        "provenance",
+        "source",
+        "expect_first_pass_valid",
+        "writer_view",
+        "invocation",
+    }
+)
+_ALLOWED_KEYS = _REQUIRED_KEYS | {"repair_view"}
+
+
+class CorpusError(ValueError):
+    """A corpus file is malformed; the harness never sees its contents."""
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusCase:
+    """One stored writer capture plus the facts the report is grouped by."""
+
+    name: str
+    provenance: str
+    source: str
+    expect_first_pass_valid: bool
+    benchmark_input: ContractBenchmarkInput
+
+
+def _text(case: dict[str, object], key: str, filename: str) -> str:
+    value = case[key]
+    if not isinstance(value, str) or not value.strip():
+        raise CorpusError(f"{filename}: {key} must be a non-empty string")
+    return value
+
+
+def _mapping(case: dict[str, object], key: str, filename: str) -> dict[str, object]:
+    value = case[key]
+    if not isinstance(value, dict):
+        raise CorpusError(f"{filename}: {key} must be an object")
+    return cast("dict[str, object]", value)
+
+
+def _load_case(path: Path) -> CorpusCase:
+    filename = path.name
+    try:
+        document = cast(object, json.loads(path.read_text(encoding="utf-8")))
+    except json.JSONDecodeError as error:
+        raise CorpusError(f"{filename}: invalid JSON: {error}") from None
+    if not isinstance(document, dict):
+        raise CorpusError(f"{filename}: case must be a JSON object")
+    case = cast("dict[str, object]", document)
+
+    unknown = sorted(set(case) - _ALLOWED_KEYS)
+    if unknown:
+        raise CorpusError(f"{filename}: unknown keys: {', '.join(unknown)}")
+    missing = sorted(_REQUIRED_KEYS - set(case))
+    if missing:
+        raise CorpusError(f"{filename}: missing keys: {', '.join(missing)}")
+
+    provenance = _text(case, "provenance", filename)
+    if provenance not in _PROVENANCES:
+        raise CorpusError(
+            f"{filename}: provenance must be one of "
+            + f"{', '.join(sorted(_PROVENANCES))}, not {provenance!r}"
+        )
+    expect_valid = case["expect_first_pass_valid"]
+    if not isinstance(expect_valid, bool):
+        raise CorpusError(f"{filename}: expect_first_pass_valid must be a boolean")
+    raw_repair_view = case.get("repair_view")
+    repair_view: dict[str, object] | None = None
+    if raw_repair_view is not None:
+        if not isinstance(raw_repair_view, dict):
+            raise CorpusError(f"{filename}: repair_view must be an object")
+        repair_view = cast("dict[str, object]", raw_repair_view)
+    if expect_valid and repair_view is not None:
+        raise CorpusError(
+            f"{filename}: repair_view is unreachable when the case is expected valid"
+        )
+
+    name = _text(case, "name", filename)
+    return CorpusCase(
+        name=name,
+        provenance=provenance,
+        source=_text(case, "source", filename),
+        expect_first_pass_valid=expect_valid,
+        benchmark_input=ContractBenchmarkInput(
+            name=name,
+            writer_view=_mapping(case, "writer_view", filename),
+            invocation=_mapping(case, "invocation", filename),
+            repair_view=repair_view,
+        ),
+    )
+
+
+def load_corpus(root: Path) -> tuple[CorpusCase, ...]:
+    """Load every ``*.json`` case under ``root``, ordered by filename."""
+    if not root.is_dir():
+        raise CorpusError(f"corpus directory not found: {root}")
+    paths = sorted(root.glob("*.json"))
+    if not paths:
+        raise CorpusError(f"corpus directory holds no cases: {root}")
+    cases = tuple(_load_case(path) for path in paths)
+    counts = Counter(case.name for case in cases)
+    duplicates = sorted(name for name, count in counts.items() if count > 1)
+    if duplicates:
+        raise CorpusError(f"duplicate case names: {', '.join(duplicates)}")
+    return cases
+
+
+def expectation_mismatches(
+    cases: Sequence[CorpusCase], report: BenchmarkReport
+) -> tuple[str, ...]:
+    """Cases whose replayed first-pass validity contradicts the recorded one."""
+    return tuple(
+        f"{case.name}: recorded expect_first_pass_valid="
+        + f"{str(case.expect_first_pass_valid).lower()}, replay produced "
+        + f"{str(record.first_pass_valid).lower()}"
+        for case, record in zip(cases, report.records)
+        if case.expect_first_pass_valid != record.first_pass_valid
+    )
+
+
+def captured_invalid_rate(
+    cases: Sequence[CorpusCase], report: BenchmarkReport
+) -> float | None:
+    """First-pass-invalid share of captured cases, or ``None`` when there are none."""
+    captured = [
+        record
+        for case, record in zip(cases, report.records)
+        if case.provenance == CAPTURED
+    ]
+    if not captured:
+        return None
+    return sum(not record.first_pass_valid for record in captured) / len(captured)
+
+
+def corpus_problems(
+    cases: Sequence[CorpusCase], report: BenchmarkReport
+) -> tuple[str, ...]:
+    """Everything that should turn the weekly run red, in report order."""
+    problems = list(expectation_mismatches(cases, report))
+    rate = captured_invalid_rate(cases, report)
+    if rate is not None and rate > INVALID_BUDGET:
+        problems.append(
+            f"captured first-pass invalid rate {rate:.1%} exceeds the "
+            + f"{INVALID_BUDGET:.0%} budget"
+        )
+    return tuple(problems)
+
+
+def _budget_status(cases: Sequence[CorpusCase], report: BenchmarkReport) -> str:
+    rate = captured_invalid_rate(cases, report)
+    if rate is None:
+        return (
+            "not measurable — the corpus holds no captured cases yet "
+            + "(easy-cheese#406)"
+        )
+    captured = sum(case.provenance == CAPTURED for case in cases)
+    verdict = "met" if rate <= INVALID_BUDGET else "NOT MET"
+    return f"{verdict} — {rate:.1%} of {captured} captured cases were first-pass invalid"
+
+
+def _display_path(corpus_root: Path) -> str:
+    resolved = corpus_root.resolve()
+    if resolved.is_relative_to(REPO_ROOT):
+        return str(resolved.relative_to(REPO_ROOT))
+    return str(resolved)
+
+
+def render_report(
+    cases: Sequence[CorpusCase], report: BenchmarkReport, corpus_root: Path
+) -> str:
+    """Render the markdown the weekly job publishes to its job summary."""
+    attempts = sum(record.repair_attempted for record in report.records)
+    canonical_sizes = [
+        record.canonical_bytes
+        for record in report.records
+        if record.canonical_bytes is not None
+    ]
+    captured = sum(case.provenance == CAPTURED for case in cases)
+    lines = [
+        "## Contract validity benchmark",
+        "",
+        f"Corpus: `{_display_path(corpus_root)}` — {len(cases)} cases "
+        + f"({captured} captured, {len(cases) - captured} synthetic)",
+        "",
+        "| Metric | Value |",
+        "| --- | ---: |",
+        f"| First-pass validity (all cases) | {report.first_pass_validity:.1%} |",
+        "| Repair success among attempts | "
+        + (f"{report.repair_rate:.1%} |" if attempts else "n/a (none attempted) |"),
+        "| Largest canonical payload | "
+        + (f"{max(canonical_sizes):,} bytes |" if canonical_sizes else "n/a |"),
+        "",
+        f"Budget: captured writer output stays under {INVALID_BUDGET:.0%} "
+        + "first-pass invalid.",
+        f"Status: {_budget_status(cases, report)}",
+        "",
+        "| Case | Provenance | First pass | Repair | Writer bytes | Canonical bytes |",
+        "| --- | --- | --- | --- | ---: | ---: |",
+    ]
+    for case, record in zip(cases, report.records):
+        if not record.repair_attempted:
+            repair = "—"
+        else:
+            repair = "repaired" if record.repair_succeeded else "unrepaired"
+        canonical = (
+            "n/a" if record.canonical_bytes is None else f"{record.canonical_bytes:,}"
+        )
+        lines.append(
+            f"| {case.name} | {case.provenance} | "
+            + f"{'valid' if record.first_pass_valid else 'invalid'} | {repair} | "
+            + f"{record.writer_bytes:,} | {canonical} |"
+        )
+
+    problems = corpus_problems(cases, report)
+    if problems:
+        lines.extend(["", "### Problems", ""])
+        lines.extend(f"- {problem}" for problem in problems)
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    _ = parser.add_argument(
+        "--corpus",
+        type=Path,
+        default=CORPUS_ROOT,
+        help="directory of writer-capture JSON cases (default: benchmarks/contracts)",
+    )
+    args = parser.parse_args(argv)
+    corpus_root = cast(Path, args.corpus)
+
+    try:
+        cases = load_corpus(corpus_root)
+    except CorpusError as error:
+        print(f"contract_benchmarks: {error}", file=sys.stderr)
+        return 2
+
+    report = benchmark_contracts(case.benchmark_input for case in cases)
+    print(render_report(cases, report, corpus_root), end="")
+    problems = corpus_problems(cases, report)
+    for problem in problems:
+        print(f"contract_benchmarks: {problem}", file=sys.stderr)
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/python/test_contract_benchmark_corpus.py
+++ b/tests/python/test_contract_benchmark_corpus.py
@@ -1,0 +1,281 @@
+"""The stored writer-output corpus, its loader, and the weekly report."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "src"))
+
+import contract_benchmarks  # noqa: E402
+from easy_cheese_schemas.benchmarks import (  # noqa: E402
+    BenchmarkReport,
+    benchmark_contracts,
+)
+
+CORPUS = ROOT / "benchmarks" / "contracts"
+
+
+def _committed_case(name: str) -> dict[str, object]:
+    document = cast(
+        object, json.loads((CORPUS / f"{name}.json").read_text(encoding="utf-8"))
+    )
+    assert isinstance(document, dict)
+    return cast("dict[str, object]", document)
+
+
+def _write(root: Path, filename: str, case: dict[str, object]) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _ = (root / filename).write_text(json.dumps(case), encoding="utf-8")
+
+
+def _valid_case(**overrides: object) -> dict[str, object]:
+    return _committed_case("review-result-clean") | overrides
+
+
+def _invalid_case(**overrides: object) -> dict[str, object]:
+    return _committed_case("review-result-host-owned-field") | overrides
+
+
+def _run(
+    root: Path,
+) -> tuple[tuple[contract_benchmarks.CorpusCase, ...], BenchmarkReport]:
+    cases = contract_benchmarks.load_corpus(root)
+    return cases, benchmark_contracts(case.benchmark_input for case in cases)
+
+
+def test_committed_corpus_replays_to_its_recorded_expectations() -> None:
+    """The backward-compat canary: a contract change may not flip stored payloads."""
+    cases = contract_benchmarks.load_corpus(CORPUS)
+    report = benchmark_contracts(case.benchmark_input for case in cases)
+
+    assert [case.name for case in cases] == [
+        "planner-result-complete",
+        "planner-result-partial",
+        "review-result-clean",
+        "review-result-host-owned-field",
+    ]
+    assert contract_benchmarks.expectation_mismatches(cases, report) == ()
+    assert [record.first_pass_valid for record in report.records] == [
+        True,
+        True,
+        True,
+        False,
+    ]
+    assert report.first_pass_validity == 0.75
+    assert report.repair_rate == 1.0
+    assert contract_benchmarks.corpus_problems(cases, report) == ()
+
+
+def test_expectation_mismatch_names_the_case_and_both_verdicts(tmp_path: Path) -> None:
+    _write(tmp_path, "flipped.json", _valid_case(expect_first_pass_valid=False))
+    cases, report = _run(tmp_path)
+
+    assert contract_benchmarks.expectation_mismatches(cases, report) == (
+        "review-result-clean: recorded expect_first_pass_valid=false, "
+        + "replay produced true",
+    )
+    assert contract_benchmarks.corpus_problems(cases, report) == (
+        "review-result-clean: recorded expect_first_pass_valid=false, "
+        + "replay produced true",
+    )
+
+
+def test_budget_is_measured_over_captured_cases_only(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "a-synthetic-invalid.json",
+        _invalid_case(name="synthetic-invalid", provenance="synthetic"),
+    )
+    _write(
+        tmp_path,
+        "b-captured-valid.json",
+        _valid_case(name="captured-valid", provenance="captured"),
+    )
+    cases, report = _run(tmp_path)
+
+    assert report.first_pass_validity == 0.5
+    assert contract_benchmarks.captured_invalid_rate(cases, report) == 0.0
+    assert contract_benchmarks.corpus_problems(cases, report) == ()
+
+
+def test_captured_invalid_rate_is_none_without_captured_cases(tmp_path: Path) -> None:
+    _write(tmp_path, "only-synthetic.json", _valid_case())
+    cases, report = _run(tmp_path)
+
+    assert contract_benchmarks.captured_invalid_rate(cases, report) is None
+
+
+def test_captured_breach_over_budget_is_a_problem(tmp_path: Path) -> None:
+    for index in range(9):
+        _write(
+            tmp_path,
+            f"valid-{index}.json",
+            _valid_case(name=f"captured-valid-{index}", provenance="captured"),
+        )
+    _write(
+        tmp_path,
+        "z-invalid.json",
+        _invalid_case(name="captured-invalid", provenance="captured"),
+    )
+    cases, report = _run(tmp_path)
+
+    assert contract_benchmarks.captured_invalid_rate(cases, report) == pytest.approx(0.1)
+    assert contract_benchmarks.corpus_problems(cases, report) == ()
+
+    _write(
+        tmp_path,
+        "z-invalid-2.json",
+        _invalid_case(name="captured-invalid-2", provenance="captured"),
+    )
+    cases, report = _run(tmp_path)
+
+    assert contract_benchmarks.captured_invalid_rate(cases, report) == pytest.approx(
+        2 / 11
+    )
+    assert contract_benchmarks.corpus_problems(cases, report) == (
+        "captured first-pass invalid rate 18.2% exceeds the 10% budget",
+    )
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ({"surprise": 1}, "unknown keys: surprise"),
+        ({"provenance": "guessed"}, "provenance must be one of captured, synthetic"),
+        ({"expect_first_pass_valid": "yes"}, "expect_first_pass_valid must be a boolean"),
+        ({"name": "   "}, "name must be a non-empty string"),
+        ({"invocation": []}, "invocation must be an object"),
+        ({"repair_view": {}}, "repair_view is unreachable"),
+    ],
+)
+def test_malformed_cases_are_rejected_before_the_harness(
+    tmp_path: Path, case: dict[str, object], message: str
+) -> None:
+    _write(tmp_path, "case.json", _valid_case(**case))
+
+    with pytest.raises(contract_benchmarks.CorpusError) as error:
+        _ = contract_benchmarks.load_corpus(tmp_path)
+
+    assert message in str(error.value)
+    assert str(error.value).startswith("case.json: ")
+
+
+def test_missing_keys_are_named_in_the_rejection(tmp_path: Path) -> None:
+    _write(tmp_path, "case.json", {"name": "sparse", "provenance": "synthetic"})
+
+    with pytest.raises(contract_benchmarks.CorpusError) as error:
+        _ = contract_benchmarks.load_corpus(tmp_path)
+
+    assert str(error.value) == (
+        "case.json: missing keys: expect_first_pass_valid, invocation, source, "
+        "writer_view"
+    )
+
+
+def test_duplicate_case_names_are_rejected(tmp_path: Path) -> None:
+    _write(tmp_path, "one.json", _valid_case(name="twin"))
+    _write(tmp_path, "two.json", _valid_case(name="twin"))
+
+    with pytest.raises(contract_benchmarks.CorpusError) as error:
+        _ = contract_benchmarks.load_corpus(tmp_path)
+
+    assert str(error.value) == "duplicate case names: twin"
+
+
+def test_invalid_json_and_empty_directories_are_rejected(tmp_path: Path) -> None:
+    with pytest.raises(contract_benchmarks.CorpusError) as empty:
+        _ = contract_benchmarks.load_corpus(tmp_path)
+    assert str(empty.value) == f"corpus directory holds no cases: {tmp_path}"
+
+    missing = tmp_path / "absent"
+    with pytest.raises(contract_benchmarks.CorpusError) as gone:
+        _ = contract_benchmarks.load_corpus(missing)
+    assert str(gone.value) == f"corpus directory not found: {missing}"
+
+    _ = (tmp_path / "broken.json").write_text("{", encoding="utf-8")
+    with pytest.raises(contract_benchmarks.CorpusError) as broken:
+        _ = contract_benchmarks.load_corpus(tmp_path)
+    assert str(broken.value).startswith("broken.json: invalid JSON: ")
+
+
+def test_report_states_the_budget_status_and_every_case(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "a-captured.json",
+        _invalid_case(name="captured-invalid", provenance="captured"),
+    )
+    _write(tmp_path, "b-synthetic.json", _valid_case(name="synthetic-valid"))
+    cases, report = _run(tmp_path)
+
+    rendered = contract_benchmarks.render_report(cases, report, tmp_path)
+
+    assert rendered.startswith("## Contract validity benchmark\n")
+    assert f"Corpus: `{tmp_path}` — 2 cases (1 captured, 1 synthetic)" in rendered
+    assert "| First-pass validity (all cases) | 50.0% |" in rendered
+    assert "| Repair success among attempts | 100.0% |" in rendered
+    assert "| Largest canonical payload | 267 bytes |" in rendered
+    assert "Budget: captured writer output stays under 10% first-pass invalid." in rendered
+    assert (
+        "Status: NOT MET — 100.0% of 1 captured cases were first-pass invalid"
+        in rendered
+    )
+    assert "| captured-invalid | captured | invalid | repaired | 99 | 267 |" in rendered
+    assert "| synthetic-valid | synthetic | valid | — | 73 | 267 |" in rendered
+    assert rendered.endswith(
+        "### Problems\n\n"
+        + "- captured first-pass invalid rate 100.0% exceeds the 10% budget\n"
+    )
+
+
+def test_report_reports_no_repairs_and_no_captured_cases(tmp_path: Path) -> None:
+    _write(tmp_path, "only.json", _valid_case())
+    cases, report = _run(tmp_path)
+
+    rendered = contract_benchmarks.render_report(cases, report, tmp_path)
+
+    assert "| Repair success among attempts | n/a (none attempted) |" in rendered
+    assert (
+        "Status: not measurable — the corpus holds no captured cases yet "
+        + "(easy-cheese#406)" in rendered
+    )
+    assert "### Problems" not in rendered
+
+
+def test_main_publishes_the_committed_report_and_exits_clean(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert contract_benchmarks.main([]) == 0
+
+    captured = capsys.readouterr()
+    assert "Corpus: `benchmarks/contracts` — 4 cases (0 captured, 4 synthetic)" in (
+        captured.out
+    )
+    assert "| First-pass validity (all cases) | 75.0% |" in captured.out
+    assert "| Largest canonical payload | 2,070 bytes |" in captured.out
+    assert captured.err == ""
+
+
+def test_main_exits_one_on_a_problem_and_two_on_a_broken_corpus(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write(tmp_path, "flipped.json", _valid_case(expect_first_pass_valid=False))
+
+    assert contract_benchmarks.main(["--corpus", str(tmp_path)]) == 1
+    problem = capsys.readouterr()
+    assert "### Problems" in problem.out
+    assert problem.err == (
+        "contract_benchmarks: review-result-clean: recorded "
+        "expect_first_pass_valid=false, replay produced true\n"
+    )
+
+    assert contract_benchmarks.main(["--corpus", str(tmp_path / "absent")]) == 2
+    broken = capsys.readouterr()
+    assert broken.out == ""
+    assert broken.err.startswith("contract_benchmarks: corpus directory not found: ")


### PR DESCRIPTION
Weekly cron workflow replaying a benchmark corpus through the real normalize_agent_output boundary, reporting the <10% first-pass-invalid budget to the step summary. Synthetic seed corpus reports 'not measurable' until captured cases land; the automatic capture path is left open as its own privacy-sensitive design pass. Refs #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018V6nZ6MgNn3vNPgQCRVwky