### PR TITLE
docs(affinage): use the canonical pyz invocation form

### DIFF
--- a/skills/affinage/SKILL.md
+++ b/skills/affinage/SKILL.md
@@ -77,7 +77,7 @@ Read `references/flow-details.md` for exact commands, exit codes, and grading re
 1. **Resolve PR.** Use `<pr-ref>` or `gh pr view --json number`.
    Normalize a `PR#<n>` reference or a PR URL to its integer.
    Resolve `<owner>/<repo>` from the Git remote.
-2. **Fetch PR status.** Run `affinage.pyz pr-status <pr>`.
+2. **Fetch PR status.** Run `python3 skills/affinage/scripts/affinage.pyz pr-status <pr>`.
    Exit 3 stops with `status: halt: pr-status-logs-expired`.
    Any other nonzero exit stops with `status: halt: pr-status-unavailable`.
    Route a conflicting or dirty merge state to `## Merge-conflict resolution`.
@@ -111,7 +111,7 @@ Read `references/flow-details.md` for exact commands, exit codes, and grading re
     Draft `Attempted fix reverted — <reason>.` for deferred comment findings.
 11. **Post replies.** Show one reply gate for every drafted reply.
     Skip the gate only when `--auto` is active.
-    Post approved replies with `affinage.pyz post-reply`.
+    Post approved replies with `python3 skills/affinage/scripts/affinage.pyz post-reply`.
 12. **Publish.** Run this step only after all approved replies post.
     Publish when `/cure` applies at least one fix.
     Also publish when `/melt` resolved a merge conflict.
@@ -168,9 +168,9 @@ Use these affinage tools:
 
 | Need | Prefer | Fallback |
 | --- | --- | --- |
-| PR status | `skills/affinage/scripts/affinage.pyz pr-status` | `gh pr checks` and `gh pr view` |
+| PR status | `python3 skills/affinage/scripts/affinage.pyz pr-status` | `gh pr checks` and `gh pr view` |
 | GitHub fetch | `gh api` | none; stop the skill |
-| Reply posting | `skills/affinage/scripts/affinage.pyz post-reply` | none; direct `gh api` calls omit attribution |
+| Reply posting | `python3 skills/affinage/scripts/affinage.pyz post-reply` | none; direct `gh api` calls omit attribution |
 | Diff inspection | `delta` | `git diff --unified=3` |
 
 ## Output
@@ -260,7 +260,7 @@ The gate therefore runs once at the publication boundary.
 - Never apply code fixes in affinage.
 - Send code fixes to `/cure` and merge conflicts to `/melt`.
 - Never post a reply without approval, unless `--auto` is active.
-- Post replies only through `skills/affinage/scripts/affinage.pyz post-reply`.
+- Post replies only through `python3 skills/affinage/scripts/affinage.pyz post-reply`.
 - End every reply with `agent on behalf of <handle>`.
 - Resolve `<handle>` from `RESPOND_GH_HANDLE`, `gh api user --jq .login`, or `git config user.name`.
 - Skip a thread when the resolved handle wrote its latest comment.

--- a/skills/affinage/references/flow-details.md
+++ b/skills/affinage/references/flow-details.md
@@ -43,7 +43,7 @@ Call `age_route.route(score=<float>, ...)` with these values:
 This route includes comment count and CI class.
 It can increase fan-out for a small PR with many comments or red CI.
 
-If only the bundle exists, pipe JSON to `affinage.pyz age-route`.
+If only the bundle exists, pipe JSON to `python3 skills/affinage/scripts/affinage.pyz age-route`.
 The command reads JSON from standard input and writes route JSON to standard output.
 Pass the returned `n`, `lenses`, and `effort` to `/age`.
 Then treat each `/age` finding as an additional claim.

--- a/skills/affinage/references/merge-conflict.md
+++ b/skills/affinage/references/merge-conflict.md
@@ -17,7 +17,7 @@ In default and `--auto` modes, run checkout and `/melt` before `/cure`.
 Treat a resolved merge as a publishable change.
 If `/melt` cannot resolve the conflicts, write `status: halt: merge-conflicts-need-human` and stop.
 Run terminal `/plate` after every approved reply posts.
-Then run `affinage.pyz pr-status` again to confirm that the conflicts are gone.
+Then run `python3 skills/affinage/scripts/affinage.pyz pr-status` again to confirm that the conflicts are gone.
 
 In `--safe` mode, require approval before checkout and `/melt`.
 Include `Resolve merge conflicts` in the cure selection options.

--- a/tests/python/test_affinage_contract.py
+++ b/tests/python/test_affinage_contract.py
@@ -41,7 +41,7 @@ def test_melt_leaves_the_resolution_for_plate() -> None:
 def test_remote_status_recheck_follows_publication() -> None:
     conflict = _read(REFERENCES / "merge-conflict.md")
     publish = conflict.index("Run terminal `/plate` after every approved reply posts.")
-    recheck = conflict.index("Then run `affinage.pyz pr-status` again")
+    recheck = conflict.index("Then run `python3 skills/affinage/scripts/affinage.pyz pr-status` again")
     assert publish < recheck, "the remote status recheck must follow terminal /plate"
 
 


### PR DESCRIPTION
## Summary

Follow-up to #646, which put the last skill (press) on the `@bundle_command` surface. Every skill's Python command surface is now uniform, but the *documented* invocation form still varied across skill markdown: bare `<skill>.pyz <command>`, interpreter-less `skills/<skill>/scripts/<skill>.pyz <command>`, a `<skill>/scripts/` placeholder, and quoted paths.

This PR normalizes the `affinage` skill's SKILL.md and references to the one canonical form that the generated `references/commands.md` and the wiki's local-workflow section already document:

```
python3 skills/affinage/scripts/affinage.pyz <command> [args...]
```

Docs plus one test assertion: `tests/python/test_affinage_contract.py` pinned the bare `affinage.pyz pr-status` prose in merge-conflict.md, so its expected substring now pins the canonical form. No Python source or bundle changes. Bundle-name mentions that are not invocations are left as they were.

## Verification

- Sweep: every `.pyz` reference under `skills/affinage/` outside the generated `references/commands.md` now matches the canonical form.
- `just lint-md`, `.github/scripts/validate_skills.py` (SKILL.md body budget), and `pytest tests/python` green on the branch.

One PR per skill with deviations (affinage, cook, easy-cheese-setup, mold, press); the other eight skills already used the canonical form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
