### PR TITLE
feat(mold): batch the four handshake audits into one scope table

### DIFF
--- a/skills/mold/SKILL.md
+++ b/skills/mold/SKILL.md
@@ -104,7 +104,7 @@ Each settled consequential fork must appear in Approach, Interface sketches, and
 
 Curdle requires the **two-key handshake**. It requires an explicit user verb, such as `curdle` or `ship it`. It also requires the agent's coherence self-check. Present the validated typed `CurdPlan`'s `N curds / M waves` with the final approval request in Flow step 5; on Light's single-curd path there is no plan, so present the spec alone and mark the plan boxes `n/a`. See `references/handshake.md` for the checklist, mandatory gates, and override semantics.
 
-Before the handshake runs, also perform the **agent-introduced-scope** check. Flag each noun in Approach / Decisions / Interface sketches that the user did not type. Require explicit approval for each term before extraction. See `references/handshake.md` § Agent-introduced scope for the full procedure and single-chokepoint guarantee.
+Before the handshake runs, present the **scope audit table** once: agent-introduced nouns, non-goals, entity bindings, and follow-ups, each with a default. One confirm approves the defaults; only leverage rows and unresolved bindings need their own verb. Procedure: `references/handshake.md` § Scope audit table.
 
 If any gate is unmet, propose the smallest next question, evidence check, or planner correction. Do the same if the typed plan remains invalid after one retry. Write artifacts only after both keys pass.
 

--- a/skills/mold/references/curdle.md
+++ b/skills/mold/references/curdle.md
@@ -43,7 +43,7 @@ created: <YYYY-MM-DD>
 confidence: <low | medium | high>
 leverage: []   # fired trigger ids per `../../cheese/references/routing-policy.md` § Leverage triggers; copied from the handoff packet, extended when a later mode fires one
 gates_overridden: []   # list of unchecked handshake items if `curdle anyway` was used
-agent_introduced_scope: []   # terms in the spec the user did not type — each approved per `handshake.md` § Agent-introduced scope (audit trail; downstream skills trust this list)
+agent_introduced_scope: []   # terms in the spec the user did not type — approved through the scope audit table per `handshake.md` § Scope audit table (audit trail; downstream skills trust this list)
 entity_referent_bindings: []   # list of binding records {noun, verdict, referent, citation, note} for identity/ownership-role nouns bound to code referents or marked NEW ENTITY — each resolved per `handshake.md` § Entity-referent binding (audit trail; downstream skills trust this list)
 agent_resolution: []   # the shared agent-resolution block per `../../cheese/references/agent-resolution.md`
 gate_applicability:

--- a/skills/mold/references/handshake.md
+++ b/skills/mold/references/handshake.md
@@ -48,7 +48,7 @@ These are not soft suggestions — Curdle hard-blocks until they are addressed:
 - **Sketch gate:** mandatory when the chosen option touches more than one module or introduces a new public interface. Skip only for trivial single-function changes (the agent must say so out loud).
 - **Grill gate:** mandatory for high-blast-radius decisions. The shape check (`shape-check.md`) ranks blast radius `low | medium | high` from semantic caller search and `tilth_deps` when available. A `high` verdict — multi-module callers or more than five importers — makes Grill mandatory.
 - **Open hypotheses:** any Validate Cycle launched but unjudged blocks Curdle unless the user accepts it as `[TBD]`.
-- **Agent-introduced scope:** every distinguishing noun in the spec must trace to a user-typed mention or receive per-term approval. See the full procedure in § Agent-introduced scope below. Curdle is the single chokepoint because downstream skills trust the resulting frontmatter and do not re-block.
+- **Agent-introduced scope:** every distinguishing noun in the spec must trace to a user-typed mention or carry an approved scope-audit row. See the full procedure in § Agent-introduced scope below. Curdle is the single chokepoint because downstream skills trust the resulting frontmatter and do not re-block.
 - **Entity-referent binding:** bind every identity noun to a code referent or mark it NEW ENTITY. Resolve each ALIAS; do not only note it. See the full procedure in § Entity-referent binding below.
 - **Non-goals audit:** every `Non-goals` bullet traces to a user-stated out-of-scope item or is marked `[AGENT-INTRODUCED]`. Full procedure in § Non-goals audit below.
 - **Fork taste test:** Require a fresh-context verdict before decomposition. The verdict must match the draft SHA256. It must cover each settled consequential decision exactly once. It cannot contain contradictions, orphaned decisions, unsupported assumptions, or acceptance gaps. When the ledger pins a `goal`, the draft's Problem statement must contain it unchanged, compared case- and whitespace-insensitively, or the verdict fails as `goal-drift`. Mold permits the initial verdict and two corrective rounds. A third failure stops the process.
