### PR TITLE
fix(ci): force npm in the schema-site Cloudflare deploy

### DIFF
--- a/.github/workflows/schemas-site.yml
+++ b/.github/workflows/schemas-site.yml
@@ -79,4 +79,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          # Force npm: the action otherwise infers pnpm from the repo's
+          # root pnpm-lock.yaml (the Starlight docs), but this Python-only
+          # job never sets up Node/pnpm, so wrangler install fails.
+          packageManager: npm
           command: pages deploy dist-schemas --project-name=easy-cheese-schemas --branch=main


### PR DESCRIPTION
The `Deploy to Cloudflare Pages` step in `schemas-site.yml` fails:

```
##[error]Unable to locate executable file: pnpm.
```

`wrangler-action` infers the package manager from a lockfile. This repo's root `pnpm-lock.yaml` (the Starlight docs) makes it pick **pnpm**, but the schema-site job is Python-only and never sets up Node/pnpm — so wrangler can't install and the deploy dies before it reaches Cloudflare.

Fix: pin `packageManager: npm` on the action. npm is always present on the runner.

Everything before the deploy step already passes (goldens verify + build). Verified failing run: https://github.com/paulnsorensen/easy-cheese/actions/runs/34001595583

Refs #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)