### PR TITLE
ci(validate): install just from PyPI instead of the GitHub releases API

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -69,10 +69,12 @@ jobs:
           version: "0.12.5"
           python-version: "3.12"
 
+      # PyPI install: no GitHub API call, so the repo-wide GITHUB_TOKEN
+      # budget (1,000 requests/hour) is not spent on every job.
       - name: Set up just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
-        with:
-          just-version: "1.58.0"
+        run: |
+          uv tool install rust-just==1.58.0
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install test dependencies
         run: |
@@ -149,10 +151,12 @@ jobs:
           version: "0.12.5"
           python-version: "3.12"
 
+      # PyPI install: no GitHub API call, so the repo-wide GITHUB_TOKEN
+      # budget (1,000 requests/hour) is not spent on every job.
       - name: Set up just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
-        with:
-          just-version: "1.58.0"
+        run: |
+          uv tool install rust-just==1.58.0
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: basedpyright
         run: just typecheck
@@ -170,10 +174,12 @@ jobs:
           version: "0.12.5"
           python-version: "3.12"
 
+      # PyPI install: no GitHub API call, so the repo-wide GITHUB_TOKEN
+      # budget (1,000 requests/hour) is not spent on every job.
       - name: Set up just
-        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3.1.0
-        with:
-          just-version: "1.58.0"
+        run: |
+          uv tool install rust-just==1.58.0
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: markdownlint
         uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe # v24.1.0
         with:

--- a/tests/python/test_justfile_ci_contract.py
+++ b/tests/python/test_justfile_ci_contract.py
@@ -37,7 +37,12 @@ def test_check_and_ci_depend_on_dead_code() -> None:
 
 
 def test_ci_jobs_pin_tools() -> None:
-    """Test and lint jobs pin both uv and just setup actions."""
+    """Test and lint jobs pin uv and install a pinned just from PyPI.
+
+    The just install must not use a GitHub-releases action: every such
+    call spends the repo-wide GITHUB_TOKEN budget and fails all jobs once
+    it is exhausted.
+    """
     jobs = cast(
         dict[str, object],
         yaml.safe_load(
@@ -53,4 +58,6 @@ def test_ci_jobs_pin_tools() -> None:
             if "uses" in step
         }
         assert "version" in cast(dict[str, object], uses["astral-sh/setup-uv"])
-        assert "just-version" in cast(dict[str, object], uses["extractions/setup-just"])
+        assert "extractions/setup-just" not in uses
+        runs = [cast(str, step["run"]) for step in steps if "run" in step]
+        assert any("uv tool install rust-just==1.58.0" in run for run in runs)


### PR DESCRIPTION
Install `just` from PyPI (`rust-just==1.58.0`) in the three `validate` jobs that used `extractions/setup-just`.

**Semantics-preserving** for the code; changes CI setup only. Same `just` version, same jobs, same commands.

## Why

CI jobs authenticate with the repo-scoped `GITHUB_TOKEN`, which has a **1,000 requests/hour budget shared by the whole repository**. `extractions/setup-just` calls `GET /repos/casey/just/releases` in every job even with `just-version` pinned. With twelve `fix/r014-*` branches plus `main` pushing in parallel (~200 workflow runs in the last two hours), that budget empties and every job in every branch fails at "Set up just" with `API rate limit exceeded for installation` until the hourly reset — see PR #580's validate run `33724407452` (two attempts, 06:41Z and 06:53Z, identical failure).

`uv tool install rust-just` downloads from PyPI and makes no GitHub API call. Each job already runs `astral-sh/setup-uv`, so no new action is added.

## What to verify

- `just --version` prints `1.58.0` in each of the three jobs (validate, typecheck, lint).
- `$HOME/.local/bin` is appended to `GITHUB_PATH` so later steps find `just`.
- Verified locally: `uv tool install rust-just==1.58.0` → `just 1.58.0`; `yamllint -c .yamllint.yml .github/workflows/validate.yml` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3HF3RADLUjfPfektaXtQR