@@ -63,7 +63,7 @@ These are not soft suggestions — Curdle hard-blocks until they are addressed:
 
 ## Scope audit table
 
-The agent-introduced scope, non-goals, entity-referent, and follow-up audits below populate **one table, presented once, before the handshake**. Each row carries a default disposition. One confirm of the table approves every default. A row needs its own explicit verb only when it fires a leverage trigger (`../../cheese/references/routing-policy.md` § Leverage triggers) or is an unresolved ALIAS / NEW ENTITY binding. The grep and semantic search that populate the rows still run; the per-row approval round does not.
+The agent-introduced scope, non-goals, entity-referent, and follow-up audits below populate **one table, presented once, before the handshake**. Each row carries a default disposition. One confirm of the table approves every default. A row needs its own explicit verb only when it fires a leverage trigger (`../../cheese/references/routing-policy.md` § Leverage triggers) or is an unresolved ALIAS / NEW ENTITY binding. A row fires a trigger when the term, bullet, or noun it names would itself fire one of the eight ids if kept: an auth knob fires `auth`, a new export fires `contract`, a new domain fires `new-slice`. Such a row renders `needs your verb` in its Default cell, and the confirm never covers it. The grep and semantic search that populate the rows still run; the per-row approval round does not.
 
 ```
 Scope audit:
@@ -72,9 +72,10 @@ Scope audit:
 | 1 | scope | <noun> | agent / citation | keep | — |
 | 2 | non-goal | <bullet> | agent | keep | — |
 | 3 | entity | <noun> | search | Bound <referent> | — |
-| 4 | follow-up | <unit> | dialogue | non-goal only | — |
-| 5 | scope | <noun> | citation | drop | contract |
-Confirm the table, or name the rows to change.
+| 4 | follow-up | <unit: member, member> | dialogue | non-goal only | — |
+| 5 | scope | <noun> | citation | needs your verb | contract |
+| 6 | entity | <noun> | search | needs your verb (ALIAS <referent>) | — |
+Confirm the table to accept every default. Rows marked `needs your verb` block until you name a verb for each.
 ```
 
 Curdle runs the table as the terminal backstop. It remains the single chokepoint that downstream skills trust (RC3).
@@ -90,7 +91,7 @@ Procedure:
 3. **Any noun with zero hits is agent-introduced.** Mark it `[AGENT-INTRODUCED]` inline in the draft and add a `scope` row to the scope audit table. Default `keep` when the noun restates the user's ask or binds to a code referent, `follow-up` when it names new work, `drop` otherwise.
 
 4. **One confirm of the table approves the defaults.** A row that fires a leverage trigger needs its own verb: "keep <term>", "drop <term>", or "make <term> a follow-up". "Make <term> a follow-up" records a candidate within `Decided`. This choice does not create an issue or other artifact.
-5. **When the user explicitly drops a direction**, write a rejection record to `.cheese/.out-of-scope/<slug>-NNN.md`. A direction can be an approach, design knob, or named feature that the user declines. Use the format in `curdle.md` § Rejected-directions store. Do not make a rejected direction a follow-up candidate. Add explicit deferrals to the follow-up candidate set instead.
+5. **When a direction is dropped**, whether the user typed the verb or confirmed a `drop` default, write a rejection record to `.cheese/.out-of-scope/<slug>-NNN.md`. A direction can be an approach, design knob, or named feature that the user declines. Use the format in `curdle.md` § Rejected-directions store. Do not make a rejected direction a follow-up candidate. Add explicit deferrals to the follow-up candidate set instead.
 6. Do not silently promote a flagged term from a research citation into a design knob. This applies to briesearch sub-agent citations, fetched docs, and MCP results. The citation is evidence, not a mandate. See `skills/briesearch/references/synthesis.md` § Alternatives are open questions.
 
 This gate exists because research sub-agents have historically over-synthesised. For example, a Tavily snippet mentioning "X or Y" became a shipped `[setting].knob = "x" | "y"` flag. The flag passed through curdle → cook although the user never typed the distinguishing noun. The grep heuristic detects this type of drift early.
