### PR TITLE
chore(install): drop git-delta, ripgrep, fd, and jq from the installer

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -142,7 +142,7 @@ jobs:
           # the latest released tag (which can lag behind main when new
           # skills are added).
           EC_SKILL_REF: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: bash scripts/install.sh --skip-mcp --tools gh,ripgrep,fd,jq,ast-grep,git-delta,just,mergiraf
+        run: bash scripts/install.sh --skip-mcp --tools gh,ripgrep,fd,jq,ast-grep,just,mergiraf
 
   typecheck:
     name: type-check python

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -142,7 +142,7 @@ jobs:
           # the latest released tag (which can lag behind main when new
           # skills are added).
           EC_SKILL_REF: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: bash scripts/install.sh --skip-mcp --tools gh,ripgrep,fd,jq,ast-grep,just,mergiraf
+        run: bash scripts/install.sh --skip-mcp --tools gh,ast-grep,just,mergiraf
 
   typecheck:
     name: type-check python

--- a/README.md
+++ b/README.md
@@ -171,7 +171,6 @@ Workflow skills name preferred tools when they help, with bounded fallbacks for 
 | milknado (MCP) | Mikado task-graph backend for `/cook`'s fan-path curd prerequisite tracking | In-report curd decomposition in manifest YAML; no external task-graph backend needed |
 | `ripgrep` | Fast text search | `grep`, `find`, editor search |
 | `gh` | GitHub issues, PRs, checks, examples | local git commands or user-provided links/logs |
-| `delta` | Readable diffs | plain `git diff` |
 | `mergiraf` | Structured merge conflict resolution | manual conflict resolution plus tests |
 | `jq` | JSON inspection for reports or tool output | manual inspection |
 | `fd` | Fast file discovery | `find` |
@@ -502,25 +501,6 @@ Fast text search used as a fallback when tilth is unavailable.
 brew install ripgrep           # macOS/Linux
 winget install BurntSushi.ripgrep.MSVC  # Windows
 cargo install ripgrep          # Rust/Cargo
-```
-
-### delta
-
-Human-readable diffs used by `/age` and `/cure`.
-
-```sh
-brew install git-delta         # macOS/Linux
-cargo install git-delta        # Rust/Cargo
-winget install dandavison.delta # Windows
-```
-
-Add to `~/.gitconfig` to enable globally:
-
-```ini
-[core]
-    pager = delta
-[interactive]
-    diffFilter = delta --color-only
 ```
 
 ### mergiraf

--- a/README.md
+++ b/README.md
@@ -169,11 +169,8 @@ Workflow skills name preferred tools when they help, with bounded fallbacks for 
 | LSP / [Serena](https://github.com/oraios/serena) (MCP) | Type-aware xrefs (`find_referencing_symbols`, `find_implementations`), symbol-bounded edits (`rename_symbol`, `replace_symbol_body`, `safe_delete_symbol`), and LSP diagnostics | `sg`, `tilth_search`, targeted reads via tilth |
 | hallouminate (MCP) | Per-repo wiki for cross-session design rationale, ADR grounding, and `/mold` evidence | Skip wiki grounding; proceed with diff + code evidence only; cap at `speculating` when design rationale is central |
 | milknado (MCP) | Mikado task-graph backend for `/cook`'s fan-path curd prerequisite tracking | In-report curd decomposition in manifest YAML; no external task-graph backend needed |
-| `ripgrep` | Fast text search | `grep`, `find`, editor search |
 | `gh` | GitHub issues, PRs, checks, examples | local git commands or user-provided links/logs |
 | `mergiraf` | Structured merge conflict resolution | manual conflict resolution plus tests |
-| `jq` | JSON inspection for reports or tool output | manual inspection |
-| `fd` | Fast file discovery | `find` |
 | `just` | Project task discovery | package scripts or documented commands |
 
 When a preferred tool is unavailable, workflow skills say so once, use the strongest bounded fallback, and lower confidence only if evidence quality suffers.
@@ -442,9 +439,9 @@ bash /tmp/easy-cheese-install.sh --dry-run
 Common flags:
 
 ```sh
-# Install only ripgrep + jq, skip MCP registration
+# Install only just + mergiraf, skip MCP registration
 curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh \
