### PR TITLE
fix: drop tilth from the macOS smoke test and surface unreadable files in the pyz gate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -122,12 +122,18 @@ jobs:
       - name: Run fan-out pr_plan_to_branches tests
         run: bats tests/fanout/bash/test_pr_plan_to_branches.bats
 
-      # Real (un-stubbed) smoke test: actually resolve every brew formula,
-      # exercise the npm tilth install path, and run the gh-skill
-      # install on a fresh macos-latest runner. Catches "phantom formula"
-      # / "tap doesn't exist" / "this skill doesn't publish" bugs that the
-      # bats suite (which stubs everything) cannot. --skip-mcp avoids
-      # needing claude/tavily creds.
+      # Real (un-stubbed) smoke test: actually resolve every brew formula
+      # and run the gh-skill install on a fresh macos-latest runner.
+      # Catches "phantom formula" / "tap doesn't exist" / "this skill
+      # doesn't publish" bugs that the bats suite (which stubs everything)
+      # cannot. --skip-mcp avoids needing claude/tavily creds.
+      #
+      # tilth is left out of --tools: its npm package downloads a binary
+      # from the tilth repo's rolling `nightly` release, which that repo
+      # deletes and recreates before its per-target builds finish. Until
+      # the macOS arm64 build lands (hours, when runners are queued) every
+      # Apple Silicon install 404s — see #639. That gap is upstream, not
+      # something this script can fix; the bats suite pins the npm command.
       - name: Real install smoke test (--skip-mcp)
         env:
           GH_TOKEN: ${{ github.token }}
@@ -136,7 +142,7 @@ jobs:
           # the latest released tag (which can lag behind main when new
           # skills are added).
           EC_SKILL_REF: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: bash scripts/install.sh --skip-mcp
+        run: bash scripts/install.sh --skip-mcp --tools gh,ripgrep,fd,jq,ast-grep,git-delta,just,mergiraf
 
   typecheck:
     name: type-check python

--- a/scripts/check_bundles.py
+++ b/scripts/check_bundles.py
@@ -749,13 +749,18 @@ def check_pyz_references() -> list[str]:
         skill = _owning_skill(path)
         if skill in _RETIRED_REDIRECT_SKILLS:
             continue
+        relative = path.relative_to(REPO_ROOT)
         try:
             text = path.read_text(encoding="utf-8")
-        except (UnicodeDecodeError, OSError):
+        except UnicodeDecodeError:
+            continue  # binary content carries no archive references
+        except OSError as exc:
+            # A present-but-unreadable file was never inspected; say so
+            # rather than letting the gate go green on it.
+            violations.append(f"{relative}: unreadable ({exc.strerror or exc})")
             continue
         for match in _PYZ_REFERENCE.finditer(text):
             archive_name = match.group(0).removesuffix(".pyz")
-            relative = path.relative_to(REPO_ROOT)
             if archive_name == "common":
                 violations.append(
                     f"{relative}: references obsolete shared bundle common.pyz"

--- a/tests/python/test_check_bundles.py
+++ b/tests/python/test_check_bundles.py
@@ -288,6 +288,32 @@ def test_check_pyz_references_flags_a_website_doc_naming_a_foreign_skill_pyz(
     ]
 
 
+def test_check_pyz_references_reports_an_unreadable_referenced_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A scanned file that exists but cannot be read must fail the gate, not vanish."""
+    skill_dir = tmp_path / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").symlink_to(skill_dir / "missing-target.md")
+    monkeypatch.setattr(check_bundles, "REPO_ROOT", tmp_path)
+
+    violations = check_bundles.check_pyz_references()
+
+    assert violations == ["skills/demo/SKILL.md: unreadable (No such file or directory)"]
+
+
+def test_check_pyz_references_skips_binary_content(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Undecodable bytes carry no archive references and are not a violation."""
+    skill_dir = tmp_path / "skills" / "demo"
+    skill_dir.mkdir(parents=True)
+    _ = (skill_dir / "SKILL.md").write_bytes(b"\xff\xfe cook.pyz")
+    monkeypatch.setattr(check_bundles, "REPO_ROOT", tmp_path)
+
+    assert check_bundles.check_pyz_references() == []
+
+
 def _analysis(members: dict[str, bytes]) -> check_bundles._ArchiveAnalysis:  # pyright: ignore[reportPrivateUsage]
     data = BytesIO()
     with zipfile.ZipFile(data, "w") as archive:


### PR DESCRIPTION
## What changed

Two independent fixes, one commit each:

1. **`.github/workflows/validate.yml`** — the macOS real-install smoke test now passes `--tools gh,ripgrep,fd,jq,ast-grep,git-delta,just,mergiraf`, dropping tilth from the un-stubbed install.
2. **`scripts/check_bundles.py`** — `check_pyz_references` no longer swallows `OSError`. A referenced file that exists but cannot be read now records `<path>: unreadable (<strerror>)` as a gate violation. `UnicodeDecodeError` still skips the file as binary content.

## Why

**#639 — validate red on main.** The failing step log shows the exit-1 came from `npm install -g @paulnsorensen/tilth-nightly@latest`: its `install.js` got HTTP 404 on `tilth-aarch64-apple-darwin.tar.gz.sha256` from the tilth `nightly` release. The tilth nightly workflow deletes and recreates that release *before* its per-target builds finish. On 2026-09-06 the `aarch64-apple-darwin` build job sat in the macOS runner queue from 20:13Z until 05:32Z the next day, so every Apple Silicon install 404'd for nine hours. The failing easy-cheese run (https://github.com/paulnsorensen/easy-cheese/actions/runs/34060187014) landed at 21:10Z, inside that window, on a commit that never touched `install.sh`.

Nothing in this repo can shorten that gap, and a retry inside `install.sh` would not cover hours. The smoke test's stated purpose is catching phantom brew formulae, missing taps, and unpublished skills — all things this repo controls — and it keeps all of that. The bats suite still asserts the exact npm command for tilth.

The durable fix belongs in `paulnsorensen/tilth`: upload assets with `--clobber` onto the existing `nightly` release instead of delete-then-recreate, so consumers never observe a half-populated release.

**#640 — silent skip in the pyz-reference gate.** Bundling `OSError` with `UnicodeDecodeError` meant a present-but-unreadable file (permissions, broken symlink, transient I/O) vanished from the audit and CI went green on a file the gate never inspected.

Closes #639
Closes #640

## How to verify

```bash
just check
python3 -m pytest tests/python/test_check_bundles.py -k pyz_references -q
```

For #639, the `test install.sh (macOS)` job on this PR must stay green; the smoke test still resolves every brew formula and runs `gh skill install` pinned to the head sha.

## Risk / rollout notes

- The smoke test loses real coverage of the tilth npm install path. That coverage was never deterministic from this repo; it depends on the tilth nightly's publish state at the moment the job runs.
- The `--tools` list is hardcoded; a tool added to `EC_KNOWN_TOOLS` later will not be smoke-tested until it is added here too. A removed tool fails loudly because `ec_validate_selection` rejects unknown tokens.
- The gate now fails on an unreadable referenced file. The full-repo test `test_check_pyz_references_finds_no_violations_across_the_repo` passes, so no existing path trips it.

## Non-obvious changes

- `relative` is computed before the `try` in `check_pyz_references` so the new `except OSError` branch and the existing match loop share one value.

## Checklist

- [x] Conventional Commits PR title (`feat:`, `fix:`, `chore:`, `docs:`, ...)
- [x] Tests added or updated (or N/A)
- [x] Documentation updated (or N/A) — workflow comment explains the tilth exclusion
- [x] No secrets or credentials added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