@@ -104,24 +105,24 @@ Curdle is the single chokepoint for this gate. Downstream skills (`/cook`, etc.)
 Procedure:
 
 1. For each `Non-goals` bullet, grep prior user turns for a statement that puts the item out of scope. Search only the user's typed messages. Examples include "don't bother with X", "leave Y alone", and an explicit deferral.
-2. **Any bullet with no such user statement is agent-introduced.** Mark it `[AGENT-INTRODUCED]` inline and add a `non-goal` row to the scope audit table with default `keep`. The user keeps, drops, or rewords it by confirming or editing the row.
+2. **Any bullet with no such user statement is agent-introduced.** Mark it `[AGENT-INTRODUCED]` inline and add a `non-goal` row to the scope audit table with default `keep`. Non-goals the bounds pass authored as `[AGENT-DECIDED]` are agent-introduced by definition and enter the table the same way. The user keeps, drops, or rewords it by confirming or editing the row.
 3. Record approved-but-flagged non-goals in the same `agent_introduced_scope` frontmatter list, so the paper trail survives downstream.
 4. Add every audited non-goal to the follow-up candidate set, including approved `[AGENT-INTRODUCED]` bullets. Candidate status preserves the scope boundary without accepting future work.
 
-This audit is the `Non-goals audit` coherence gate. It is the `non_goals_audit` node in the gate model (`gate-graph.md`). Run it **inline per round** as non-goals are proposed. Run it again at Curdle as the terminal backstop. Curdle hard-blocks extraction until every bullet traces to the user or has approved `[AGENT-INTRODUCED]` status.
+This audit is the `Non-goals audit` coherence gate. It is the `non_goals_audit` node in the gate model (`gate-graph.md`). Populate its rows as non-goals are proposed; present them once, in the scope audit table. Curdle reruns it as the terminal backstop and hard-blocks extraction until every bullet traces to the user or has an approved `[AGENT-INTRODUCED]` row.
 
 ## Follow-up disposition (inside the non-goals audit)
 
 Before the two-key handshake, dispose of every follow-up candidate in one batch: the `follow-up` rows of the scope audit table. This process extends the existing `Non-goals audit` gate. It does not add or rename a gate. The default destination is **non-goal only**; every other destination is a user edit on the row.
 
-1. Group related candidates into independently deliverable units. The user approves each grouping or splitting choice.
-2. Search GitHub Issues and Hallouminate roadmap goals when discovery is available. Present each semantic match for possible reuse. The user approves each reuse.
+1. Group related candidates into independently deliverable units. Each unit is one `follow-up` row whose cell lists its members; confirming the table accepts the grouping, and the user splits or merges by editing the row.
+2. Search GitHub Issues and Hallouminate roadmap goals when discovery is available. A semantic match becomes the row's default destination, `link #<id>`, in place of non-goal only; the user approves the reuse by confirming the row.
 3. Recommend one destination per unit:
    - **non-goal only** — keep the scope boundary, create no follow-up artifact, and offer no action choice;
    - **GitHub Issue** — use for discrete, independently actionable work;
    - **roadmap goal** — use for coordinated, milestone-scale, or dependency-linked work;
    - **local issue draft** — use when publication is not desired or available.
-4. The user approves the destination. For other destinations, ask the user to choose the action: **create/link now** or **leave prepared**.
+4. The user approves the destination by confirming the row's default or editing it. An edited destination also names the action: **create/link now** or **leave prepared**.
 5. Record accepted units for Curdle. Keep rejected design directions in the rejection store. Do not add them to this batch.
 
 The user approves grouping, splitting, semantic-match reuse, destination, and action choices by confirming the table's defaults or editing the rows. Mold settles none silently; every default is visible in the table. Omit this batch when no candidates exist. Preserve the current handshake and Curdle flow.

--- a/skills/mold/references/handshake.md
+++ b/skills/mold/references/handshake.md
@@ -63,7 +63,7 @@ These are not soft suggestions — Curdle hard-blocks until they are addressed:
 
 ## Scope audit table
 
