### PR TITLE
docs(easy-cheese-setup): use the canonical pyz invocation form

### DIFF
--- a/skills/easy-cheese-setup/SKILL.md
+++ b/skills/easy-cheese-setup/SKILL.md
@@ -19,12 +19,12 @@ Register the durable `cheese-durable` Hallouminate corpus. The corpus makes each
 
 Register the current repository as a Hallouminate tenant when the user requests it. This process is idempotent. It does not delete data.
 
-The engine is a self-contained bundle at `scripts/easy-cheese-setup.pyz`. It has three commands. Each command changes data only with `--apply`. Without this option, each command only reports.
+The engine is a self-contained bundle at `skills/easy-cheese-setup/scripts/easy-cheese-setup.pyz`. It has three commands. Each command changes data only with `--apply`. Without this option, each command only reports.
 
 ```
-python3 <skill>/scripts/easy-cheese-setup.pyz global [--apply]   # durable-corpus registration/repair
-python3 <skill>/scripts/easy-cheese-setup.pyz local  [--apply]   # per-repository tenant registration
-python3 <skill>/scripts/easy-cheese-setup.pyz doctor [--apply]   # both legs
+python3 skills/easy-cheese-setup/scripts/easy-cheese-setup.pyz global [--apply]   # durable-corpus registration/repair
+python3 skills/easy-cheese-setup/scripts/easy-cheese-setup.pyz local  [--apply]   # per-repository tenant registration
+python3 skills/easy-cheese-setup/scripts/easy-cheese-setup.pyz doctor [--apply]   # both legs
 ```
 
 At installation, `install.sh` calls `global --apply` when `--mcp` includes `hallouminate`. This skill controls the interactive process.
@@ -47,7 +47,7 @@ Run `doctor` without `--apply` first. It reports the planned actions for both le
 - **Legacy migration requires user interaction.** An unmarked `cheese-global → ~/.cheese` block is stale. Show the report. Ask the user for confirmation. Then use the explicit migration option. The installer never uses this option:
 
   ```bash
-  python3 <skill>/scripts/easy-cheese-setup.pyz global --migrate-legacy --apply
+  python3 skills/easy-cheese-setup/scripts/easy-cheese-setup.pyz global --migrate-legacy --apply
   ```
 
   Leave a `cheese-global` block unchanged if it points anywhere except `~/.cheese`.


### PR DESCRIPTION
## Summary

Follow-up to #646, which put the last skill (press) on the `@bundle_command` surface. Every skill's Python command surface is now uniform, but the *documented* invocation form still varied across skill markdown: bare `<skill>.pyz <command>`, interpreter-less `skills/<skill>/scripts/<skill>.pyz <command>`, a `<skill>/scripts/` placeholder, and quoted paths.

This PR normalizes the `easy-cheese-setup` skill's SKILL.md and references to the one canonical form that the generated `references/commands.md` and the wiki's local-workflow section already document:

```
python3 skills/easy-cheese-setup/scripts/easy-cheese-setup.pyz <command> [args...]
```

Docs only. No Python, bundle, or test changes. Bundle-name mentions that are not invocations are left as they were.

## Verification

- Sweep: every `.pyz` reference under `skills/easy-cheese-setup/` outside the generated `references/commands.md` now matches the canonical form.
- `just lint-md`, `.github/scripts/validate_skills.py` (SKILL.md body budget), and `pytest tests/python` green on the branch.

One PR per skill with deviations (affinage, cook, easy-cheese-setup, mold, press); the other eight skills already used the canonical form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