-  | bash -s -- --tools ripgrep,jq --skip-mcp
+  | bash -s -- --tools just,mergiraf --skip-mcp
 
 # Register MCP servers only (assumes CLI tools and skills are already installed)
 curl -fsSL https://raw.githubusercontent.com/paulnsorensen/easy-cheese/main/scripts/install.sh \
@@ -493,16 +490,6 @@ cargo install ast-grep         # Rust/Cargo
 scoop install ast-grep         # Windows (Scoop)
 ```
 
-### ripgrep (`rg`)
-
-Fast text search used as a fallback when tilth is unavailable.
-
-```sh
-brew install ripgrep           # macOS/Linux
-winget install BurntSushi.ripgrep.MSVC  # Windows
-cargo install ripgrep          # Rust/Cargo
-```
-
 ### mergiraf
 
 Structured merge-conflict resolution used by `/melt`.
@@ -510,27 +497,6 @@ Structured merge-conflict resolution used by `/melt`.
 ```sh
 cargo install mergiraf         # Rust/Cargo
 brew install mergiraf          # macOS/Linux (if tap is available)
-```
-
-### `jq`
-
-JSON inspection used by various skills for structured output.
-
-```sh
-brew install jq                # macOS/Linux
-winget install jqlang.jq       # Windows
-apt-get install jq             # Debian/Ubuntu
-```
-
-### `fd`
-
-Fast file discovery used as a fallback when tilth is unavailable.
-
-```sh
-brew install fd                # macOS/Linux
-cargo install fd-find          # Rust/Cargo
-winget install sharkdp.fd      # Windows
-apt-get install fd-find        # Debian/Ubuntu
 ```
 
 ### `just`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,7 +18,7 @@
 # All known CLI tools. tilth is included but installed via npm from the
 # @paulnsorensen/tilth-nightly package (not brew — tilth has no Homebrew
 # formula upstream).
-EC_KNOWN_TOOLS="gh ripgrep fd jq ast-grep just mergiraf tilth"
+EC_KNOWN_TOOLS="gh ast-grep just mergiraf tilth"
 
 # Repository the installer pulls skills from. Centralized so discovery and
 # install both reference the same source.
@@ -38,7 +38,6 @@ EC_DEFAULT_MCP="tilth context7 hallouminate"
 # Map a brew formula name to the binary it installs (when they differ).
 ec_tool_binary() {
     case "$1" in
-        ripgrep)   echo "rg" ;;
         ast-grep)  echo "sg" ;;
         *)         echo "$1" ;;
     esac
@@ -65,8 +64,7 @@ Usage:
 
 Options:
   --tools <list>       Comma-separated CLI tools to install. Default: all.
-                       Choices: gh, ripgrep, fd, jq, ast-grep, just,
-                                mergiraf, tilth
+                       Choices: gh, ast-grep, just, mergiraf, tilth
   --mcp <list>         Comma-separated MCP servers to register. Default:
                        tilth,context7,hallouminate. Choices: tilth, context7,
                        tavily, hallouminate, milknado, none

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,7 +18,7 @@
 # All known CLI tools. tilth is included but installed via npm from the
 # @paulnsorensen/tilth-nightly package (not brew — tilth has no Homebrew
 # formula upstream).
-EC_KNOWN_TOOLS="gh ripgrep fd jq ast-grep git-delta just mergiraf tilth"
+EC_KNOWN_TOOLS="gh ripgrep fd jq ast-grep just mergiraf tilth"
 
 # Repository the installer pulls skills from. Centralized so discovery and
 # install both reference the same source.
@@ -40,7 +40,6 @@ ec_tool_binary() {
     case "$1" in
         ripgrep)   echo "rg" ;;
         ast-grep)  echo "sg" ;;
-        git-delta) echo "delta" ;;
         *)         echo "$1" ;;
     esac
 }
@@ -66,8 +65,8 @@ Usage:
 
 Options:
   --tools <list>       Comma-separated CLI tools to install. Default: all.
-                       Choices: gh, ripgrep, fd, jq, ast-grep, git-delta,
-                                just, mergiraf, tilth
+                       Choices: gh, ripgrep, fd, jq, ast-grep, just,
+                                mergiraf, tilth
   --mcp <list>         Comma-separated MCP servers to register. Default:
                        tilth,context7,hallouminate. Choices: tilth, context7,
                        tavily, hallouminate, milknado, none

--- a/skills/affinage/SKILL.md
+++ b/skills/affinage/SKILL.md
@@ -171,7 +171,6 @@ Use these affinage tools:
 | PR status | `python3 skills/affinage/scripts/affinage.pyz pr-status` | `gh pr checks` and `gh pr view` |
 | GitHub fetch | `gh api` | none; stop the skill |
 | Reply posting | `python3 skills/affinage/scripts/affinage.pyz post-reply` | none; direct `gh api` calls omit attribution |
-| Diff inspection | `delta` | `git diff --unified=3` |
 
 ## Output
 

--- a/skills/pasteurize/SKILL.md
+++ b/skills/pasteurize/SKILL.md
@@ -304,7 +304,6 @@ It follows the `age-route` bundle convention.
 | Code search and impact | semantic caller and dependency search | bounded text search with a precision warning |
 | Code read | fresh bounded read from the write backend | bounded read with stable line anchors |
 | Instrumentation edit | stale-safe anchored edit | LSP or snapshot edit with stale-write detection |
-| Diff view | `delta` | plain `git diff` |
 | GitHub context | `gh` | local Git history or user links |
 | External check | `/briesearch` | a clearly marked assumption |
 

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -68,7 +68,6 @@ count_skills() {
 @test "ec_tool_binary maps formula names to binaries" {
     [[ "$(ec_tool_binary ripgrep)" == "rg" ]]
     [[ "$(ec_tool_binary ast-grep)" == "sg" ]]
-    [[ "$(ec_tool_binary git-delta)" == "delta" ]]
     [[ "$(ec_tool_binary jq)" == "jq" ]]
     [[ "$(ec_tool_binary fd)" == "fd" ]]
     [[ "$(ec_tool_binary just)" == "just" ]]

--- a/tests/bash/test_install.bats
+++ b/tests/bash/test_install.bats
@@ -66,10 +66,7 @@ count_skills() {
 # -- ec_tool_binary -----------------------------------------------------------
 
 @test "ec_tool_binary maps formula names to binaries" {
-    [[ "$(ec_tool_binary ripgrep)" == "rg" ]]
     [[ "$(ec_tool_binary ast-grep)" == "sg" ]]
-    [[ "$(ec_tool_binary jq)" == "jq" ]]
-    [[ "$(ec_tool_binary fd)" == "fd" ]]
     [[ "$(ec_tool_binary just)" == "just" ]]
     [[ "$(ec_tool_binary mergiraf)" == "mergiraf" ]]
     [[ "$(ec_tool_binary tilth)" == "tilth" ]]
@@ -79,12 +76,12 @@ count_skills() {
 # -- ec_validate_selection ----------------------------------------------------
 
 @test "ec_validate_selection accepts subset of allowed list" {
-    run ec_validate_selection "ripgrep,jq" "$EC_KNOWN_TOOLS"
+    run ec_validate_selection "just,mergiraf" "$EC_KNOWN_TOOLS"
     [ "$status" -eq 0 ]
 }
 
 @test "ec_validate_selection rejects unknown token" {
-    run ec_validate_selection "ripgrep,bogus" "$EC_KNOWN_TOOLS"
+    run ec_validate_selection "just,bogus" "$EC_KNOWN_TOOLS"
     [ "$status" -ne 0 ]
     [[ "$output" == *"Unknown selection: bogus"* ]]
 }
@@ -108,13 +105,13 @@ count_skills() {
 }
 
 @test "ec_parse_args --tools with value parses comma list" {
-    ec_parse_args --tools ripgrep,jq
-    [[ "$EC_TOOLS" == "ripgrep,jq" ]]
+    ec_parse_args --tools just,mergiraf
+    [[ "$EC_TOOLS" == "just,mergiraf" ]]
 }
 
 @test "ec_parse_args --tools=value parses inline value" {
-    ec_parse_args --tools=fd
-    [[ "$EC_TOOLS" == "fd" ]]
+    ec_parse_args --tools=just
+    [[ "$EC_TOOLS" == "just" ]]
 }
 
 @test "ec_parse_args --skip-mcp sets MCP to none" {
@@ -175,7 +172,7 @@ count_skills() {
 }
 
 @test "ec_parse_args rejects unknown tool selection" {
-    run ec_parse_args --tools ripgrep,foobar
+    run ec_parse_args --tools just,foobar
     [ "$status" -eq 2 ]
     [[ "$output" == *"foobar"* ]]
 }
@@ -231,10 +228,10 @@ STUB
 # -- ec_brew_install_if_missing ----------------------------------------------
 
 @test "ec_brew_install_if_missing skips when binary already on PATH" {
-    make_stub jq
+    make_stub just
     make_stub brew
     export EC_BREW="$STUB_BIN/brew"
-    run ec_brew_install_if_missing jq
+    run ec_brew_install_if_missing just
     [ "$status" -eq 0 ]
     [[ "$output" == *"already installed"* ]]
     # brew should NOT have been invoked
@@ -242,34 +239,34 @@ STUB
 }
 
 @test "ec_brew_install_if_missing dry-run prints would-run line" {
-    EC_DRY_RUN=1 run ec_brew_install_if_missing ripgrep
+    EC_DRY_RUN=1 run ec_brew_install_if_missing just
     [ "$status" -eq 0 ]
-    [[ "$output" == *"would run 'brew install ripgrep'"* ]]
+    [[ "$output" == *"would run 'brew install just'"* ]]
 }
 
 @test "ec_brew_install_if_missing invokes brew when missing" {
     make_stub brew
     export EC_BREW="$STUB_BIN/brew"
-    run ec_brew_install_if_missing ripgrep
+    run ec_brew_install_if_missing just
     [ "$status" -eq 0 ]
-    grep -q "^brew install ripgrep$" "$STUB_LOG"
+    grep -q "^brew install just$" "$STUB_LOG"
 }
 
 @test "ec_brew_install_if_missing surfaces brew failure" {
     make_stub brew 1
     export EC_BREW="$STUB_BIN/brew"
-    run ec_brew_install_if_missing ripgrep
+    run ec_brew_install_if_missing just
     [ "$status" -ne 0 ]
 }
 
 # -- ec_install_tools ---------------------------------------------------------
 
 @test "ec_install_tools (dry-run) iterates each formula in the list" {
-    PATH="$STUB_BIN" EC_DRY_RUN=1 run ec_install_tools "ripgrep,jq,fd"
+    PATH="$STUB_BIN" EC_DRY_RUN=1 run ec_install_tools "just,mergiraf,ast-grep"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"would run 'brew install ripgrep'"* ]]
-    [[ "$output" == *"would run 'brew install jq'"* ]]
-    [[ "$output" == *"would run 'brew install fd'"* ]]
+    [[ "$output" == *"would run 'brew install just'"* ]]
+    [[ "$output" == *"would run 'brew install mergiraf'"* ]]
+    [[ "$output" == *"would run 'brew install ast-grep'"* ]]
 }
 
 @test "ec_install_tools routes tilth through ec_install_tilth, not brew" {


### PR DESCRIPTION
## Summary

Trim the convenience installer to tools that a script or skill in this repo calls.

- Remove `git-delta`, `ripgrep`, `fd`, and `jq` from `EC_KNOWN_TOOLS`, `ec_tool_binary`, and the `--tools` usage text in `scripts/install.sh`.
- Remove the same four from the CI smoke test in `validate.yml`.
- Remove their README tool-table rows and install sections. Retarget the README `--tools` example.
- Remove the `delta` row from the affinage and pasteurize preferred-tool tables.
- Retarget the bats fixtures that used `ripgrep`, `jq`, and `fd` as example tool names to `just`, `mergiraf`, and `ast-grep`.

Kept: `gh` (plate, affinage, gh skills), `ast-grep` (code-intelligence routing), `just` (`just check` gate), `mergiraf` (melt), `tilth` (core).

## Test plan

- [x] `bats tests/bash/test_install.bats` — 98 ok, 0 failures
- [x] `shellcheck scripts/install.sh`
- [x] `pytest tests/python` — 2021 passed, 1 skipped
- [x] `.github/scripts/test_validate_skills.py` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)