### PR TITLE
fix(cheese): permit constrained specialist fallback

### DIFF
--- a/skills/cheese/references/agent-resolution.md
+++ b/skills/cheese/references/agent-resolution.md
@@ -14,8 +14,8 @@ Apply these gates in order for every requested agent:
 2. **Minimum power.** Power is `cheap | default | powerful`; effort is `low | medium | high`. Reject a candidate known to be below the requested power. A candidate whose power is unknown is eligible only as the final fallback and sets `degraded: true`.
 3. **Specificity.** Among eligible candidates choose an exact easy-cheese specialist, then a compatible specialist, then a general worker.
 
-A general worker can fill a read-only role when the host cannot restrict tools.
-Make the no-write constraint explicit.
+When the host cannot restrict tools, an eligible specialist or general worker can fill a read-only role only when the caller states an explicit no-write constraint.
+This includes an artifact-capable Explorer under the same explicit no-write constraint.
 Record `permission_enforcement: prompt-only` and set `degraded: true`.
 Prompt-only enforcement cannot satisfy write work or stronger isolation.
 

--- a/tests/python/test_agent_resolution_contract.py
+++ b/tests/python/test_agent_resolution_contract.py
@@ -106,6 +106,23 @@ def test_shared_reference_is_normative_and_linked() -> None:
     ).read_text(encoding="utf-8")
 
 
+def test_prompt_only_fallback_covers_eligible_specialists() -> None:
+    reference = (SKILLS / "cheese" / "references" / "agent-resolution.md").read_text(
+        encoding="utf-8"
+    )
+    lowered = reference.lower()
+
+    assert "eligible specialist or general worker" in lowered
+    assert "can fill a read-only role only when the caller states an explicit no-write constraint" in lowered
+    assert "artifact-capable explorer under the same explicit no-write constraint" in lowered
+    assert "permission_enforcement: prompt-only" in lowered
+    assert "degraded: true" in lowered
+    assert "prompt-only enforcement cannot satisfy write work or stronger isolation" in lowered
+    assert "missing required tools or write capability stops dispatch" in lowered
+    assert "halt when required worktree or fresh-context isolation is unavailable" in lowered
+    assert "a general worker can fill a read-only role" not in lowered
+
+
 def test_each_dispatching_skill_has_local_resolution_contract() -> None:
     for name in DISPATCHING:
         body = _body(name)


### PR DESCRIPTION
## Purpose

Permit eligible specialist agents to serve read-only requests when the host cannot restrict their tools.

## Changes

- Require an explicit caller no-write instruction for every prompt-only fallback.
- Include artifact-capable Explorer under that same restriction.
- Preserve required write capability, stronger isolation, and degraded-enforcement reporting.
- Add regression coverage for the shared resolver contract.

## Verification

- `ulimit -n 4096; just check`: exit 0.
- Full gate: 4,222 tests pass; four tests skip.
- Focused resolver tests: five pass.
- Independent severity review: no remaining findings.
- Formatters leave the prepared diff unchanged.
- The gate reports lockfile line-length and documentation highlighting warnings.

## Artifacts

| Target | Backend | Verified |
|---|---|---|
| `skills/cheese/references/agent-resolution.md` | tracked source | true |
| `tests/python/test_agent_resolution_contract.py` | tracked source | true |

## Risks and coordination

Prompt-only enforcement is an instruction boundary, not an operating-system restriction.
This PR supports the separate dotfiles Explorer artifact contract.
It is an independent ordinary PR against `main`.
