### PR TITLE
docs(wiki): promote language-reviewability research report

### DIFF
--- a/.hallouminate/wiki/index.md
+++ b/.hallouminate/wiki/index.md
@@ -18,6 +18,7 @@ git-tracking axis (`skills/cheese/references/formatting.md:103`).
 - [architecture/](./architecture/index.md) — architecture
 - [decisions/](./decisions/index.md) — decisions
 - [gotchas/](./gotchas/index.md) — gotchas
+- [research/](./research/index.md) — research
 - [specs/](./specs/index.md) — specs
 - [architecture](./architecture.md) — Architecture of easy-cheese
 - [docs-mermaid-rendering](./docs-mermaid-rendering.md) — Docs Mermaid rendering

--- a/.hallouminate/wiki/log.md
+++ b/.hallouminate/wiki/log.md
@@ -77,3 +77,6 @@
 - 2026-09-04 · 499c49c7b67d5eb6 · skipped-near-duplicate · — · handback `status:` vs `halt:` rule, disposition-based routing, and the handoff-gate block structure already live in workflow-invariants.md; per-finding ledgers, commit lists, CI status, and the 897-line skill-review-cure.md status table were transient and dropped.
 - 2026-09-04 · 499c49c7b67d5eb6 · retrieval-warning · gotchas/wheypoint-resume-traps.md · exact probe "Wheypoint resume traps" ranks 2 (0.0579) behind architecture/handoff-preamble-grammar.md (0.0584) after one lead revision and one citation revision; all natural probes pass; page kept, no rollback.
 
+
+
+- 2026-09-05 · bef0ae510984cffd · new-page · research/language-reviewability-evidence.md · promoted research report: diff size beats language choice (200–400 LOC), Ray et al. overturned by Berger et al., ~15% typed-JS bug catch, memory-safety class elimination, 19% faster defect finding with full-word identifiers, Python/TS/Go tiering, easy-cheese skill touchpoints.

--- a/.hallouminate/wiki/research/index.md
+++ b/.hallouminate/wiki/research/index.md
@@ -1,0 +1,11 @@
+# research
+
+Research reports promoted from the XDG project corpus into the tracked wiki
+because a human asked to review them in a PR. The default home for a
+research report is still `$XDG_DATA_HOME/cheese/<project>/research/`
+(see [wiki-conventions](../wiki-conventions.md)); a page lands here only
+when its evidence should ground repository decisions across sessions.
+
+<!-- HALLOUMINATE:INDEX-START -->
+- [language-reviewability-evidence](./language-reviewability-evidence.md) — Language readability and reviewability evidence (AI-review era)
+<!-- HALLOUMINATE:INDEX-END -->