-The agent-introduced scope, non-goals, entity-referent, and follow-up audits below populate **one table, presented once, before the handshake**. Each row carries a default disposition. One confirm of the table approves every default. A row needs its own explicit verb only when it fires a leverage trigger (`../../cheese/references/routing-policy.md` § Leverage triggers) or is an unresolved ALIAS / NEW ENTITY binding. A row fires a trigger when the term, bullet, or noun it names would itself fire one of the eight ids if kept: an auth knob fires `auth`, a new export fires `contract`, a new domain fires `new-slice`. Such a row renders `needs your verb` in its Default cell, and the confirm never covers it. The grep and semantic search that populate the rows still run; the per-row approval round does not.
+The agent-introduced scope, non-goals, entity-referent, and follow-up audits below populate **one table, presented once, before the handshake**. Each row carries a default disposition. One confirm of the table approves every default except the rows marked `needs your verb`. A row needs its own explicit verb only when it fires a leverage trigger (`../../cheese/references/routing-policy.md` § Leverage triggers) or is an unresolved ALIAS / NEW ENTITY binding. A row fires a trigger when the term, bullet, or noun it names would itself fire one of the eight ids if kept: an auth knob fires `auth`, a new export fires `contract`, a new domain fires `new-slice`. Such a row renders `needs your verb` in its Default cell, and the confirm never covers it. The grep and semantic search that populate the rows still run; the per-row approval round does not.
 
 ```
 Scope audit:
@@ -75,7 +75,7 @@ Scope audit:
 | 4 | follow-up | <unit: member, member> | dialogue | non-goal only | — |
 | 5 | scope | <noun> | citation | needs your verb | contract |
 | 6 | entity | <noun> | search | needs your verb (ALIAS <referent>) | — |
-Confirm the table to accept every default. Rows marked `needs your verb` block until you name a verb for each.
+Confirm the table to accept the defaults. Rows marked `needs your verb` block until you name a verb for each.
 ```
 
 Curdle runs the table as the terminal backstop. It remains the single chokepoint that downstream skills trust (RC3).
@@ -105,7 +105,7 @@ Curdle is the single chokepoint for this gate. Downstream skills (`/cook`, etc.)
 Procedure:
 
 1. For each `Non-goals` bullet, grep prior user turns for a statement that puts the item out of scope. Search only the user's typed messages. Examples include "don't bother with X", "leave Y alone", and an explicit deferral.
-2. **Any bullet with no such user statement is agent-introduced.** Mark it `[AGENT-INTRODUCED]` inline and add a `non-goal` row to the scope audit table with default `keep`. Non-goals the bounds pass authored as `[AGENT-DECIDED]` are agent-introduced by definition and enter the table the same way. The user keeps, drops, or rewords it by confirming or editing the row.
+2. **Any bullet with no such user statement is agent-introduced.** Mark it `[AGENT-INTRODUCED]` inline and add a `non-goal` row to the scope audit table with default `keep`. Non-goals that the bounds pass authored as `[AGENT-DECIDED]` are agent-introduced by definition and enter the table the same way. The user keeps, drops, or rewords it by confirming or editing the row.
 3. Record approved-but-flagged non-goals in the same `agent_introduced_scope` frontmatter list, so the paper trail survives downstream.
 4. Add every audited non-goal to the follow-up candidate set, including approved `[AGENT-INTRODUCED]` bullets. Candidate status preserves the scope boundary without accepting future work.
 
@@ -116,7 +116,7 @@ This audit is the `Non-goals audit` coherence gate. It is the `non_goals_audit` 
 Before the two-key handshake, dispose of every follow-up candidate in one batch: the `follow-up` rows of the scope audit table. This process extends the existing `Non-goals audit` gate. It does not add or rename a gate. The default destination is **non-goal only**; every other destination is a user edit on the row.
 
 1. Group related candidates into independently deliverable units. Each unit is one `follow-up` row whose cell lists its members; confirming the table accepts the grouping, and the user splits or merges by editing the row.
-2. Search GitHub Issues and Hallouminate roadmap goals when discovery is available. A semantic match becomes the row's default destination, `link #<id>`, in place of non-goal only; the user approves the reuse by confirming the row.
+2. Search GitHub Issues and Hallouminate roadmap goals when discovery is available. A semantic match is surfaced on the row as a recommended `link #<id>`, not adopted as the default: the default destination stays non-goal only, and the user adopts the link by editing the row.
 3. Recommend one destination per unit:
    - **non-goal only** — keep the scope boundary, create no follow-up artifact, and offer no action choice;
    - **GitHub Issue** — use for discrete, independently actionable work;

--- a/skills/mold/references/handshake.md
+++ b/skills/mold/references/handshake.md
@@ -61,7 +61,23 @@ These are not soft suggestions — Curdle hard-blocks until they are addressed:
   `not-applicable`. The taste and curd gates enforce this field without
   changing legacy specs.
 
