### PR TITLE
docs(press): use the canonical pyz invocation form

### DIFF
--- a/skills/press/SKILL.md
+++ b/skills/press/SKILL.md
@@ -116,7 +116,7 @@ See [`../cook/references/quality-gates.md`](../cook/references/quality-gates.md)
 1. **Read** — Load the approved spec, Cook handoff, and baseline block. Use canonical terms from `.cheese/glossary/<slug>.md` when that file exists.
 2. **Attack** — Add or run only adversarial tests. Do not add first-coverage tests. Do not change production paths.
 3. **Classify** — Select `green`, `in_contract_red`, `invalid_evidence`, or `production_changed` from the adversarial run.
-4. **Continue or stop** — Run `press.pyz press-route` with `outcome` and `repair_cycles`. Only `Continue`, `Dispatch`, and `Stop` action shapes are public.
+4. **Continue or stop** — Run `python3 skills/press/scripts/press.pyz press-route` with `outcome` and `repair_cycles`. Only `Continue`, `Dispatch`, and `Stop` action shapes are public.
 5. **Report** — Write `.cheese/press/<slug>.md` at a terminal result. Include the attempts, evidence, and review follow-ups.
 6. **Hand off** — Send only a GREEN `Dispatch("/age")` to the global Age route.
 

--- a/skills/press/references/gap-analysis.md
+++ b/skills/press/references/gap-analysis.md
@@ -59,7 +59,7 @@ Each attempt uses separate candidate and route paths. Never reuse or overwrite a
 Run this command from the project root. Use the route request for the current attempt:
 
 ```sh
-python3 "skills/press/scripts/press.pyz" press-route \
+python3 skills/press/scripts/press.pyz press-route \
   .cheese/press/outer-tdd-gates.attempt-1.route.json
 ```
 

--- a/skills/press/references/telemetry.md
+++ b/skills/press/references/telemetry.md
@@ -9,7 +9,7 @@ The record gives evidence for a route that `press-route` already selected.
 Run the command once for each attempt. Run it from the project root after `press-route`:
 
 ```sh
-python3 "skills/press/scripts/press.pyz" press-telemetry \
+python3 skills/press/scripts/press.pyz press-telemetry \
   .cheese/press/outer-tdd-gates.attempt-1.telemetry-request.json
 ```
 


### PR DESCRIPTION
## Summary

Follow-up to #646, which put the last skill (press) on the `@bundle_command` surface. Every skill's Python command surface is now uniform, but the *documented* invocation form still varied across skill markdown: bare `<skill>.pyz <command>`, interpreter-less `skills/<skill>/scripts/<skill>.pyz <command>`, a `<skill>/scripts/` placeholder, and quoted paths.

This PR normalizes the `press` skill's SKILL.md and references to the one canonical form that the generated `references/commands.md` and the wiki's local-workflow section already document:

```
python3 skills/press/scripts/press.pyz <command> [args...]
```

Docs only. No Python, bundle, or test changes. Bundle-name mentions that are not invocations are left as they were.

## Verification

- Sweep: every `.pyz` reference under `skills/press/` outside the generated `references/commands.md` now matches the canonical form.
- `just lint-md`, `.github/scripts/validate_skills.py` (SKILL.md body budget), and `pytest tests/python` green on the branch.

One PR per skill with deviations (affinage, cook, easy-cheese-setup, mold, press); the other eight skills already used the canonical form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