--- a/.hallouminate/wiki/research/language-reviewability-evidence.md
+++ b/.hallouminate/wiki/research/language-reviewability-evidence.md
@@ -1,0 +1,75 @@
+# Language readability and reviewability evidence (AI-review era)
+
+Promoted research report. It answers "which languages are easiest to read
+and review when a model writes most of the code", and it grounds the
+easy-cheese review pipeline's stance on diff size, formatting, typing, and
+naming in replicated studies rather than folklore.
+
+## TL;DR
+
+- **No language is decisively "easier to read" across the board.** Python, Ruby, and Quorum win on novice syntax intuitiveness; Go wins on uniform industrial reviewability; compiler-carried languages (Elm, Gleam, Rust, OCaml/F#, strict TypeScript) win on bug prevention per diff by moving whole defect classes off the reviewer.
+- **Diff size dwarfs language choice.** Reviewers find 70–90% of defects in 200–400-line reviews; effectiveness collapses past 400–500 LOC/hour. This is the single largest, most robust lever.
+- **"Language choice strongly determines defect rate" is folklore.** Ray et al. (FSE 2014) was substantially overturned by Berger et al. (TOPLAS 2019): eleven significant languages shrank to four with an "exceedingly small" effect size.
+- **For a Python + TypeScript stack with AI-generated code reviewed by humans**, the Pareto move is strict typed Python (mypy/pyright strict) + Black/Ruff + exhaustiveness linting, and TypeScript strict mode. Not a language switch.
+
+## Key findings
+
+1. **Diff size dwarfs language choice.** SmartBear/Cisco (2,500 reviews, 3.2M LOC): 200–400 LOC over 60–90 minutes yields 70–90% defect discovery. Modern data: ~87% detection for sub-100-line PRs vs ~28% for 1,000+ lines. Google's median change is ~24 lines. Bacchelli & Bird: the reviewer's dominant challenge is comprehension, not defect-spotting.
+2. **The headline language-to-quality study was overturned.** Berger, Hollenbeck, Maj, Vitek & Vitek (TOPLAS 2019) reproduced Ray et al. and concluded the results "undermine the conclusions of the original study". Treat any "language X has fewer bugs" claim with deep skepticism.
+3. **Static typing's benefit is real but modest and specific.** Gao, Bird & Barr (ICSE 2017): TypeScript and Flow each detect ~15% of already-shipped JavaScript bugs (CI 11.5%–18.5%). Hanenberg's controlled experiments: types help with undocumented APIs, type errors, and maintainability tasks, not semantic errors.
+4. **Memory safety is the one place a language change slashes a whole defect class.** ~70% of severe vulnerabilities at Microsoft and Chromium are memory-safety bugs. Google Android (Sept 2024, Nov 2025): memory-safety share fell from 76% (2019) to under 20%; Rust changes had a 4× lower rollback rate and spent 25% less time in code review. Strongest "language improves reviewability" evidence that exists, with selection-bias caveats.
+5. **Syntax intuitiveness is measurable and Python is near the top.** Stefik & Siebert (TOCE 2013): Perl and Java were no more accurate than a randomly-keyworded language; Quorum, Python, and Ruby were significantly better. Novice study; do not over-extrapolate to expert review.
+
+## Comprehension research that transfers to review
+
+- **Working memory is the bottleneck.** fMRI studies (Siegmund et al. ICSE 2014; Peitek et al. TSE 2020; Floyd et al. ICSE 2017) show comprehension leans on working memory and language centers. Local reasoning, meaningful identifiers, and low working-memory load make code reviewable, largely independent of language.
+- **Readability metrics.** Buse & Weimer (TSE 2010): biggest negative drivers are identifier count, line length, and punctuation density. Scalabrino et al. (TSE 2019): none of 121 metrics individually captures understandability.
+- **Identifiers.** Hofmeister, Siegmund & Holt (SANER 2017 / EMSE 2019; 72 professional developers): full-word identifiers gave a **19% increase in defect-finding speed** over single letters or abbreviations. Binkley/Sharif eye-tracking: snake_case recognized faster than camelCase.
+- **Indentation.** Miara et al. (CACM 1983): 2–4 spaces maximized comprehension and explained ~36% of quiz-score variance. Python enforces this as syntax.
+
+## Language features that aid or harm review
+
+- **Aid:** exhaustive pattern matching over sum types; no-null/Option types; immutability by default; explicit error values (Go `if err != nil`, Rust `Result`) over exceptions' action-at-a-distance; canonical formatting (gofmt, Black, Prettier, rustfmt) that removes formatting noise from every diff.
+- **Harm:** macros/metaprogramming, Ruby DSLs, Scala implicits, operator overloading. Each breaks local reasoning and forces the reviewer to reason non-locally. Go was designed to exclude these; Pike's stated goal was comprehensibility for large teams who "read, debug, modify, review, and deploy code written by everyone else".
+- **Density:** Java boilerplate dilutes signal; APL-style density overloads working memory; Python's moderate density sits near the Buse/Weimer sweet spot.
+
+## The AI-era twist
+
+Compiler-checked languages shift review burden onto the type checker: "the type checker reviews the AI". AI-generated code fails differently (plausible-looking, subtly wrong), so compiler guarantees are worth more when the author is a model. Counter-argument, well supported: **reviewer familiarity dominates**, and LLMs generate high-resource languages (Python, JS/TS, Java) far more accurately than Rust, Elm, or Gleam (MultiPL-E gaps; "LLMs Love Python", 2025). Optimal AI-era language = high human reviewability × high LLM accuracy, which points back at typed Python and strict TypeScript, Go for uniform tooling, Rust where memory safety is the point.
+
+Vendor signals (not peer-reviewed): LinearB 2026 reported ~32.7% acceptance for AI PRs vs 84.4% human; Faros AI reported 98% more merged PRs but 91% longer review time on high-AI teams; Greptile reported median PR size up 33% in 2025; CodeRabbit reported ~1.7× more issues per AI PR; GitHub Octoverse 2025 reported 32% faster merges and 28% fewer post-merge defects with AI-assisted review.
+
+## Tiering relative to a Python baseline (backend and tooling, human-reviewed)
+
+| Tier | Languages | Why |
+|---|---|---|
+| 1 | Typed Python (strict mypy/pyright), TypeScript strict, Go | Match or beat Python on reviewability; keep top LLM accuracy |
+| 2 | Kotlin, C#, modern Java, Rust, F#/OCaml | Superior bug prevention by construction; lower familiarity or LLM accuracy |
+| 3 | Elm, Gleam | Compiler carries the review; small ecosystems, low LLM accuracy |
+| 4 | Untyped JavaScript, DSL-heavy Ruby, Scala, C/C++ | Worse than Python for review |
+
+## Recommendations from the report
+
+1. Cap diffs at 200–400 changed lines and reviews at 60 minutes. Enforce with PR-size bots and stacked PRs for AI-generated code. Highest ROI of anything here.
+2. Make canonical formatting non-negotiable (Black + Ruff, Prettier, gofmt).
+3. Require the human author of record to annotate non-obvious AI-generated changes before review. Cisco data showed author-prepared reviews had markedly lower defect densities.
+4. Strict typed Python and TypeScript strict (`strict: true`, `noUncheckedIndexedAccess`) as deterministic CI gates.
+5. Exhaustiveness enforcement: discriminated unions + `assertNever` in TS; exhaustive `match` plus mypy in Python; ban silent fallthrough.
+6. Disallow metaprogramming and action-at-a-distance in reviewed code: no monkey-patching, minimal side-effecting decorators, no clever `__getattr__`.
+7. Go for standalone tooling where uniformity dominates; Rust only where memory safety or performance is the requirement; Elm/Gleam niche.
+
+## Where this touches easy-cheese
+
+- `/plate` topology (`skills/plate/references/topology.md`) forbids line-count thresholds and decides single-vs-stacked purely on review shape. The diff-size evidence argues for a size signal as a _stack recommendation trigger_, not a hard split rule.
+- `/age` sizes fan-out by a router score (`skills/age/references/fan-out.md`), not by diff size. The 200–400-line comprehension ceiling is a candidate input for packet sizing.
+- `/age` `deslop` grades a vague name `low`. The 19% defect-finding-speed result supports raising abbreviated or single-letter identifiers in reviewed hunks.
+- `/cook` taste-test Readability lens (`skills/cook/references/tdd-loop.md`) has no local-reasoning criterion; metaprogramming and action-at-a-distance are unnamed.
+- `/mold` has no language-selection guidance for new components; the tiering table is a ready default.
+
+## Caveats
+
+- Evidence quality is uneven. Replicated: diff-size effects, memory-safety class elimination, static typing's ~15% JS-bug catch. Folklore: "functional/typed languages have fewer bugs overall".
+- Novice syntax studies are not expert review. Familiarity is a massive confound. No controlled study measures review throughput across languages holding all else equal.
+- Vendor AI-era numbers are directional, not authoritative.
+
+_Source: uploaded research artifact "Most Readable and Reviewable Languages in the AI-Review Era: An Evidence-Based Analysis" (ingest hash bef0ae510984cffd), promoted for repository review on 2026-09-05 · Updated: 2026-09-05 · Supersedes: none._


### PR DESCRIPTION
## Summary

- promotes the research artifact "Most Readable and Reviewable Languages in the AI-Review Era: An Evidence-Based Analysis" into the tracked wiki as `.hallouminate/wiki/research/language-reviewability-evidence.md`
- adds the new `research/` subdirectory index, the top-level index row, and the ingest-log entry (hash `bef0ae510984cffd`)
- records where the evidence touches `/plate` topology, `/age` fan-out and `deslop`, the `/cook` taste-test, and `/mold` (follow-up skill changes are out of scope here)

Research reports default to the XDG corpus; this one is promoted into the wiki under the same review-exception rule the conventions page applies to specs.

## Review shape

Semantics-preserving documentation only. No runtime or skill behavior changes.

## Verification

- `python3 .github/scripts/validate_wiki.py` — OK, 119 pages
- `python3 .github/scripts/test_validate_wiki.py` — OK
- `markdownlint-cli2 ".hallouminate/wiki/research/*.md"` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