-These audits cover agent-introduced scope, entity-referent binding, and the non-goals audit below. Run them **inline, per dialogue round**, not only terminally at Curdle. Run each audit when new scope is proposed. Show its results in that round's decision ledger. This catches a lean when it occurs instead of reverse-engineering it at the end. Curdle reruns all three as the terminal backstop. It remains the single chokepoint that downstream skills trust (RC3).
+## Scope audit table
+
+The agent-introduced scope, non-goals, entity-referent, and follow-up audits below populate **one table, presented once, before the handshake**. Each row carries a default disposition. One confirm of the table approves every default. A row needs its own explicit verb only when it fires a leverage trigger (`../../cheese/references/routing-policy.md` § Leverage triggers) or is an unresolved ALIAS / NEW ENTITY binding. The grep and semantic search that populate the rows still run; the per-row approval round does not.
+
+```
+Scope audit:
+| # | Kind | Term / bullet / noun | Source | Default | Leverage |
+| --- | --- | --- | --- | --- | --- |
+| 1 | scope | <noun> | agent / citation | keep | — |
+| 2 | non-goal | <bullet> | agent | keep | — |
+| 3 | entity | <noun> | search | Bound <referent> | — |
+| 4 | follow-up | <unit> | dialogue | non-goal only | — |
+| 5 | scope | <noun> | citation | drop | contract |
+Confirm the table, or name the rows to change.
+```
+
+Curdle runs the table as the terminal backstop. It remains the single chokepoint that downstream skills trust (RC3).
 
 ## Agent-introduced scope
 
@@ -71,16 +87,9 @@ Procedure:
 
 1. Extract distinguishing nouns from the spec's `Approach`, `Decisions`, and `Interface sketches` blocks. Include proper-noun-like terms, library names, algorithm names, Greek parameter letters, config keys, and knobs.
 2. For each noun, grep the prior user turns for a literal mention. Search only the user's typed messages, not agent or sub-agent output.
-3. **Any noun with zero hits is agent-introduced.** Mark it `[AGENT-INTRODUCED]` inline in the draft and present a short table:
+3. **Any noun with zero hits is agent-introduced.** Mark it `[AGENT-INTRODUCED]` inline in the draft and add a `scope` row to the scope audit table. Default `keep` when the noun restates the user's ask or binds to a code referent, `follow-up` when it names new work, `drop` otherwise.
 
-   ```
-   Agent-introduced scope check:
-   | Term | First introduced by | Where in spec |
-   | --- | --- | --- |
-   | <noun> | <agent/sub-agent/citation> | <section> |
-   ```
-
-4. **The user must explicitly approve each row** before the handshake fires. Acceptable approvals: "yes keep <term>", "drop <term>", "make <term> a follow-up". Vague "looks good" is not approval. "Make <term> a follow-up" records a candidate within `Decided`. This choice does not create an issue or other artifact.
+4. **One confirm of the table approves the defaults.** A row that fires a leverage trigger needs its own verb: "keep <term>", "drop <term>", or "make <term> a follow-up". "Make <term> a follow-up" records a candidate within `Decided`. This choice does not create an issue or other artifact.
 5. **When the user explicitly drops a direction**, write a rejection record to `.cheese/.out-of-scope/<slug>-NNN.md`. A direction can be an approach, design knob, or named feature that the user declines. Use the format in `curdle.md` § Rejected-directions store. Do not make a rejected direction a follow-up candidate. Add explicit deferrals to the follow-up candidate set instead.
 6. Do not silently promote a flagged term from a research citation into a design knob. This applies to briesearch sub-agent citations, fetched docs, and MCP results. The citation is evidence, not a mandate. See `skills/briesearch/references/synthesis.md` § Alternatives are open questions.
 
@@ -95,7 +104,7 @@ Curdle is the single chokepoint for this gate. Downstream skills (`/cook`, etc.)
 Procedure:
 
 1. For each `Non-goals` bullet, grep prior user turns for a statement that puts the item out of scope. Search only the user's typed messages. Examples include "don't bother with X", "leave Y alone", and an explicit deferral.
