### PR TITLE
docs(cook): redispatch an out-of-context coder from its resume brief

### DIFF
--- a/skills/cook/references/fan-pathway.md
+++ b/skills/cook/references/fan-pathway.md
@@ -300,6 +300,21 @@ Wiring rows exist in the manifest, not the curd block.
   The host continues to harvest the other results.
   The host reports the curd.
 
+- **Coder out of context.**
+  A coder that returns `status: blocked: out of context` names a resume brief at `artifact:` (`.cheese/notes/<slug>.md`).
+  The brief carries the sections *Already read*, *Read next*, *Gates*, and *Locked decisions*.
+  Do not re-dispatch with "read the note".
+  A resumed coder given only a path re-reads the tree and spends about a third of its window before its first edit.
+  Read the brief yourself and build the next dispatch from it.
+  Paste *Read next* as `Sites:`.
+  Paste *Already read* as `Known-false leads` marked `do not re-read`.
+  Paste *Gates* as `Done means` with the recorded result and SHA.
+  Carry *Locked decisions* forward.
+  Tell the resumed coder to start at the first site and to skip the gates until it has changed something.
+  A second out-of-context return on the same brief means the dispatch is oversized.
+  Split it at the brief's remaining sites instead of a further retry.
+  This rule applies to the single-coder pathway and to curd workers.
+
 - **Aggregate-gate conflict.**
   After you harvest all wave results, run the project gates over the merged tree.
   Distinguish a real cross-curd conflict from harmless generated drift.


### PR DESCRIPTION
## Why

Session analytics over 38 resumed coder runs: every one read the checkpoint note, then re-read source anyway — median 37k tokens (28% of the window) before the first edit. 18 of 38 ran out of context a second time. The redispatch says "read the note"; the note says what was done, not what is already known or where to edit next.

## What

`skills/cook/references/fan-pathway.md` — new **Coder out of context** bullet under *Recovery and aggregate gates*:

- Read the resume brief in the orchestrator, not in the coder.
- Paste *Read next* as `Sites:`, *Already read* as `Known-false leads` (`do not re-read`), *Gates* as `Done means` with result and SHA; carry *Locked decisions*.
- A second out-of-context return on the same brief means the dispatch is oversized: split at the remaining sites.
- Applies to the single-coder pathway and curd workers.

Companion PR in `dotfiles` defines the brief's sections in `coder.md`.

## Verification

`just lint-md`: 0 issues in 128 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