-2. **Any bullet with no such user statement is agent-introduced.** Mark it `[AGENT-INTRODUCED]` inline. Present it for a decision. The user must explicitly keep, drop, or reword it. A vague "looks good" is not approval.
+2. **Any bullet with no such user statement is agent-introduced.** Mark it `[AGENT-INTRODUCED]` inline and add a `non-goal` row to the scope audit table with default `keep`. The user keeps, drops, or rewords it by confirming or editing the row.
 3. Record approved-but-flagged non-goals in the same `agent_introduced_scope` frontmatter list, so the paper trail survives downstream.
 4. Add every audited non-goal to the follow-up candidate set, including approved `[AGENT-INTRODUCED]` bullets. Candidate status preserves the scope boundary without accepting future work.
 
@@ -103,7 +112,7 @@ This audit is the `Non-goals audit` coherence gate. It is the `non_goals_audit` 
 
 ## Follow-up disposition (inside the non-goals audit)
 
-Before the two-key handshake, dispose of every follow-up candidate in one batch. This process extends the existing `Non-goals audit` gate. It does not add or rename a gate.
+Before the two-key handshake, dispose of every follow-up candidate in one batch: the `follow-up` rows of the scope audit table. This process extends the existing `Non-goals audit` gate. It does not add or rename a gate. The default destination is **non-goal only**; every other destination is a user edit on the row.
 
 1. Group related candidates into independently deliverable units. The user approves each grouping or splitting choice.
 2. Search GitHub Issues and Hallouminate roadmap goals when discovery is available. Present each semantic match for possible reuse. The user approves each reuse.
@@ -115,7 +124,7 @@ Before the two-key handshake, dispose of every follow-up candidate in one batch.
 4. The user approves the destination. For other destinations, ask the user to choose the action: **create/link now** or **leave prepared**.
 5. Record accepted units for Curdle. Keep rejected design directions in the rejection store. Do not add them to this batch.
 
-The user approves grouping, splitting, semantic-match reuse, destination, and action choices. Mold settles none silently. Omit this batch when no candidates exist. Preserve the current handshake and Curdle flow.
+The user approves grouping, splitting, semantic-match reuse, destination, and action choices by confirming the table's defaults or editing the rows. Mold settles none silently; every default is visible in the table. Omit this batch when no candidates exist. Preserve the current handshake and Curdle flow.
 
 Record each candidate within `Decided` as `[FOLLOW-UP?]`. Include its summary, source, and rationale. A follow-up candidate is dialogue state only. It does not create an artifact or future commitment.
 
@@ -136,7 +145,7 @@ Procedure:
 
 1. Extract identity/ownership-role nouns from the spec's `Approach`, `Decisions`, and `Interface sketches` blocks.
 2. Search each noun and classify it `Bound` / `ALIAS` / `NEW ENTITY` per the table above.
-3. Present the binding table inline in the draft — one row per identity-role noun:
+3. Add one `entity` row per identity-role noun to the scope audit table. A `Bound` row needs no approval; an `ALIAS` or `NEW ENTITY` row blocks until resolved. The binding detail reads:
 
    ```
    Entity-referent binding check:
@@ -152,7 +161,7 @@ This gate is the referent-level sibling of Agent-introduced scope. That gate ask
 
 ## Override semantics
 
-`curdle anyway` overrides the agent key for one extraction. It does not disable future gates. Record the override and unchecked items in the spec frontmatter. This record lets the human reviewer see them. `curdle anyway` does **not** waive the Agent-introduced-scope gate. Each flagged term still requires explicit per-term approval. The gate prevents silent inclusion, and downstream skills do not re-check. The same rule applies to the **Entity-referent gate**. Under `curdle anyway`, an unbound or aliased identity noun still blocks extraction. Downstream skills trust the frontmatter bindings and do not re-derive them.
+`curdle anyway` overrides the agent key for one extraction. It does not disable future gates. Record the override and unchecked items in the spec frontmatter. This record lets the human reviewer see them. `curdle anyway` does **not** waive the scope audit table's leverage rows or its unresolved bindings. It accepts every other default. The gate prevents silent inclusion, and downstream skills do not re-check. Under `curdle anyway`, an unbound or aliased identity noun still blocks extraction. Downstream skills trust the frontmatter bindings and do not re-derive them.
 
 ## Why both keys
 

--- a/tests/python/test_mold_scope_audit.py
+++ b/tests/python/test_mold_scope_audit.py
@@ -40,17 +40,43 @@ class TestOneTableOneConfirm:
         assert "A row that fires a leverage trigger needs its own verb" in body
         assert "A `Bound` row needs no approval" in body
 
+    def test_leverage_rows_render_as_blocking_in_the_template(self) -> None:
+        section = _section(_text(HANDSHAKE), "## Scope audit table")
+        assert "| needs your verb | contract |" in section
+        assert "| needs your verb (ALIAS <referent>) | — |" in section
+        assert "Rows marked `needs your verb` block until you name a verb for each." in section
+        assert "Confirm the table, or name the rows to change." not in section
+        assert "would itself fire one of the eight ids if kept" in section
+
+    def test_confirmed_drop_default_still_writes_a_rejection_record(self) -> None:
+        body = _text(HANDSHAKE)
+        assert "whether the user typed the verb or confirmed a `drop` default" in body
+
+    def test_agent_decided_non_goals_enter_the_table(self) -> None:
+        body = _text(HANDSHAKE)
+        assert "authored as `[AGENT-DECIDED]` are agent-introduced by definition" in body
+
     def test_per_row_approval_rounds_are_gone(self) -> None:
         body = _text(HANDSHAKE)
         assert "The user must explicitly approve each row" not in body
         assert "The user must explicitly keep, drop, or reword it." not in body
         assert 'Vague "looks good" is not approval' not in body
         assert "inline, per dialogue round" not in body
+        assert "inline per round" not in body
+        assert "per-term approval" not in body
+        assert "approves each grouping" not in body
+        assert "approves each reuse" not in body
+        assert "receive per-term approval" not in body
+        curdle = _text(REPO_ROOT / "skills" / "mold" / "references" / "curdle.md")
+        assert "each approved per `handshake.md` § Agent-introduced scope" not in curdle
 
     def test_follow_up_default_is_non_goal_only(self) -> None:
         section = _section(_text(HANDSHAKE), "## Follow-up disposition")
         assert "The default destination is **non-goal only**" in section
         assert "by confirming the table's defaults or editing the rows" in section
+        assert "Each unit is one `follow-up` row whose cell lists its members" in section
+        assert "A semantic match becomes the row's default destination, `link #<id>`" in section
+        assert "approves the destination by confirming the row's default or editing it" in section
 
     def test_curdle_anyway_accepts_the_defaults(self) -> None:
         body = _text(HANDSHAKE)

--- a/tests/python/test_mold_scope_audit.py
+++ b/tests/python/test_mold_scope_audit.py
@@ -1,0 +1,64 @@
+"""The four handshake audits ask once, through one table with defaults.
+
+Agent-introduced scope, the non-goals audit, entity-referent binding, and
+follow-up disposition each demanded per-row approval, so question volume
+scaled with noun count rather than with stakes. The grep and search that
+populate the rows still run; only leverage rows and unresolved bindings
+keep their own approval turn.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MOLD = REPO_ROOT / "skills" / "mold" / "SKILL.md"
+HANDSHAKE = REPO_ROOT / "skills" / "mold" / "references" / "handshake.md"
+
+
+def _text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _section(body: str, heading: str) -> str:
+    start = body.index(heading)
+    end = body.find("\n## ", start + len(heading))
+    return body[start : end if end != -1 else len(body)]
+
+
+class TestOneTableOneConfirm:
+    def test_table_is_presented_once_before_the_handshake(self) -> None:
+        section = _section(_text(HANDSHAKE), "## Scope audit table")
+        assert "one table, presented once, before the handshake" in section
+        assert "One confirm of the table approves every default." in section
+        for kind in ("| scope |", "| non-goal |", "| entity |", "| follow-up |"):
+            assert kind in section, kind
+
+    def test_only_leverage_rows_and_unresolved_bindings_need_a_verb(self) -> None:
+        body = _text(HANDSHAKE)
+        assert "A row needs its own explicit verb only when it fires a leverage trigger" in body
+        assert "A row that fires a leverage trigger needs its own verb" in body
+        assert "A `Bound` row needs no approval" in body
+
+    def test_per_row_approval_rounds_are_gone(self) -> None:
+        body = _text(HANDSHAKE)
+        assert "The user must explicitly approve each row" not in body
+        assert "The user must explicitly keep, drop, or reword it." not in body
+        assert 'Vague "looks good" is not approval' not in body
+        assert "inline, per dialogue round" not in body
+
+    def test_follow_up_default_is_non_goal_only(self) -> None:
+        section = _section(_text(HANDSHAKE), "## Follow-up disposition")
+        assert "The default destination is **non-goal only**" in section
+        assert "by confirming the table's defaults or editing the rows" in section
+
+    def test_curdle_anyway_accepts_the_defaults(self) -> None:
+        body = _text(HANDSHAKE)
+        assert "It accepts every other default." in body
+        assert "explicit per-term approval" not in body
+
+    def test_skill_approval_gate_names_the_table(self) -> None:
+        approval = _section(_text(MOLD), "## Approval gate")
+        assert "present the **scope audit table** once" in approval
+        assert "One confirm approves the defaults" in approval
+        assert "Require explicit approval for each term" not in approval

--- a/tests/python/test_mold_scope_audit.py
+++ b/tests/python/test_mold_scope_audit.py
@@ -30,7 +30,10 @@ class TestOneTableOneConfirm:
     def test_table_is_presented_once_before_the_handshake(self) -> None:
         section = _section(_text(HANDSHAKE), "## Scope audit table")
         assert "one table, presented once, before the handshake" in section
-        assert "One confirm of the table approves every default." in section
+        assert (
+            "One confirm of the table approves every default except the rows marked `needs your verb`."
+            in section
+        )
         for kind in ("| scope |", "| non-goal |", "| entity |", "| follow-up |"):
             assert kind in section, kind
 
@@ -75,7 +78,8 @@ class TestOneTableOneConfirm:
         assert "The default destination is **non-goal only**" in section
         assert "by confirming the table's defaults or editing the rows" in section
         assert "Each unit is one `follow-up` row whose cell lists its members" in section
-        assert "A semantic match becomes the row's default destination, `link #<id>`" in section
+        assert "A semantic match is surfaced on the row as a recommended `link #<id>`" in section
+        assert "the default destination stays non-goal only" in section
         assert "approves the destination by confirming the row's default or editing it" in section
 
     def test_curdle_anyway_accepts_the_defaults(self) -> None:

--- a/tests/python/test_transport_audit.py
+++ b/tests/python/test_transport_audit.py
@@ -184,7 +184,7 @@ EXEMPT_SITES: list[tuple[str, str, str]] = [
     ),
     (
         "skills/mold/references/handshake.md",
-        "ask the user to choose the action: **create/link now** or "
+        "An edited destination also names the action: **create/link now** or "
         + "**leave prepared**",
         "mechanical fast-path: create/link-now vs leave-prepared is the "
         + "operational disposition of an already-approved follow-up unit, "


### PR DESCRIPTION
Stacked on #634.

## Why

The handshake ran four per-item audits: per-term approval for agent-introduced nouns, per-bullet keep/drop for non-goals, a hard block per identity noun, and four separate approvals per follow-up unit (grouping, reuse, destination, action). Each was added after a real drift incident, but together they turned a small spec into a dozen detail questions that never touched architecture.

## What

- `handshake.md`: new **Scope audit table** section. The four audits populate one table with a default per row, presented once before the handshake. One confirm approves the defaults. A row needs its own verb only when it fires a leverage trigger or is an unresolved ALIAS / NEW ENTITY binding.
- Agent-introduced scope: rows default to keep / follow-up / drop by a stated rule; the per-row approval step and the "vague looks good" clause are gone.
- Non-goals audit: rows default to keep.
- Follow-up disposition: default destination is non-goal only; other destinations are row edits. The ordered phrases the routing tests pin are preserved.
- `curdle anyway` accepts every default except leverage rows and unresolved bindings.
- `mold/SKILL.md` approval-gate paragraph names the table.
- Tests: `test_mold_scope_audit.py`.

Deviation from the change list: gate ids (`non-goals-audit`, identity nouns) are unchanged rather than merged into `scope_audit`. The gate-graph tests pin them and the nodes still describe real gates; only the approval mechanics changed.

PR 4 of 5. Next: crust stop-rule in cook and shape-check as a precondition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review fixes (2026-09-07)

- Three surviving per-row sentences removed: the mandatory-gates entry, "inline per round" in the non-goals audit, and "approves each" in follow-up steps 1, 2, and 4. Grouping, reuse, and destination now live in the row cells.
- Template rows that fire a trigger or carry an unresolved binding render `needs your verb`; the confirm line says it never covers them. A row fires a trigger when the noun it names would fire one if kept.
- A confirmed `drop` default writes the same rejection record as a typed drop. Bounds-pass `[AGENT-DECIDED]` non-goals enter the table as rows.
- Tests assert on the surviving phrasings; the transport-audit exemption follows the reworded sentence.
